### PR TITLE
fix: address CodeRabbit + Copilot review findings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.0.7"
+version = "0.0.8"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.loop import Agent
 from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/agent/loop.py
+++ b/src/opendot/agent/loop.py
@@ -213,9 +213,9 @@ class Agent:
         )
         content_parts: list[str] = []
         tool_calls: dict[int, dict[str, Any]] = {}
-        usage_counted = False  # guard: with include_usage some providers report
-                               # usage on both the last content chunk AND a final
-                               # usage-only chunk — count it once per turn.
+        # Guard: with include_usage some providers report usage on both the last
+        # content chunk and a final usage-only chunk — count it once per turn.
+        usage_counted = False
 
         async for chunk in stream:
             # Usage may arrive on its own final chunk (no choices) or attached to

--- a/src/opendot/agent/usage.py
+++ b/src/opendot/agent/usage.py
@@ -35,7 +35,7 @@ class Usage:
                 self.prompt_tokens += p
                 self.completion_tokens += c
                 self.total_tokens += int(getattr(u, "total_tokens", 0) or 0) or (p + c)
-        except Exception:  # noqa: BLE001
+        except Exception:  # noqa: BLE001,S110 - accounting is best-effort, never fatal
             pass
         # Prefer token-based cost (reliable for stream chunks); else try the
         # whole-response helper.

--- a/src/opendot/catalog.py
+++ b/src/opendot/catalog.py
@@ -7,8 +7,8 @@ for what's available and routable:
   can actually route to. We only offer these in ``/provider`` so a key the user
   enters will actually work.
 * **Models** come from LiteLLM's registry (``litellm.model_cost``), filtered to
