### PR TITLE
feat(tui): in-chat model/provider/mcp/composio pickers + slash autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,21 +52,22 @@ pip install opendot
 ```bash
 opendot                              # open an interactive chat
 opendot -p "summarize this project"  # one-shot, for scripts / CI
-opendot --model claude-sonnet-4-5    # any model (see below)
+opendot --model claude-opus-4-5      # launch with a specific model (see below)
 
 opendot log                          # audit: what has the agent done here?
 opendot undo                         # revert the last action
 opendot undo 000004                  # restore the workspace to before action #4
 ```
 
-Inside the chat, slash-commands: `/log`, `/undo`, `/clear`, `/compact`,
-`/model`, `/help`.
+Inside the chat, slash-commands: `/model` (searchable model picker),
+`/provider` (connect a provider + paste an API key), `/log`, `/undo`, `/clear`,
+`/compact`, `/help`.
 
 ## Any model
 
-opendot uses [LiteLLM](https://docs.litellm.ai), so any model works — cloud,
-local, or Hugging Face. Set the provider's API key in your environment and pass
-`--model`:
+Any model works — cloud, local, or Hugging Face. You can pick a model and paste
+an API key right inside the chat with `/model` and `/provider`, or set the key
+in your environment and pass `--model`:
 
 | Provider | Env var | Example `--model` |
 |----------|---------|-------------------|
@@ -82,6 +83,8 @@ Reasoning models stream their thinking live.
 
 opendot is an [MCP](https://modelcontextprotocol.io) client: connect any MCP
 server and its tools become available to the agent alongside the built-in ones.
+Manage them from inside the chat with **`/mcp`** (a dropdown of your servers and
+their status, with "➕ Add a server"), or from the command line:
 
 ```bash
 # a stdio server — put its launch command after `--`
@@ -90,16 +93,43 @@ opendot mcp add <name> --env KEY=VALUE -- <command> [args...]
 # a remote server (http/sse)
 opendot mcp add <name> --url <https url>
 
+# a remote server that needs auth — pass an HTTP header
+opendot mcp add supabase \
+  --url "https://mcp.supabase.com/mcp?project_ref=<id>&read_only=true" \
+  --header "Authorization=Bearer <your-supabase-access-token>"
+
 opendot mcp list           # show configured servers
 opendot mcp remove <name>  # remove one
 ```
 
 Servers are stored in `~/.opendot/mcp.json` and connect automatically on the
-next launch; connected servers appear in the sidebar.
+next launch; connected servers appear in the sidebar. For authenticated remote
+servers, opendot supports the header/token method (e.g. Supabase's access
+token) — the interactive browser-OAuth flow is not implemented yet.
 
 Because opendot can't know what an external tool does, **every MCP tool call is
 treated as irreversible** — it's confirmed before running and marked ✗ in the
 ledger. Your built-in file/shell actions stay snapshotted and undoable as usual.
+
+## Connect apps with Composio
+
+Beyond MCP, opendot can connect to [Composio](https://composio.dev)'s 3000+ app
+tools (Gmail, Slack, GitHub, Notion, Linear, …) using **your own** Composio API
+key. Install the extra and use `/composio` in the chat:
+
+```bash
+pip install 'opendot[composio]'
+```
+
+- The first `/composio` asks for your Composio API key (stored in
+  `~/.opendot/composio.json`, owner-readable only).
+- After that, `/composio` lists the available apps. Pick one — if it needs
+  OAuth, opendot opens your browser to authorize and waits for you to finish;
+  direct/API-key connectors activate immediately.
+- Enabled apps appear in the sidebar; their tools load on the next launch.
+
+Composio tools reach external services, so — like MCP — **every call is treated
+as irreversible**: confirmed first, marked ✗ in the ledger.
 
 ## Project rules — `OPENDOT.md`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.0.2"
+version = "0.0.3"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"
@@ -30,6 +30,7 @@ dependencies = [
 
 [project.optional-dependencies]
 office = ["openpyxl>=3.1", "python-pptx>=0.6"]  # xlsx / pptx read+edit tools
+composio = ["composio>=0.11,<0.12"]  # /composio: 3000+ app tools (Gmail, Slack, GitHub, …)
 dev = ["pytest>=8.0", "pytest-asyncio>=0.23", "openpyxl>=3.1", "python-pptx>=0.6"]
 
 [project.scripts]

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.loop import Agent
 from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/agent/config.py
+++ b/src/opendot/agent/config.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 
 # A sensible default that works if the user has an OpenAI key; over/ridden via
 # --model, the OPENDOT_MODEL env var, or config.
-DEFAULT_MODEL = os.environ.get("OPENDOT_MODEL", "gpt-4o")
+DEFAULT_MODEL = os.environ.get("OPENDOT_MODEL", "gpt-5.1")
 
 
 @dataclass

--- a/src/opendot/agent/prompt.py
+++ b/src/opendot/agent/prompt.py
@@ -16,6 +16,14 @@ Tools:
 - write_file — create a new file or fully rewrite one
 - run_shell — anything else (npm, git, build, mv, cp, tests, …)
 
+Opening apps, files, or URLs: use run_shell with the command for the user's OS —
+  macOS:   open -a "AppName"   (or `open <file-or-url>`)
+  Linux:   gtk-launch <app> || xdg-open <file-or-url>
+  Windows: start "" "AppName-or-target"
+Don't mask failures: run the bare command (no `|| echo ...` fallback) and read
+the `[exit N]` line run_shell returns — a non-zero exit (e.g. the app isn't
+installed) means it did NOT open, so say so plainly rather than claiming success.
+
 How to work:
 - Narrate briefly BEFORE each action: say what you're about to do and why, in one \
 line, so the user can follow your reasoning. Then take the action.

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -34,7 +34,8 @@ SLASH_HELP = """\
   /undo     revert the last action ( /undo <id> to restore to a point )
   /clear    reset the conversation
   /compact  trim old conversation turns to free up context
-  /model    show the current model
+  /model    show the current model ( /model <id> to switch )
+  /provider connect a provider ( /provider <ENV_VAR> <api-key> )
   exit      quit (also: /exit, /quit, Ctrl-D)
 """
 
@@ -58,6 +59,25 @@ def _confirm(prompt: str) -> bool:
     except (EOFError, KeyboardInterrupt):
         return False
     return ans in {"y", "yes"}
+
+
+def _warn_if_missing_key(model: str) -> None:
+    """Print a friendly hint if the model's expected API key isn't in the env.
+
+    A warning only — we still let the call proceed, because LiteLLM may find the
+    key another way and we'd rather not falsely block a working setup.
+    """
+    from opendot.providers import env_var_for
+
+    env_var = env_var_for(model)
+    if env_var and not os.environ.get(env_var):
+        console.print(
+            f"[yellow]![/yellow] No [bold]{env_var}[/bold] found in your environment "
+            f"for model [cyan]{model}[/cyan].\n"
+            f"  Set it (e.g. [dim]export {env_var}=...[/dim]), or pick another model "
+            f"with [dim]--model[/dim] / [dim]$OPENDOT_MODEL[/dim].\n"
+            f"  See the model table: https://github.com/vedaant00/opendot#any-model\n"
+        )
 
 
 def _build_agent(model: str, workdir: str, confirm=None) -> Agent:
@@ -158,6 +178,13 @@ def _cmd_mcp(args) -> None:
                 env[k] = v
         if args.url:
             spec = {"url": args.url}
+            headers = {}
+            for pair in getattr(args, "header", []):
+                if "=" in pair:
+                    k, v = pair.split("=", 1)
+                    headers[k.strip()] = v.strip()
+            if headers:
+                spec["headers"] = headers  # e.g. Authorization=Bearer <token>
         else:
             cmd = list(getattr(args, "post_dashdash", []))
             if not cmd:
@@ -260,8 +287,26 @@ def _interactive(agent: Agent) -> None:
             dropped = agent.compact()
             console.print(f"[dim]compacted: dropped {dropped} old message(s)[/dim]")
             continue
-        if low == "/model":
-            console.print(f"model: [cyan]{agent.config.model}[/cyan]")
+        if low.startswith("/model"):
+            parts = text.split(maxsplit=1)
+            if len(parts) > 1:
+                agent.config.model = parts[1].strip()
+                console.print(f"model → [cyan]{agent.config.model}[/cyan]")
+                _warn_if_missing_key(agent.config.model)
+            else:
+                console.print(f"model: [cyan]{agent.config.model}[/cyan]  "
+                              "([dim]/model <id> to change[/dim])")
+            continue
+        if low.startswith("/provider") or low.startswith("/connect"):
+            from opendot.providers import register_key
+            parts = text.split()
+            if len(parts) == 3:
+                register_key(parts[1], parts[2])
+                console.print(f"[green]✓[/green] set {parts[1]} for this session — "
+                              f"persist with [dim]export {parts[1]}=…[/dim]")
+            else:
+                console.print("usage: [dim]/provider <ENV_VAR> <api-key>[/dim]  "
+                              "(the TUI has an interactive picker)")
             continue
         if low == "/log":
             _cmd_log(agent.config.workdir)
@@ -294,8 +339,8 @@ def main() -> None:
         description="An interactive terminal AI agent you can fully undo.",
     )
     parser.add_argument("-p", "--prompt", help="Run a single task and exit (one-shot mode).")
-    parser.add_argument("--model", default=os.environ.get("OPENDOT_MODEL", "gpt-4o"),
-                        help="Model id (any LiteLLM model, e.g. gpt-4o, claude-sonnet-4-5, ollama/qwen2.5).")
+    parser.add_argument("--model", default=os.environ.get("OPENDOT_MODEL", "gpt-5.1"),
+                        help="Model id (any LiteLLM model, e.g. gpt-5.1, claude-opus-4-5, ollama/qwen3).")
     parser.add_argument("-C", "--dir", default=os.getcwd(), help="Working directory (default: cwd).")
     parser.add_argument("--repl", action="store_true", help="Use the plain REPL instead of the full-screen TUI.")
     parser.add_argument("--version", action="version", version=f"opendot {__version__}")
@@ -317,6 +362,9 @@ def main() -> None:
     p_add.add_argument("--url", help="A remote MCP server URL (http/sse) instead of a command.")
     p_add.add_argument("--env", action="append", default=[], metavar="KEY=VAL",
                        help="Environment variable for the server (repeatable).")
+    p_add.add_argument("--header", action="append", default=[], metavar="KEY=VAL",
+                       help="HTTP header for a remote (--url) server, e.g. "
+                            "'Authorization=Bearer <token>' (repeatable).")
     # The launch command (after `--`) is captured from argv in main(), not here,
     # so its own flags (e.g. -y) aren't parsed by argparse.
     mcp_sub.add_parser("list", help="List configured MCP servers.")
@@ -337,6 +385,9 @@ def main() -> None:
     if args.command == "mcp":
         _cmd_mcp(args)
         return
+
+    # Everything below this point calls a model — hint if the key looks missing.
+    _warn_if_missing_key(args.model)
 
     # One-shot: -p flag, or piped stdin.
     oneshot = args.prompt

--- a/src/opendot/composio_tools.py
+++ b/src/opendot/composio_tools.py
@@ -1,0 +1,241 @@
+"""Composio integration — connect opendot to 3000+ app tools (Gmail, Slack,
+GitHub, Notion, …) using the user's own Composio API key.
+
+Design mirrors how Plandot uses Composio, adapted for a local terminal app:
+
+* **Identity.** Composio scopes everything to a ``user_id``. opendot has no
+  accounts, so on first use we mint a stable local id and store it (with the
+  api key) in ``~/.opendot/composio.json``. All connections belong to it.
+
+* **Auth.** ``toolkits.authorize(user_id, toolkit)`` returns a ConnectionRequest.
+  For OAuth apps it carries a ``redirect_url`` — we open it in the user's
+  browser and block on ``wait_for_connection`` until the account goes ACTIVE.
+  For no-auth / API-key connectors there's no redirect and it activates
+  immediately.
+
+* **Tools.** ``tools.get(user_id, toolkits=[slug])`` returns tool schemas;
+  ``tools.execute(slug, arguments, user_id=...)`` runs one. Every Composio call
+  reaches an external service, so — exactly like MCP tools — opendot treats it
+  as **irreversible**: confirmed before running and marked ✗ in the ledger.
+
+The composio SDK is an optional dependency (``pip install 'opendot[composio]'``);
+everything here fails soft if it isn't installed.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from opendot.reversibility.snapshots import store_root
+
+
+def _config_path():
+    return store_root() / "composio.json"
+
+
+def load_config() -> dict:
+    """Read ~/.opendot/composio.json → {"api_key", "user_id", "apps": [...]}."""
+    path = _config_path()
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8")) or {}
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def save_config(cfg: dict) -> None:
+    path = _config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+    try:  # keep the key file private (best-effort; no-op on Windows)
+        path.chmod(0o600)
+    except OSError:
+        pass
+
+
+def is_configured() -> bool:
+    return bool(load_config().get("api_key"))
+
+
+def set_api_key(api_key: str) -> str:
+    """Store the api key, minting a stable local user_id on first use.
+    Returns the user_id."""
+    cfg = load_config()
+    cfg["api_key"] = api_key.strip()
+    if not cfg.get("user_id"):
+        cfg["user_id"] = "opendot-" + uuid.uuid4().hex[:12]
+    save_config(cfg)
+    return cfg["user_id"]
+
+
+def enabled_apps() -> list[str]:
+    """Toolkit slugs the user has activated in opendot (their tools load on launch)."""
+    return list(load_config().get("apps", []))
+
+
+def add_enabled_app(slug: str) -> None:
+    cfg = load_config()
+    apps = cfg.get("apps", [])
+    if slug not in apps:
+        apps.append(slug)
+    cfg["apps"] = apps
+    save_config(cfg)
+
+
+def composio_available() -> bool:
+    try:
+        import composio  # noqa: F401
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _client():
+    """A Composio client bound to the stored api key. Raises if unconfigured."""
+    from composio import Composio
+
+    cfg = load_config()
+    key = cfg.get("api_key")
+    if not key:
+        raise RuntimeError("Composio is not configured (no api key). Run /composio.")
+    return Composio(api_key=key), cfg["user_id"]
+
+
+# ---- catalog / connection management (used by the /composio TUI flow) ----
+
+def list_apps(search: str | None = None, limit: int = 200) -> list[dict]:
+    """Available Composio toolkits: [{slug, name, description}]. Empty on failure."""
+    try:
+        client, _ = _client()
+        resp = client.toolkits.list(limit=limit, sort_by="usage")
+    except Exception:  # noqa: BLE001
+        return []
+    items = getattr(resp, "items", None) or []
+    out = []
+    for tk in items:
+        slug = (getattr(tk, "slug", "") or "").lower()
+        if not slug:
+            continue
+        meta = getattr(tk, "meta", None)
+        desc = getattr(tk, "description", "") or (getattr(meta, "description", "") if meta else "")
+        name = getattr(tk, "name", "") or slug
+        if search and search.lower() not in f"{name} {slug}".lower():
+            continue
+        out.append({"slug": slug, "name": name, "description": desc})
+    return out
+
+
+def list_connected() -> set[str]:
+    """Toolkit slugs the user has an ACTIVE connection for."""
+    try:
+        client, user_id = _client()
+        resp = client.connected_accounts.list(user_ids=[user_id], statuses=["ACTIVE"])
+    except Exception:  # noqa: BLE001
+        return set()
+    items = getattr(resp, "items", None) or []
+    slugs = set()
+    for acc in items:
+        tk = getattr(acc, "toolkit", None)
+        slug = getattr(tk, "slug", None) if tk else None
+        if slug:
+            slugs.add(slug.lower())
+    return slugs
+
+
+@dataclass
+class ConnectResult:
+    ok: bool
+    needs_auth: bool = False
+    redirect_url: str | None = None
+    request: Any = None  # the ConnectionRequest, so the caller can wait on it
+    error: str | None = None
+
+
+def begin_connect(slug: str) -> ConnectResult:
+    """Start connecting a toolkit. If it needs OAuth, returns the redirect_url and
+    the ConnectionRequest (caller opens the browser then calls
+    ``wait_for_connection``). If it's a direct/no-auth connector, it's already
+    active and ok=True."""
+    try:
+        client, user_id = _client()
+        req = client.toolkits.authorize(user_id=user_id, toolkit=slug)
+    except Exception as exc:  # noqa: BLE001
+        return ConnectResult(ok=False, error=f"{type(exc).__name__}: {exc}")
+    redirect = getattr(req, "redirect_url", None)
+    if redirect:
+        return ConnectResult(ok=False, needs_auth=True, redirect_url=redirect, request=req)
+    return ConnectResult(ok=True, request=req)
+
+
+# ---- tool specs + execution (used by the Toolbox) ----
+
+def build_tool_specs() -> list[dict]:
+    """OpenAI-style function specs for all tools of the user's enabled apps.
+
+    Names are namespaced ``composio__<slug>__<TOOL_SLUG>`` so they can't collide
+    with built-ins or MCP tools and are recognisable as external/irreversible.
+    Returns [] if composio isn't installed / configured / has no enabled apps.
+    """
+    apps = enabled_apps()
+    if not apps or not composio_available():
+        return []
+    try:
+        client, user_id = _client()
+    except Exception:  # noqa: BLE001
+        return []
+    specs: list[dict] = []
+    for slug in apps:
+        try:
+            tools = client.tools.get(user_id, toolkits=[slug], limit=1000)
+        except Exception:  # noqa: BLE001
+            continue
+        for t in tools:
+            fn = t.get("function", t) if isinstance(t, dict) else getattr(t, "function", t)
+            name = (fn.get("name") if isinstance(fn, dict) else getattr(fn, "name", "")) or ""
+            if not name:
+                continue
+            desc = fn.get("description", "") if isinstance(fn, dict) else getattr(fn, "description", "")
+            params = fn.get("parameters", {}) if isinstance(fn, dict) else getattr(fn, "parameters", {})
+            specs.append({
+                "type": "function",
+                "function": {
+                    "name": f"composio__{slug}__{name}",
+                    "description": desc or f"Composio {slug} tool {name}",
+                    "parameters": params or {"type": "object", "properties": {}},
+                },
+            })
+    return specs
+
+
+def is_composio_tool(name: str) -> bool:
+    return name.startswith("composio__")
+
+
+def execute_tool(name: str, arguments: dict) -> str:
+    """Run a namespaced composio tool. ``name`` is composio__<slug>__<TOOL_SLUG>."""
+    try:
+        _, _, tool_slug = name.split("__", 2)
+    except ValueError:
+        return f"error: malformed composio tool name {name!r}"
+    try:
+        client, user_id = _client()
+        # skip the toolkit-version check — we execute the latest, same as Plandot
+        # (otherwise the SDK raises ToolVersionRequiredError).
+        res = client.tools.execute(
+            tool_slug, arguments or {},
+            user_id=user_id, dangerously_skip_version_check=True,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return f"error: composio execution failed: {type(exc).__name__}: {exc}"
+    # ToolExecutionResponse — prefer a JSON dump of its data/successful fields.
+    data = getattr(res, "data", None)
+    if data is None and isinstance(res, dict):
+        data = res.get("data", res)
+    try:
+        return json.dumps(data if data is not None else res, default=str)[:8000]
+    except Exception:  # noqa: BLE001
+        return str(res)[:8000]

--- a/src/opendot/mcp/manager.py
+++ b/src/opendot/mcp/manager.py
@@ -14,7 +14,9 @@ Config lives at ``~/.opendot/mcp.json`` (Claude-Desktop-style):
         "pyscrappy": { "command": "pyscrappy-mcp" },
         "github":    { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-github"],
                        "env": {"GITHUB_TOKEN": "..."} },
-        "remote":    { "url": "https://example.com/mcp" }          // http/sse
+        "remote":    { "url": "https://example.com/mcp" },         // http/sse
+        "supabase":  { "url": "https://mcp.supabase.com/mcp?project_ref=abc",
+                       "headers": {"Authorization": "Bearer <PAT>"} }  // authenticated remote
       }
     }
 
@@ -147,11 +149,12 @@ class MCPManager:
         """Return (read, write) streams for a stdio or http/sse server."""
         if spec.get("url"):
             url = spec["url"]
+            headers = spec.get("headers") or None  # e.g. {"Authorization": "Bearer ..."}
             if url.rstrip("/").endswith("/sse"):
                 from mcp.client.sse import sse_client
-                return (await self._stack.enter_async_context(sse_client(url)))[:2]
+                return (await self._stack.enter_async_context(sse_client(url, headers=headers)))[:2]
             from mcp.client.streamable_http import streamablehttp_client
-            return (await self._stack.enter_async_context(streamablehttp_client(url)))[:2]
+            return (await self._stack.enter_async_context(streamablehttp_client(url, headers=headers)))[:2]
         # stdio
         from mcp import StdioServerParameters
         from mcp.client.stdio import stdio_client

--- a/src/opendot/providers.py
+++ b/src/opendot/providers.py
@@ -1,0 +1,91 @@
+"""Provider ↔ API-key mapping and model discovery.
+
+opendot stays model-agnostic: it never ships its own model list. This module is
+the one place that (a) maps a model string to the env var LiteLLM expects for
+it, and (b) discovers available models from LiteLLM's own registry so the TUI's
+`/model` picker shows real, current models without a hardcoded table.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Ordered so more specific prefixes win. Maps a model-string prefix to the env
+# var LiteLLM reads the key from. Used for the missing-key hint and the
+# `/provider` connect flow — never to restrict which models can be used.
+PROVIDER_KEYS: dict[str, str] = {
+    "anthropic/": "ANTHROPIC_API_KEY",
+    "claude": "ANTHROPIC_API_KEY",       # bare `claude-...` routes to Anthropic
+    "gemini/": "GEMINI_API_KEY",
+    "deepseek/": "DEEPSEEK_API_KEY",
+    "groq/": "GROQ_API_KEY",
+    "mistral/": "MISTRAL_API_KEY",
+    "huggingface/": "HF_TOKEN",
+    "openai/": "OPENAI_API_KEY",
+    "gpt-": "OPENAI_API_KEY",            # bare `gpt-...` routes to OpenAI
+    "o1": "OPENAI_API_KEY",
+    "o3": "OPENAI_API_KEY",
+}
+
+# Models that run locally / need no key — never warn or prompt for these.
+NO_KEY_PREFIXES = ("ollama/", "ollama_chat/", "lm_studio/")
+
+# The providers offered in the `/provider` connect flow: (display name, env var).
+# One entry per distinct key; deduped from PROVIDER_KEYS in a stable order.
+CONNECTABLE_PROVIDERS: list[tuple[str, str]] = [
+    ("OpenAI", "OPENAI_API_KEY"),
+    ("Anthropic", "ANTHROPIC_API_KEY"),
+    ("Google (Gemini)", "GEMINI_API_KEY"),
+    ("DeepSeek", "DEEPSEEK_API_KEY"),
+    ("Groq", "GROQ_API_KEY"),
+    ("Mistral", "MISTRAL_API_KEY"),
+    ("Hugging Face", "HF_TOKEN"),
+]
+
+
+def env_var_for(model: str) -> str | None:
+    """The API-key env var LiteLLM expects for ``model``, or None if unknown /
+    keyless (local models)."""
+    low = model.lower()
+    if low.startswith(NO_KEY_PREFIXES):
+        return None
+    for prefix, var in PROVIDER_KEYS.items():
+        if low.startswith(prefix):
+            return var
+    return None
+
+
+def provider_of(model: str) -> str:
+    """Group label for a model string, for the `/model` picker's headings.
+    Uses the LiteLLM prefix if present (``deepseek/...`` -> ``deepseek``), else
+    a best-effort guess from the key map, else ``other``."""
+    if "/" in model:
+        return model.split("/", 1)[0]
+    var = env_var_for(model)
+    if var:
+        return var.replace("_API_KEY", "").replace("_TOKEN", "").lower()
+    return "other"
+
+
+def list_models() -> list[str]:
+    """Real model strings from LiteLLM's registry (``litellm.model_cost``).
+
+    Returns them sorted; empty list if LiteLLM isn't importable. This is the
+    source for the `/model` picker — no hardcoded list, updates with LiteLLM.
+    """
+    try:
+        import litellm
+
+        names = [m for m in litellm.model_cost.keys() if m and m != "sample_spec"]
+        return sorted(set(names))
+    except Exception:  # noqa: BLE001 - registry unavailable
+        return []
+
+
+def register_key(env_var: str, value: str) -> None:
+    """Set an API key in this process's environment so it takes effect now.
+
+    opendot does not persist secrets to disk — the caller shows the user the
+    `export` line to add to their shell profile for persistence.
+    """
+    os.environ[env_var] = value

--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -307,9 +307,23 @@ class Toolbox:
                     "parameters": mt.input_schema,
                 },
             })
