### PR TITLE
chore: make composio a core dependency; bump to 0.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,7 @@ ledger. Your built-in file/shell actions stay snapshotted and undoable as usual.
 
 Beyond MCP, opendot can connect to [Composio](https://composio.dev)'s 3000+ app
 tools (Gmail, Slack, GitHub, Notion, Linear, …) using **your own** Composio API
-key. Install the extra and use `/composio` in the chat:
-
-```bash
-pip install 'opendot[composio]'
-```
+key. Just use `/composio` in the chat:
 
 - The first `/composio` asks for your Composio API key (stored in
   `~/.opendot/composio.json`, owner-readable only).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.0.4"
+version = "0.0.5"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"
@@ -27,11 +27,11 @@ dependencies = [
     "prompt_toolkit>=3.0",  # plain REPL input (history, editing)
     "mcp>=1.2",          # MCP client: connect to external MCP servers' tools
     "textual-image>=0.8",  # render the logo image on the welcome screen (TGP/Sixel/Unicode)
+    "composio>=0.11,<0.12",  # /composio: 3000+ app tools (Gmail, Slack, GitHub, …)
 ]
 
 [project.optional-dependencies]
 office = ["openpyxl>=3.1", "python-pptx>=0.6"]  # xlsx / pptx read+edit tools
-composio = ["composio>=0.11,<0.12"]  # /composio: 3000+ app tools (Gmail, Slack, GitHub, …)
 dev = ["pytest>=8.0", "pytest-asyncio>=0.23", "openpyxl>=3.1", "python-pptx>=0.6"]
 
 [project.scripts]

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.loop import Agent
 from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 
-__version__ = "0.0.4"
+__version__ = "0.0.5"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/composio_tools.py
+++ b/src/opendot/composio_tools.py
@@ -18,8 +18,8 @@ Design mirrors how Plandot uses Composio, adapted for a local terminal app:
   reaches an external service, so — exactly like MCP tools — opendot treats it
   as **irreversible**: confirmed before running and marked ✗ in the ledger.
 
-The composio SDK is an optional dependency (``pip install 'opendot[composio]'``);
-everything here fails soft if it isn't installed.
+The composio SDK is a core dependency, but everything here still fails soft if
+the import is unavailable, so a broken install never crashes opendot.
 """
 
 from __future__ import annotations

--- a/src/opendot/tui.py
+++ b/src/opendot/tui.py
@@ -937,7 +937,8 @@ class OpendotTUI(App):
         from opendot import composio_tools as cx
 
         if not cx.composio_available():
-            self._write("Composio isn't installed. Run:  pip install 'opendot[composio]'", "sys")
+            # composio is a core dep, so this only trips on a broken install.
+            self._write("Composio isn't available — try reinstalling opendot.", "sys")
             return
 
         # First run (or no key yet): ask for the Composio API key.


### PR DESCRIPTION
Move `composio` from the optional [composio] extra into core dependencies so
/composio works out of the box with a plain `pip install opendot` — no extra to
install. Update the docstring, the TUI "unavailable" message, and the README to
drop the extra-install step. Bump version to 0.0.5.