### PR TITLE
fix: sidebar showed 0 tokens / $0 — track streaming usage correctly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.0.6"
+version = "0.0.7"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.loop import Agent
 from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 
-__version__ = "0.0.6"
+__version__ = "0.0.7"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/agent/loop.py
+++ b/src/opendot/agent/loop.py
@@ -213,12 +213,16 @@ class Agent:
         )
         content_parts: list[str] = []
         tool_calls: dict[int, dict[str, Any]] = {}
+        usage_counted = False  # guard: with include_usage some providers report
+                               # usage on both the last content chunk AND a final
+                               # usage-only chunk — count it once per turn.
 
         async for chunk in stream:
-            # The final usage chunk (include_usage) has no choices.
-            if getattr(chunk, "usage", None) and not chunk.choices:
-                self.usage.add_response(chunk, litellm)
-                continue
+            # Usage may arrive on its own final chunk (no choices) or attached to
+            # a content chunk — capture it either way, but only once.
+            if not usage_counted and getattr(chunk, "usage", None):
+                self.usage.add_response(chunk, litellm, model=self.config.model)
+                usage_counted = True
             if not chunk.choices:
                 continue
             delta = chunk.choices[0].delta
@@ -250,7 +254,7 @@ class Agent:
             model=self.config.model, messages=self.messages, tools=tools,
             temperature=self.config.temperature, stream=False,
         )
-        self.usage.add_response(resp, litellm)
+        self.usage.add_response(resp, litellm, model=self.config.model)
         msg = resp.choices[0].message
         raw = getattr(msg, "tool_calls", None) or []
         calls = [

--- a/src/opendot/agent/usage.py
+++ b/src/opendot/agent/usage.py
@@ -20,17 +20,35 @@ class Usage:
     total_tokens: int = 0
     cost_usd: float = 0.0
 
-    def add_response(self, resp, litellm) -> None:
-        """Fold one LiteLLM response's usage + cost into the running totals."""
+    def add_response(self, resp, litellm, model: str | None = None) -> None:
+        """Fold one LiteLLM response's usage + cost into the running totals.
+
+        Cost is computed from the token counts + model (works for stream chunks),
+        with completion_cost as a fallback — completion_cost often fails on raw
+        stream chunks, which is why streamed turns showed $0."""
+        p = c = 0
         try:
             u = getattr(resp, "usage", None)
             if u:
-                self.prompt_tokens += int(getattr(u, "prompt_tokens", 0) or 0)
-                self.completion_tokens += int(getattr(u, "completion_tokens", 0) or 0)
-                self.total_tokens += int(getattr(u, "total_tokens", 0) or 0)
+                p = int(getattr(u, "prompt_tokens", 0) or 0)
+                c = int(getattr(u, "completion_tokens", 0) or 0)
+                self.prompt_tokens += p
+                self.completion_tokens += c
+                self.total_tokens += int(getattr(u, "total_tokens", 0) or 0) or (p + c)
         except Exception:  # noqa: BLE001
             pass
-        try:
-            self.cost_usd += float(litellm.completion_cost(completion_response=resp) or 0.0)
-        except Exception:  # noqa: BLE001
-            pass
+        # Prefer token-based cost (reliable for stream chunks); else try the
+        # whole-response helper.
+        added = False
+        if model and (p or c):
+            try:
+                pc, cc = litellm.cost_per_token(model=model, prompt_tokens=p, completion_tokens=c)
+                self.cost_usd += float(pc or 0.0) + float(cc or 0.0)
+                added = True
+            except Exception:  # noqa: BLE001
+                pass
+        if not added:
+            try:
+                self.cost_usd += float(litellm.completion_cost(completion_response=resp) or 0.0)
+            except Exception:  # noqa: BLE001
+                pass

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,0 +1,82 @@
+"""Usage/cost accounting tests.
+
+Covers the streaming path's two past bugs: cost showing $0 (computed from raw
+chunks) and tokens double-counting when a provider reports usage on both the
+last content chunk and a final usage-only chunk.
+"""
+
+import asyncio
+import types
+
+from opendot.agent.config import AgentConfig
+from opendot.agent.loop import Agent
+from opendot.agent.usage import Usage
+
+
+class _Usage:
+    prompt_tokens = 1000
+    completion_tokens = 500
+    total_tokens = 1500
+
+
+class _Delta:
+    content = None
+    reasoning_content = None
+    tool_calls = None
+
+
+class _Choice:
+    def __init__(self):
+        self.delta = _Delta()
+
+
+def _chunk(with_choices, with_usage):
+    c = types.SimpleNamespace()
+    c.choices = [_Choice()] if with_choices else []
+    c.usage = _Usage() if with_usage else None
+    return c
+
+
+class _FakeLiteLLM(types.SimpleNamespace):
+    async def acompletion(self, **kw):
+        async def gen():
+            yield _chunk(True, False)   # content only
+            yield _chunk(True, True)    # last content chunk WITH usage
+            yield _chunk(False, True)   # final usage-only chunk (duplicate)
+        return gen()
+
+    def cost_per_token(self, model, prompt_tokens, completion_tokens):
+        return (0.005, 0.0025)
+
+
+def _bare_agent():
+    a = Agent.__new__(Agent)
+    a.config = AgentConfig(model="gpt-4o", workdir="/tmp")
+    a.usage = Usage()
+    a.messages = []
+    a.toolbox = types.SimpleNamespace(_confirm=None, specs=lambda: [])
+    return a
+
+
+def test_streaming_usage_counted_once_not_doubled():
+    a = _bare_agent()
+
+    async def run():
+        async for _ in a._stream_turn(_FakeLiteLLM(), []):
+            pass
+
+    asyncio.run(run())
+    assert a.usage.total_tokens == 1500          # not 3000
+    assert round(a.usage.cost_usd, 4) == 0.0075  # not 0.015
+
+
+def test_add_response_cost_from_tokens():
+    """Cost is derived from token counts + model (works for stream chunks),
+    not only from completion_cost."""
+    import litellm
+
+    u = Usage()
+    resp = types.SimpleNamespace(usage=_Usage())
+    u.add_response(resp, litellm, model="gpt-4o")
+    assert u.total_tokens == 1500
+    assert u.cost_usd > 0  # real pricing for gpt-4o


### PR DESCRIPTION
The TUI sidebar always showed "0 tokens · $0.00" even after real turns. Two
causes in the streaming path:

- Cost was computed via litellm.completion_cost on raw stream chunks, which
  fails — so cost stayed 0. Now derived from token counts + model
  (litellm.cost_per_token), with completion_cost as a fallback.
- Usage is captured whether the provider reports it on a final usage-only chunk
  or attached to the last content chunk, with a guard so it's counted exactly
  once per turn (some providers with include_usage report it on both, which
  would double-count).

Adds tests/test_usage.py covering both the once-only guard and token-based cost.
Bumps version to 0.0.7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage and cost tracking for streamed and non-streamed responses.
  * Prevented token usage from being counted twice when reported in multiple streaming chunks.
  * Improved cost calculation when detailed token usage is available.

* **Chores**
  * Updated the package version to 0.0.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->