+        # External Composio tools (never in read-only explorer boxes).
+        if not self.read_only:
+            from opendot import composio_tools
+            specs.extend(composio_tools.build_tool_specs())
         return specs
 
     def call(self, name: str, args: dict[str, Any]) -> str:
+        # Composio tools are external + opaque like MCP: confirm + mark irreversible.
+        from opendot import composio_tools
+        if composio_tools.is_composio_tool(name):
+            reason = "external Composio tool — opendot cannot undo it"
+            if not self._confirm(f"Run {name}?  {reason}"):
+                return "skipped: user declined an external Composio tool call"
+            if self.rev is not None:
+                self.rev.before_action("shell", name, reversible=False, note=reason)
+            return composio_tools.execute_tool(name, args)
+
         # MCP tools are external + opaque: opendot can't undo them, so gate every
         # call through confirm and record it as irreversible in the ledger.
         mt = self._mcp_tools.get(name)

--- a/src/opendot/tui.py
+++ b/src/opendot/tui.py
@@ -61,11 +61,218 @@ class ConfirmModal(ModalScreen[bool]):
         if event.key == "escape":
             self.dismiss(False)
 
-# Per-tool glyphs so each step reads at a glance (opencode/Plandot-style).
-_TOOL_ICONS = {
-    "read_file": "📖", "write_file": "✎", "edit": "✂", "list_files": "▤",
-    "grep": "🔍", "glob": "❊", "run_shell": "❯",
-}
+
+class SearchListModal(ModalScreen[str | None]):
+    """A searchable, keyboard-navigable list picker (opencode-style).
+
+    ``items`` is a list of (value, label, group) tuples. Typing filters by
+    label; ↑/↓ move; Enter selects (returns the value); Esc cancels (None).
+    """
+
+    CSS = """
+    SearchListModal { align: center middle; }
+    #box { width: 70%; max-width: 90; height: 80%; padding: 1 2;
+           border: thick $accent; background: $surface; }
+    #title { text-style: bold; margin-bottom: 1; }
+    #search { margin-bottom: 1; }
+    #list { height: 1fr; }
+    """
+
+    def __init__(self, title: str, items: list[tuple[str, str, str]]) -> None:
+        super().__init__()
+        self._title = title
+        self._items = items  # (value, label, group)
+
+    def compose(self) -> ComposeResult:
+        from textual.widgets import OptionList
+
+        with Vertical(id="box"):
+            yield Static(id="title")
+            yield Input(placeholder="Search…", id="search")
+            yield OptionList(id="list")
+
+    def on_mount(self) -> None:
+        self._set_title()
+        self._populate("")
+        self.query_one("#search", Input).focus()
+
+    def _set_title(self) -> None:
+        # "esc cancel" flush right: pad the gap to the title widget's width.
+        title = self.query_one("#title", Static)
+        hint = "esc cancel"
+        width = title.content_size.width or 60
+        gap = max(4, width - len(self._title) - len(hint))
+        title.update(Text.assemble((self._title, "bold"), (" " * gap, ""), (hint, "dim")))
+
+    def _populate(self, query: str) -> None:
+        from textual.widgets import OptionList
+        from textual.widgets.option_list import Option
+
+        q = query.lower()
+        ol = self.query_one("#list", OptionList)
+        ol.clear_options()
+        last_group = None
+        self._values: list[str] = []
+        for value, label, group in self._items:
+            if q and q not in label.lower():
+                continue
+            if group and group != last_group:
+                ol.add_option(Option(Text(group.upper(), style="bold magenta"), disabled=True))
+                last_group = group
+            ol.add_option(Option(label, id=str(len(self._values))))
+            self._values.append(value)
+        if self._values:
+            ol.highlighted = 1 if (self._items and self._items[0][2]) else 0
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        self._populate(event.value)
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        # Enter in the search box selects the current highlight.
+        from textual.widgets import OptionList
+
+        event.stop()  # don't let Enter bubble to the main chat input
+        ol = self.query_one("#list", OptionList)
+        if ol.highlighted is not None:
+            opt = ol.get_option_at_index(ol.highlighted)
+            if opt.id is not None:
+                self.dismiss(self._values[int(opt.id)])
+
+    def on_option_list_option_selected(self, event) -> None:
+        if event.option.id is not None:
+            self.dismiss(self._values[int(event.option.id)])
+
+    def on_key(self, event) -> None:
+        from textual.widgets import OptionList
+
+        if event.key == "escape":
+            self.dismiss(None)
+        elif event.key in ("down", "up"):
+            # Let the arrow keys drive the list while focus stays in the search box.
+            ol = self.query_one("#list", OptionList)
+            if event.key == "down":
+                ol.action_cursor_down()
+            else:
+                ol.action_cursor_up()
+            event.stop()
+
+
+class ApiKeyModal(ModalScreen[str | None]):
+    """A single password field to paste an API key. Returns the key, or None."""
+
+    CSS = """
+    ApiKeyModal { align: center middle; }
+    #box { width: 60%; max-width: 80; height: auto; padding: 1 2;
+           border: thick $accent; background: $surface; }
+    #title { text-style: bold; margin-bottom: 1; }
+    """
+
+    def __init__(self, provider: str, env_var: str) -> None:
+        super().__init__()
+        self._provider = provider
+        self._env_var = env_var
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="box"):
+            yield Static(id="title")
+            yield Input(placeholder="Paste API key…", password=True, id="key")
+
+    def on_mount(self) -> None:
+        title = self.query_one("#title", Static)
+        head, hint = f"Connect {self._provider}", "esc cancel"
+        width = title.content_size.width or 60
+        gap = max(4, width - len(head) - len(hint))
+        title.update(Text.assemble(
+            (head, "bold"), (" " * gap, ""), (hint + "\n", "dim"),
+            (f"sets {self._env_var} for this session", "dim italic"),
+        ))
+        self.query_one("#key", Input).focus()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        event.stop()  # don't let Enter bubble to the main chat input
+        self.dismiss(event.value.strip() or None)
+
+    def on_key(self, event) -> None:
+        if event.key == "escape":
+            self.dismiss(None)
+
+
+class McpAddModal(ModalScreen[dict | None]):
+    """Form to add an MCP server. Returns {"name", "spec"} or None.
+
+    One field decides the transport: a value starting with http(s):// is a
+    remote server (with an optional Authorization header); anything else is a
+    stdio launch command (split on spaces).
+    """
+
+    CSS = """
+    McpAddModal { align: center middle; }
+    #box { width: 70%; max-width: 90; height: auto; padding: 1 2;
+           border: thick $accent; background: $surface; }
+    #title { text-style: bold; margin-bottom: 1; }
+    Input { margin-bottom: 1; }
+    #hint { color: $text-muted; text-style: italic; }
+    """
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="box"):
+            yield Static(id="title")
+            yield Input(placeholder="name (e.g. github, supabase)", id="name")
+            yield Input(placeholder="https://…/mcp   OR   npx -y @scope/server args…", id="target")
+            yield Input(placeholder="Authorization header (remote only, optional)", id="header")
+            yield Static(
+                "enter submit · a value starting with http(s):// is treated as a remote URL",
+                id="hint",
+            )
+
+    def on_mount(self) -> None:
+        title = self.query_one("#title", Static)
+        head, hint = "Add an MCP server", "esc cancel"
+        width = title.content_size.width or 60
+        gap = max(4, width - len(head) - len(hint))
+        title.update(Text.assemble((head, "bold"), (" " * gap, ""), (hint, "dim")))
+        self.query_one("#name", Input).focus()
+
+    def _submit(self) -> None:
+        name = self.query_one("#name", Input).value.strip()
+        target = self.query_one("#target", Input).value.strip()
+        header = self.query_one("#header", Input).value.strip()
+        if not name or not target:
+            return  # name + target required; keep the form open
+        if target.lower().startswith(("http://", "https://")):
+            spec: dict = {"url": target}
+            if header:
+                k, _, v = header.partition("=") if "=" in header else header.partition(":")
+                spec["headers"] = {k.strip(): v.strip()}
+        else:
+            parts = target.split()
+            spec = {"command": parts[0]}
+            if len(parts) > 1:
+                spec["args"] = parts[1:]
+        self.dismiss({"name": name, "spec": spec})
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        event.stop()  # don't let Enter bubble to the main chat input
+        self._submit()
+
+    def on_key(self, event) -> None:
+        if event.key == "escape":
+            self.dismiss(None)
+
+
+# Slash commands shown in the autocomplete popup (name, one-line description).
+# Single source of truth — the popup filters this list.
+SLASH_COMMANDS: list[tuple[str, str]] = [
+    ("/model", "switch model (searchable picker)"),
+    ("/provider", "connect a provider + API key"),
+    ("/mcp", "manage MCP servers"),
+    ("/composio", "connect apps (Gmail, Slack, …)"),
+    ("/log", "show the action ledger"),
+    ("/undo", "revert the last action ( /undo <id> )"),
+    ("/clear", "reset the conversation"),
+    ("/compact", "trim old turns to free context"),
+    ("/help", "list commands"),
+]
 
 
 def _render_tool_result(tool: str, result: str):