-  those providers and to text chat models only (``mode`` in {chat, completion})
-  — no image / audio / video / embedding models.
+  those providers and to text chat models only (``mode`` in {chat, completion,
+  responses}) — no image / audio / video / embedding models.
 
 No network, no external database, no hardcoded model strings.
 """

--- a/src/opendot/providers.py
+++ b/src/opendot/providers.py
@@ -47,7 +47,10 @@ def known_key_vars() -> list[str]:
             return vars_
     except Exception:  # noqa: BLE001
         pass
-    return list(dict.fromkeys(_ENV_OVERRIDES.values()))
+    # Catalog unavailable: fall back to the common providers (_AUTO_ORDER covers
+    # the <PROVIDER>_API_KEY ones) plus the override exceptions — so a user with
+    # e.g. OPENAI_API_KEY still shows up in the sidebar.
+    return list(dict.fromkeys(_AUTO_ORDER + list(_ENV_OVERRIDES.values())))
 
 
 def _env_for_provider_id(provider: str) -> str | None:

--- a/src/opendot/tui/app.py
+++ b/src/opendot/tui/app.py
@@ -454,19 +454,14 @@ class OpendotTUI(App):
     async def _pick_model(self) -> None:
         import asyncio
         from opendot import catalog
-        from opendot.providers import list_models, provider_of
 
-        # Prefer the models.dev catalog (curated names, grouped, text+tool only);
-        # fall back to LiteLLM's bundled registry offline / if it's empty.
+        # Text chat models from LiteLLM's registry, grouped by provider.
         entries = await asyncio.to_thread(catalog.list_models)
-        if entries:
-            items = [(e["model"], f"{e['name']}   {e['model']}", e["provider"]) for e in entries]
-        else:
-            models = list_models()
-            if not models:
-                self._write("model list unavailable; use  /model <id>  to set one directly.", "sys")
-                return
-            items = sorted(((m, m, provider_of(m)) for m in models), key=lambda t: (t[2], t[1]))
+        if not entries:
+            self._write("model list unavailable; use  /model <id>  to set one directly.", "sys")
+            return
+        # name == model in the catalog, so show the model string once.
+        items = [(e["model"], e["model"], e["provider"]) for e in entries]
         chosen = await self.push_screen_wait(SearchListModal("Select model", items))
         if chosen:
             self._set_model(chosen)
@@ -475,7 +470,7 @@ class OpendotTUI(App):
         import asyncio
         from opendot.providers import connectable_providers, register_key
 
-        # models.dev list when reachable, hardcoded fallback otherwise.
+        # LiteLLM-routable providers that have text models (from the catalog).
         pairs = await asyncio.to_thread(connectable_providers)
         items = [(var, name, "Providers") for name, var in pairs]
         var = await self.push_screen_wait(SearchListModal("Connect a provider", items))

--- a/src/opendot/tui/modals.py
+++ b/src/opendot/tui/modals.py
@@ -93,6 +93,8 @@ class SearchListModal(ModalScreen[str | None]):
         ol.clear_options()
         last_group = None
         self._values: list[str] = []
+        row_index = 0          # index into the OptionList (headers included)
+        first_selectable = None  # index of the first non-disabled (data) row
         for item in self._items:
             value, label, group = item[0], item[1], item[2]
             status = item[3] if len(item) > 3 else ""  # optional right-aligned status
@@ -101,12 +103,16 @@ class SearchListModal(ModalScreen[str | None]):
             if group and group != last_group:
                 ol.add_option(Option(Text(group.upper(), style="bold magenta"), disabled=True))
                 last_group = group
+                row_index += 1
             # Status (e.g. "✓ enabled") is rendered flush-right via a grid.
             prompt = _row_bar(label, status, "green") if status else Text(label)
             ol.add_option(Option(prompt, id=str(len(self._values))))
+            if first_selectable is None:
+                first_selectable = row_index  # this data row's OptionList index
+            row_index += 1
             self._values.append(value)
-        if self._values:
-            ol.highlighted = 1 if (self._items and self._items[0][2]) else 0
+        if first_selectable is not None:
+            ol.highlighted = first_selectable
 
     def on_input_changed(self, event: Input.Changed) -> None:
         self._populate(event.value)

--- a/src/opendot/tui/sidebar.py
+++ b/src/opendot/tui/sidebar.py
@@ -69,7 +69,8 @@ class Sidebar(Static):
         if connected_providers:
             self._section(t, "Providers")
             for var in connected_providers:
-                label = var.replace("_API_KEY", "").replace("_TOKEN", "").title()
+                base = var.replace("_API_KEY", "").replace("_TOKEN", "")
+                label = base.replace("_", " ").title()  # no stray underscores
                 t.append("• ", style="dim")
                 t.append(f"{label} ", style="green")
                 t.append("✓\n", style="green")

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -58,7 +58,8 @@ def test_model_for_available_key_handles_huggingface(monkeypatch, fake_catalog):
 
 
 def test_env_var_for_known_providers():
-    # Resolved live via litellm.get_llm_provider — covers bare + prefixed forms.
+    # Resolved by _provider_id_for (pure lookup: prefix or registry) — covers
+    # bare + prefixed forms.
     assert p.env_var_for("gpt-4o") == "OPENAI_API_KEY"
     assert p.env_var_for("claude-opus-4-5") == "ANTHROPIC_API_KEY"
     assert p.env_var_for("deepseek/deepseek-chat") == "DEEPSEEK_API_KEY"

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -71,12 +71,22 @@ def test_streaming_usage_counted_once_not_doubled():
 
 
 def test_add_response_cost_from_tokens():
-    """Cost is derived from token counts + model (works for stream chunks),
-    not only from completion_cost."""
-    import litellm
+    """Cost is derived from token counts + model (works for stream chunks), via
+    cost_per_token — not the completion_cost helper. Stubbed so it doesn't depend
+    on LiteLLM's live pricing data."""
+    calls = {"completion_cost": 0}
+
+    class _StubLiteLLM(types.SimpleNamespace):
+        def cost_per_token(self, model, prompt_tokens, completion_tokens):
+            return (0.01, 0.02)
+
+        def completion_cost(self, **kw):  # must NOT be used when tokens are present
+            calls["completion_cost"] += 1
+            return 999.0
 
     u = Usage()
     resp = types.SimpleNamespace(usage=_Usage())
-    u.add_response(resp, litellm, model="gpt-4o")
+    u.add_response(resp, _StubLiteLLM(), model="gpt-4o")
     assert u.total_tokens == 1500
-    assert u.cost_usd > 0  # real pricing for gpt-4o
+    assert round(u.cost_usd, 4) == 0.03          # 0.01 + 0.02 from cost_per_token
+    assert calls["completion_cost"] == 0         # token-based path was used


### PR DESCRIPTION
- remove dead list_models() fallback branch in /model picker; show model
  string once (name == model in the catalog)
- known_key_vars() offline fallback now includes the standard <PROVIDER>_API_KEY
  providers, not just the override exceptions (sidebar was hiding them)
- SearchListModal default highlight lands on the first selectable row, never a
  disabled group header, after filtering
- sidebar provider labels: strip underscores before title-casing
- usage.py: narrow S110 suppression on best-effort accounting blocks
- loop.py: de-indent the usage-guard comment
- test_usage.py: stub cost_per_token so cost test doesn't depend on live pricing
- refresh stale comments (models.dev -> LiteLLM; get_llm_provider)
- bump version to 0.0.8