### PR TITLE
release 0.0.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,18 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Check tag matches package version
+        run: |
+          # Tag is like refs/tags/v0.0.2 -> strip to 0.0.2
+          TAG="${GITHUB_REF_NAME#v}"
+          # Read version from pyproject.toml (grep the [project] version line)
+          PKG=$(grep -E '^\s*version\s*=' pyproject.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "tag=$TAG  pyproject version=$PKG"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Tag v$TAG does not match pyproject.toml version $PKG."
+            echo "::error::Bump 'version' in pyproject.toml (and src/opendot/__init__.py) to $TAG, commit, then re-tag."
+            exit 1
+          fi
       - name: Build sdist + wheel
         run: |
           python -m pip install --upgrade pip build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.0.1"
+version = "0.0.2"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.loop import Agent
 from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]


### PR DESCRIPTION
## What & why

Release prep for v0.0.2 and repo scaffolding: bump version to 0.0.2, add PyPI
release workflow (tag-triggered, Trusted Publishing) with a tag/version-match
check, CI workflow, LICENSE/SECURITY/CONTRIBUTING, issue + PR templates,
CodeRabbit config, README logo + badges, and MCP `add/list/remove` commands.

## How I verified it

`pytest` passes locally (51 tests). Wheel + sdist build and `twine check` passes;
clean-installed the wheel in a fresh venv and confirmed `opendot --version` →
0.0.2. Ran `opendot mcp add/list/remove` and verified the written
`~/.opendot/mcp.json`.

## Checklist

- [ ] Small and focused (one change)
- [x] Added/updated tests; `pytest` passes locally
- [x] If it touches `reversibility/` or a mutating tool: actions are snapshotted and undo still restores exactly (tests added)
- [x] If it changes the UI: screenshot / short recording included below