@@ -158,6 +365,39 @@ class Sidebar(Static):
                 t.append(f"{name} failed\n", style="red")
             t.append("\n")
 
+        # -- Providers (which API keys are set this session) --
+        try:
+            import os
+            from opendot.providers import CONNECTABLE_PROVIDERS
+            connected_providers = [n for n, var in CONNECTABLE_PROVIDERS if os.environ.get(var)]
+        except Exception:  # noqa: BLE001
+            connected_providers = []
+        if connected_providers:
+            self._section(t, "Providers")
+            for name in connected_providers:
+                t.append("• ", style="dim")
+                t.append(f"{name} ", style="green")
+                t.append("✓\n", style="green")
+            t.append("\n")
+
+        # -- Composio (show once a key is set; then list enabled apps) --
+        try:
+            from opendot import composio_tools
+            cx_configured = composio_tools.is_configured()
+            capps = composio_tools.enabled_apps()
+        except Exception:  # noqa: BLE001
+            cx_configured, capps = False, []
+        if cx_configured:
+            self._section(t, "Composio")
+            t.append("connected ", style="green")
+            t.append("✓\n", style="green")
+            for slug in capps:
+                t.append("• ", style="dim")
+                t.append(f"{slug}\n", style="green")
+            if not capps:
+                t.append("no apps enabled yet\n", style="dim")
+            t.append("\n")
+
         # -- Ledger (the differentiator) --
         self._section(t, "Ledger")
         t.append("undoable ↺ · irreversible ✗\n", style="dim")
@@ -190,14 +430,19 @@ class OpendotTUI(App):
     #input { height: 5; border: round $accent; margin: 0 1; padding: 0 1; }
     #modeline { height: 1; margin: 0 1; color: $text-muted; }
 
-    /* Each message type is a visually distinct block. */
+    /* Slash-command autocomplete popup — sits just above the input. */
+    #cmdpopup { height: auto; max-height: 10; margin: 0 1; padding: 0;
+                border: round $panel; background: $surface; }
+    #cmdpopup > .option-list--option-highlighted { background: $accent; color: $text; }
+
+    /* Message blocks — understated, opencode-style. The answer is the only
+       block with real visual weight; everything else recedes. */
     .msg { margin: 1 0 0 0; }
-    .user   { background: $boost; color: $text; text-style: bold;
-              border-left: thick $accent; padding: 0 1; }
-    .think  { color: $text-muted; text-style: italic; margin: 0 0 0 2; }
-    .answer { color: $text; border-left: thick $success; padding: 0 1; }
-    .tool   { color: $accent; text-style: bold; margin: 1 0 0 0; }
-    .toolout{ color: $text-muted; margin: 0 0 0 2; }
+    .user   { color: $text; border-left: solid $accent; padding: 0 1; }
+    .think  { color: $text-muted; margin: 0 0 0 2; }
+    .answer { color: $text; border-left: solid #2dd4bf; padding: 0 1; }
+    .tool   { color: $text-muted; margin: 1 0 0 2; }
+    .toolout{ color: $text-muted; margin: 0 0 0 4; }
     .err    { color: $error; text-style: bold; border-left: thick $error; padding: 0 1; }
     .sys    { color: $text-muted; text-style: italic; }
     """
@@ -227,13 +472,19 @@ class OpendotTUI(App):
 
     def compose(self) -> ComposeResult:
         from textual.containers import Vertical
+        from textual.widgets import OptionList
 
         yield Header(show_clock=False)
         with Horizontal(id="body"):
             # Left column: transcript fills, input + mode line pinned at its bottom.
             with Vertical(id="main"):
                 yield VerticalScroll(id="transcript")
-                yield Input(placeholder="Ask opendot…  (/help /log /undo /clear /compact)", id="input")
+                # Slash-command autocomplete — hidden until the line starts with '/'.
+                popup = OptionList(id="cmdpopup")
+                popup.display = False
+                popup.can_focus = False  # keep typing focus in the input
+                yield popup
+                yield Input(placeholder="Ask opendot…  (type / for commands)", id="input")
                 yield Static(self._mode_line(), id="modeline")
             yield Sidebar(self.agent)
         yield Footer()
@@ -263,8 +514,96 @@ class OpendotTUI(App):
     def _refresh_sidebar(self) -> None:
         self.query_one(Sidebar).refresh()
 
+    # -- slash-command autocomplete --
+    def _popup(self):
+        from textual.widgets import OptionList
+        return self.query_one("#cmdpopup", OptionList)
+
+    @property
+    def _popup_open(self) -> bool:
+        return self._popup().display
+
+    def _matches(self, text: str) -> list[tuple[str, str]]:
+        """Commands matching the current input. Active only while the line is a
+        single '/word' with no space yet (i.e. still choosing a command)."""
+        if not text.startswith("/") or " " in text:
+            return []
+        q = text[1:].lower()
+        return [(n, d) for n, d in SLASH_COMMANDS if n[1:].lower().startswith(q)]
+
+    def _sync_popup(self, text: str) -> None:
+        from textual.widgets.option_list import Option
+
+        matches = self._matches(text)
+        popup = self._popup()
+        if not matches:
+            popup.display = False
+            return
+        popup.display = True  # display first so the widget has a real width
+        popup.clear_options()
+        # Right-align descriptions to the popup's right edge. content_size is
+        # reliable now that display=True and layout has settled; fall back to the
+        # main column width (terminal minus 34-col sidebar and margins).
+        width = popup.content_size.width
+        if width <= 0:
+            width = max(20, self.size.width - 34 - 6)
+        for name, desc in matches:
+            gap = max(2, width - len(name) - len(desc))
+            line = Text.assemble((name, "bold"), (" " * gap, ""), (desc, "dim"))
+            popup.add_option(Option(line, id=name))
+        popup.highlighted = 0
+
+    def _highlighted_command(self) -> str | None:
+        popup = self._popup()
+        if popup.highlighted is None:
+            return None
+        return self._popup().get_option_at_index(popup.highlighted).id
+
+    def _accept_popup(self, *, run: bool) -> None:
+        """Pick the highlighted command. If ``run``, execute it immediately
+        (Enter); otherwise just complete it into the input so the user can add
+        an argument (Tab), e.g. `/undo 4` or `/model gpt-5.1`."""
+        name = self._highlighted_command()
+        if name is None:
+            return
+        inp = self.query_one("#input", Input)
+        self._popup().display = False
+        if run:
+            inp.value = ""
+            self._slash(name)
+        else:
+            inp.value = name + " "
+            inp.cursor_position = len(inp.value)
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id == "input":
+            self._sync_popup(event.value)
+
+    def on_key(self, event) -> None:
+        """Drive the autocomplete popup from the keyboard while it's open."""
+        if not self._popup_open:
+            return
+        popup = self._popup()
+        if event.key == "down":
+            popup.action_cursor_down(); event.stop(); event.prevent_default()
+        elif event.key == "up":
+            popup.action_cursor_up(); event.stop(); event.prevent_default()
+        elif event.key == "tab":
+            self._accept_popup(run=False); event.stop(); event.prevent_default()
+        elif event.key == "escape":
+            popup.display = False; event.stop(); event.prevent_default()
+
     # -- input handling --
     async def on_input_submitted(self, event: Input.Submitted) -> None:
+        # Only the main prompt submits chat. A submit from any other Input
+        # (e.g. a modal's password/search field) must never become a message —
+        # modals also .stop() it, this is defence in depth so secrets can't leak.
+        if event.input.id != "input":
+            return
+        # If the popup is open, Enter runs the highlighted command immediately.
+        if self._popup_open:
+            self._accept_popup(run=True)
+            return
         text = event.value.strip()
         self.query_one("#input", Input).value = ""
         if not text or self._busy:
@@ -285,7 +624,7 @@ class OpendotTUI(App):
         except Exception:  # noqa: BLE001
             who = "you"
         now = datetime.datetime.now().strftime("%H:%M")
-        header = Text.assemble((who, "bold"), (f"  {now}", "dim"))
+        header = Text.assemble((who, "dim"), (f"  {now}", "dim"))
         self._write(Text.assemble(header, "\n", (text, "")), "user")
         # Use the message as the sidebar's task title (first ~40 chars).
         sb = self.query_one(Sidebar)
@@ -299,7 +638,7 @@ class OpendotTUI(App):
         cmd = cmd.lower()
         a = self.agent
         if cmd == "help":
-            self._write("commands: /log /undo [id] /clear /compact /model /help", "sys")
+            self._write("commands: /log /undo [id] /clear /compact /model /provider /mcp /composio /help", "sys")
         elif cmd == "clear":
             a.reset()
             self._write("context cleared", "sys")
@@ -307,13 +646,179 @@ class OpendotTUI(App):
             n = a.compact()
             self._write(f"compacted: dropped {n} old message(s)", "sys")
         elif cmd == "model":
-            self._write(f"model: {a.config.model}", "sys")
+            # A bare arg sets the model directly; otherwise open the picker.
+            if rest.strip():
+                self._set_model(rest.strip())
+            else:
+                self.run_worker(self._pick_model(), exclusive=False)
+        elif cmd in ("provider", "connect"):
+            self.run_worker(self._connect_provider(), exclusive=False)
+        elif cmd == "mcp":
+            self.run_worker(self._manage_mcp(), exclusive=False)
+        elif cmd == "composio":
+            self.run_worker(self._manage_composio(), exclusive=False)
         elif cmd == "log":
             self.action_log()
         elif cmd == "undo":
             self._do_undo(rest.strip() or None)
         else:
             self._write(f"unknown command: /{cmd}", "sys")
+
+    # -- model / provider pickers --
+    def _set_model(self, model: str) -> None:
+        """Switch the live model and refresh the sidebar (which shows it)."""
+        self.agent.config.model = model
+        self._write(f"model → {model}", "sys")
+        self._refresh_sidebar()
+        # Nudge if the key for this model isn't set yet.
+        from opendot.providers import env_var_for
+        import os
+        var = env_var_for(model)
+        if var and not os.environ.get(var):
+            self._write(f"note: {var} is not set — use /provider to connect.", "sys")
+
+    async def _pick_model(self) -> None:
+        from opendot.providers import list_models, provider_of
+
+        models = list_models()
+        if not models:
+            self._write("model list unavailable (litellm registry not found); "
+                        "use  /model <id>  to set one directly.", "sys")
+            return
+        # (value, label, group) sorted by provider then model for grouped display.
+        items = sorted(
+            ((m, m, provider_of(m)) for m in models),
+            key=lambda t: (t[2], t[1]),
+        )
+        chosen = await self.push_screen_wait(SearchListModal("Select model", items))
+        if chosen:
+            self._set_model(chosen)
+
+    async def _connect_provider(self) -> None:
+        from opendot.providers import CONNECTABLE_PROVIDERS, register_key
+
+        items = [(var, name, "Providers") for name, var in CONNECTABLE_PROVIDERS]
+        var = await self.push_screen_wait(SearchListModal("Connect a provider", items))
+        if not var:
+            return
+        name = next((n for n, v in CONNECTABLE_PROVIDERS if v == var), var)
+        key = await self.push_screen_wait(ApiKeyModal(name, var))
+        if not key:
+            return
+        register_key(var, key)
+        self._write(f"✓ {name} connected for this session.", "sys")
+        self._write(f"to persist, add to your shell:  export {var}=…", "sys")
+        self._refresh_sidebar()
+
+    async def _manage_mcp(self) -> None:
+        from opendot.mcp import add_mcp_server, load_mcp_config
+
+        servers = load_mcp_config()
+        mgr = getattr(self.agent, "mcp", None)
+        connected = set(mgr.connected) if mgr else set()
+        errors = dict(mgr.errors) if mgr else {}
+
+        # Build the list: each server with a status glyph, then an Add entry.
+        items: list[tuple[str, str, str]] = []
+        for name, spec in servers.items():
+            target = spec.get("url") or " ".join(
+                [spec.get("command", "")] + spec.get("args", [])
+            )
+            if name in connected:
+                n = sum(1 for mt in mgr.tools if mt.server == name)
+                status = f"✓ {n} tools"
+            elif name in errors:
+                status = "✗ failed"
+            else:
+                status = "· not connected"
+            items.append((f"server:{name}", f"{name}   {target[:40]}   {status}", "Servers"))
+        items.append(("__add__", "➕ Add a server…", ""))
+
+        chosen = await self.push_screen_wait(SearchListModal("MCP servers", items))
+        if chosen != "__add__":
+            return  # selecting a server is view-only for now
+        result = await self.push_screen_wait(McpAddModal())
+        if not result:
+            return
+        add_mcp_server(result["name"], result["spec"])
+        self._write(
+            f"✓ added MCP server '{result['name']}' — it connects on next launch "
+            f"(restart opendot).",
+            "sys",
+        )
+
+    async def _manage_composio(self) -> None:
+        import asyncio
+        import webbrowser
+
+        from opendot import composio_tools as cx
+
+        if not cx.composio_available():
+            self._write("Composio isn't installed. Run:  pip install 'opendot[composio]'", "sys")
+            return
+
+        # First run (or no key yet): ask for the Composio API key.
+        if not cx.is_configured():
+            key = await self.push_screen_wait(ApiKeyModal("Composio", "COMPOSIO_API_KEY"))
+            if not key:
+                return
+            cx.set_api_key(key)
+            self._write("✓ Composio connected. Run /composio again to browse apps.", "sys")
+            self._refresh_sidebar()
+            return
+
+        # Configured: list apps (marking connected/enabled ones), let the user pick.
+        self._write("loading Composio apps…", "sys")
+        apps = await asyncio.to_thread(cx.list_apps)
+        if not apps:
+            self._write("couldn't load Composio apps (check your key / connection).", "sys")
+            return
+        connected = await asyncio.to_thread(cx.list_connected)
+        enabled = set(cx.enabled_apps())
+
+        items: list[tuple[str, str, str]] = []
+        for app in apps:
+            slug = app["slug"]
+            if slug in enabled:
+                mark = "✓ enabled"
+            elif slug in connected:
+                mark = "· connected"
+            else:
+                mark = ""
+            label = f"{app['name']}   {slug}   {mark}".rstrip()
+            items.append((slug, label, "Apps"))
+
+        slug = await self.push_screen_wait(SearchListModal("Composio apps", items))
+        if not slug:
+            return
+
+        # Already enabled → nothing to do.
+        if slug in enabled:
+            self._write(f"{slug} is already enabled.", "sys")
+            return
+
+        # Connect (OAuth → browser + wait, or direct connector → immediate).
+        self._write(f"connecting {slug}…", "sys")
+        res = await asyncio.to_thread(cx.begin_connect, slug)
+        if res.error:
+            self._write(f"couldn't connect {slug}: {res.error}", "sys")
+            return
+        if res.needs_auth and res.redirect_url:
+            self._write(f"→ opening your browser to authorize {slug}…", "sys")
+            webbrowser.open(res.redirect_url)
+            self._write(f"  if it didn't open: {res.redirect_url}", "sys")
+            try:
+                await asyncio.to_thread(res.request.wait_for_connection, 180)
+            except Exception as exc:  # noqa: BLE001
+                self._write(f"authorization didn't complete: {exc}", "sys")
+                return
+        cx.add_enabled_app(slug)
+        self._write(
+            f"✓ {slug} connected and enabled. Its tools load on next launch "
+            f"(restart opendot).",
+            "sys",
+        )
+        self._refresh_sidebar()
 
     async def _run_turn(self, message: str) -> None:
         mode = None
@@ -334,15 +839,18 @@ class OpendotTUI(App):
                     if mode != "think":
                         flush_answer()
                         mode = "think"
-                    self._write(Text(ev.text.rstrip(), style="italic"), "think")
+                        self._write(Text("Thought", style="dim bold"), "think")
+                    self._write(Text(ev.text.rstrip(), style="dim italic"), "think")
                 elif ev.type == "text":
                     mode = "answer"
                     buf.append(ev.text)
                 elif ev.type == "tool_start":
                     flush_answer(); mode = None
-                    icon = _TOOL_ICONS.get(ev.tool, "▸")
-                    args = ", ".join(f"{k}={v!r}"[:50] for k, v in ev.args.items())
-                    self._write(Text(f"{icon} {ev.tool}  ", style="bold").append(f"({args})", style="dim"), "tool")
+                    args = "  ".join(str(v)[:50] for v in ev.args.values())
+                    line = Text("→ ", style="dim").append(ev.tool, style="bold")
+                    if args:
+                        line.append("  " + args, style="dim")
+                    self._write(line, "tool")
                 elif ev.type == "tool_end":
                     self._write(_render_tool_result(ev.tool, ev.result), "toolout")
                     self._refresh_sidebar()

--- a/tests/test_composio.py
+++ b/tests/test_composio.py
@@ -1,0 +1,59 @@
+"""Tests for the Composio integration's local logic — config, identity,
+namespacing, and fail-soft behavior. Network calls (list_apps, execute) are not
+tested here (they need a real key); we verify they don't raise on bad keys.
+"""
+
+import os
+import stat
+
+import pytest
+
+from opendot import composio_tools as cx
+
+
+@pytest.fixture(autouse=True)
+def isolated_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENDOT_HOME", str(tmp_path / "store"))
+
+
+def test_unconfigured_then_configured():
+    assert cx.is_configured() is False
+    uid = cx.set_api_key("comp_testkey")
+    assert uid.startswith("opendot-")
+    assert cx.is_configured() is True
+    # user_id is stable across reads
+    assert cx.load_config()["user_id"] == uid
+
+
+def test_api_key_file_is_private(tmp_path):
+    cx.set_api_key("comp_secret")
+    path = cx._config_path()
+    mode = stat.S_IMODE(path.stat().st_mode)
+    # owner-only (0o600); skip the assertion on platforms that don't honor it
+    if os.name != "nt":
+        assert mode == 0o600
+
+
+def test_enable_apps_dedup_and_persist():
+    cx.set_api_key("k")
+    cx.add_enabled_app("gmail")
+    cx.add_enabled_app("slack")
+    cx.add_enabled_app("gmail")  # dup
+    assert cx.enabled_apps() == ["gmail", "slack"]
+
+
+def test_namespacing_helpers():
+    assert cx.is_composio_tool("composio__gmail__GMAIL_SEND_EMAIL")
+    assert not cx.is_composio_tool("read_file")
+    assert not cx.is_composio_tool("mcp__github__create_issue")
+
+
+def test_execute_malformed_name_is_soft_error():
+    cx.set_api_key("k")
+    out = cx.execute_tool("composio__bad", {})
+    assert out.startswith("error: malformed")
+
+
+def test_build_specs_empty_without_enabled_apps():
+    cx.set_api_key("k")  # configured but no apps enabled
+    assert cx.build_tool_specs() == []

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -110,3 +110,24 @@ def test_mcp_add_cli_parses_flags_vs_command(tmp_path, monkeypatch):
     cli.main()
     cfg = load_mcp_config()
     assert cfg["s"] == {"command": "cmd", "args": ["-y", "pkg"], "env": {"K": "v"}}
+
+
+def test_mcp_add_remote_with_header(tmp_path, monkeypatch):
+    """`opendot mcp add NAME --url <u> --header 'Authorization=Bearer x'` stores
+    the header so authenticated remote servers (e.g. Supabase PAT) can connect."""
+    import sys
+    from opendot import cli
+    from opendot.mcp.manager import load_mcp_config
+
+    monkeypatch.setenv("OPENDOT_HOME", str(tmp_path / "store"))
+    monkeypatch.setattr(sys, "argv", [
+        "opendot", "mcp", "add", "supabase",
+        "--url", "https://mcp.supabase.com/mcp?project_ref=abc",
+        "--header", "Authorization=Bearer tok123",
+    ])
+    cli.main()
+    cfg = load_mcp_config()
+    assert cfg["supabase"] == {
+        "url": "https://mcp.supabase.com/mcp?project_ref=abc",
+        "headers": {"Authorization": "Bearer tok123"},
+    }

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,47 @@
+"""Tests for the provider/model helpers behind the /model and /provider pickers.
+
+These lock in the model→env-var mapping (used for the missing-key hint and the
+connect flow) and that model discovery reads from LiteLLM's registry.
+"""
+
+import os
+
+from opendot import providers as p
+
+
+def test_env_var_for_known_providers():
+    assert p.env_var_for("gpt-5.1") == "OPENAI_API_KEY"
+    assert p.env_var_for("claude-opus-4-5") == "ANTHROPIC_API_KEY"
+    assert p.env_var_for("deepseek/deepseek-chat") == "DEEPSEEK_API_KEY"
+    assert p.env_var_for("gemini/gemini-3-pro") == "GEMINI_API_KEY"
+    assert p.env_var_for("huggingface/together/x") == "HF_TOKEN"
+
+
+def test_env_var_for_keyless_local_models():
+    assert p.env_var_for("ollama/qwen3") is None
+    assert p.env_var_for("lm_studio/foo") is None
+
+
+def test_env_var_for_unknown():
+    assert p.env_var_for("some-unknown-model") is None
+
+
+def test_provider_of_grouping():
+    assert p.provider_of("deepseek/deepseek-chat") == "deepseek"
+    assert p.provider_of("gpt-5.1") == "openai"
+    assert p.provider_of("claude-opus-4-5") == "anthropic"
+
+
+def test_list_models_from_registry():
+    models = p.list_models()
+    # LiteLLM ships a large registry; if it's importable we expect real entries.
+    assert isinstance(models, list)
+    if models:  # only assert content when litellm is present
+        assert "sample_spec" not in models
+        assert all(isinstance(m, str) and m for m in models)
+
+
+def test_register_key_sets_env(monkeypatch):
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    p.register_key("DEEPSEEK_API_KEY", "sk-xyz")
+    assert os.environ["DEEPSEEK_API_KEY"] == "sk-xyz"

--- a/tests/test_tui_modals.py
+++ b/tests/test_tui_modals.py
@@ -1,0 +1,80 @@
+"""Regression tests for TUI modal event handling.
+
+The key one: a secret typed into a modal's input (e.g. the Composio API key)
+must NEVER bubble up and get submitted as a chat message. This reproduces and
+guards the leak where pressing Enter in ApiKeyModal sent the key to the agent.
+"""
+
+import pytest
+
+from opendot.tui import OpendotTUI, ApiKeyModal
+from opendot.agent.events import Event
+
+
+class _FakeUsage:
+    total_tokens = 0
+    cost_usd = 0.0
+
+
+class _FakeRev:
+    def history(self):
+        return []
+
+
+class _FakeConfig:
+    model = "gpt-5.1"
+    workdir = "/tmp/ws"
+
+
+class _FakeTB:
+    _confirm = None
+
+
+class _FakeAgent:
+    def __init__(self):
+        self.usage = _FakeUsage()
+        self.reversibility = _FakeRev()
+        self.config = _FakeConfig()
+        self.toolbox = _FakeTB()
+        self.mcp = None
+        self.ran = []
+
+    def reset(self):
+        pass
+
+    async def run(self, msg):
+        self.ran.append(msg)
+        yield Event(type="text", text="x")
+
+
+async def test_apikey_modal_enter_does_not_leak_to_chat(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENDOT_HOME", str(tmp_path / "store"))
+    app = OpendotTUI(_FakeAgent())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        # Open the key modal directly (equivalent to running /provider or the
+        # first /composio step) and submit a secret with Enter.
+        app.push_screen(ApiKeyModal("Composio", "COMPOSIO_API_KEY"))
+        await pilot.pause()
+        app.screen.query_one("#key").value = "ak_SECRET"
+        await pilot.press("enter")
+        for _ in range(4):
+            await pilot.pause()
+        # The secret must not have been submitted to the agent as a message.
+        assert "ak_SECRET" not in app.agent.ran
+
+
+async def test_slash_autocomplete_enter_runs_command(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENDOT_HOME", str(tmp_path / "store"))
+    app = OpendotTUI(_FakeAgent())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        for ch in ["slash", "c", "l", "e", "a", "r"]:
+            await pilot.press(ch)
+        await pilot.pause()
+        await pilot.press("enter")  # popup open → runs /clear immediately
+        await pilot.pause()
+        # /clear ran (no chat turn), input cleared, popup closed.
+        assert app.agent.ran == []
+        assert app.query_one("#input").value == ""
+        assert app.query_one("#cmdpopup").display is False


### PR DESCRIPTION
Add interactive setup and app integrations to the TUI, so users configure everything from inside the chat instead of only via CLI flags.

Pickers & autocomplete:
- /model: searchable picker populated from LiteLLM's registry (no hardcoded model list); /model <id> still sets one directly.
- /provider: pick a provider, paste an API key in a masked modal; key is set for the session and the export line is shown to persist it.
- /mcp: dropdown of configured servers with live status, plus an add-server form. Adds custom HTTP header support so authenticated remotes (e.g. Supabase's token) work; --header on `opendot mcp add`.
- /composio: connect Composio's app tools with your own API key — browse apps, OAuth via browser + wait, or direct connectors. Tools namespaced composio__<app>__<tool> and treated as irreversible (confirm + ledger ✗), like MCP. Optional extra: opendot[composio].
- Slash-command autocomplete popup: type '/' to filter commands; Enter runs, Tab completes for commands taking an argument.

Fixes & polish:
- Security: stop modal inputs (API key, search, MCP form) from bubbling Enter to the chat, so a pasted secret can never be submitted as a message; the main handler also ignores submits from non-chat inputs. Regression-tested.
- composio execute: pass dangerously_skip_version_check to avoid ToolVersionRequiredError.
- Sidebar shows connected Providers and Composio status; refreshes on connect.
- Restyle: minimal user block, muted tool lines, dim "Thought" label; teal accent on AI answers. Right-align command descriptions and modal "esc cancel".
- Default model bumped to gpt-5.1; friendly missing-API-key hint on launch.
- README: document /model, /provider, /mcp, /composio; drop LiteLLM mention.

New module: src/opendot/providers.py (provider↔key map + model discovery).
Tests: 66 passing (added composio, providers, mcp-header, tui-modal regression).