### PR TITLE
feat(composio): use Composio Tool Router; move to tools/; add auth detection (0.0.9)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,10 @@ everything it does. Contributions are welcome; please keep that guarantee intact
 opendot is early. Issues and PRs are genuinely appreciated — you don't need to
 ask permission to open one.
 
+**New here?** Browse issues labeled
+[good first issue](https://github.com/vedaant00/opendot/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+— each one names the exact file to change and how to verify it.
+
 ## Changes that are easy to merge
 
 - Bug fixes
@@ -34,7 +38,8 @@ pytest                                          # should be all green
 ```
 src/opendot/
   cli.py           entry point (subcommands, one-shot, REPL)
-  tui.py           the full-screen Textual TUI
+  tui/             the full-screen Textual TUI (app, modals, sidebar, …)
+  catalog.py       model/provider lists sourced from LiteLLM
   agent/           the model-agnostic ReAct loop (LiteLLM), events, prompt, usage
   tools/           local file/shell tools + office (.xlsx/.pptx)
   reversibility/   THE MOAT: content-addressed snapshots, ledger, undo, classifier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.0.8"
+version = "0.0.9"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.loop import Agent
 from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 
-__version__ = "0.0.8"
+__version__ = "0.0.9"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/agent/prompt.py
+++ b/src/opendot/agent/prompt.py
@@ -24,6 +24,13 @@ Don't mask failures: run the bare command (no `|| echo ...` fallback) and read
 the `[exit N]` line run_shell returns — a non-zero exit (e.g. the app isn't
 installed) means it did NOT open, so say so plainly rather than claiming success.
 
+Connected apps (Composio): if `composio__*` tools are available, they are a
+discovery surface, not the app tools themselves. To act on a connected app
+(Gmail, Slack, GitHub, …): first SEARCH for the right tool by intent (e.g.
+"create a GitHub repo"), then execute the tool it returns. If a call comes back
+"not connected", tell the user to run `/composio` to connect that app — don't
+keep retrying.
+
 How to work:
 - Narrate briefly BEFORE each action: say what you're about to do and why, in one \
 line, so the user can follow your reasoning. Then take the action.

--- a/src/opendot/tools/composio.py
+++ b/src/opendot/tools/composio.py
@@ -181,41 +181,74 @@ def begin_connect(slug: str) -> ConnectResult:
 
 # ---- tool specs + execution (used by the Toolbox) ----
 
-def build_tool_specs() -> list[dict]:
-    """OpenAI-style function specs for all tools of the user's enabled apps.
+# --- Tool Router session (the scalable tool surface) -----------------------
+#
+# A Composio app can expose hundreds of tools; binding them all blows past the
+# model's tools-array cap (OpenAI: 128). So — like Plandot — we use Composio's
+# **Tool Router**: `composio.create(user_id, toolkits=[...])` returns a session
+# whose `.tools()` is a small, bounded set of meta-tools (search / get-schema /
+# execute). The agent discovers the specific tool it needs at runtime via those,
+# and we route calls through `session.execute()`. No cap, nothing truncated.
 
-    Names are namespaced ``composio__<slug>__<TOOL_SLUG>`` so they can't collide
-    with built-ins or MCP tools and are recognisable as external/irreversible.
-    Returns [] if composio isn't installed / configured / has no enabled apps.
-    """
-    apps = enabled_apps()
+_SESSION = None            # cached ToolRouterSession
+_SESSION_APPS: tuple = ()  # the enabled-apps set the cached session was built for
+
+
+def _session():
+    """Return a Tool Router session scoped to the enabled apps, cached until the
+    enabled-app set changes. None if composio is unconfigured/unavailable."""
+    global _SESSION, _SESSION_APPS
+    apps = tuple(enabled_apps())
     if not apps or not composio_available():
-        return []
+        return None
+    if _SESSION is not None and _SESSION_APPS == apps:
+        return _SESSION
     try:
         client, user_id = _client()
+        _SESSION = client.create(user_id=user_id, toolkits=list(apps))
+        _SESSION_APPS = apps
+        return _SESSION
+    except Exception:  # noqa: BLE001
+        _SESSION = None
+        _SESSION_APPS = ()
+        return None
+
+
+def _spec_name(fn_name: str) -> str:
+    return f"composio__{fn_name}"
+
+
+def build_tool_specs() -> list[dict]:
+    """OpenAI-style function specs for the Tool Router meta-tools of the user's
+    enabled apps — a small bounded set (search/execute), never the full tool
+    list, so we never exceed the provider's tools-array limit.
+
+    Names are namespaced ``composio__<tool>`` so they can't collide with
+    built-ins or MCP tools. Returns [] if composio isn't configured / enabled.
+    """
+    session = _session()
+    if session is None:
+        return []
+    try:
+        tools = session.tools()
     except Exception:  # noqa: BLE001
         return []
     specs: list[dict] = []
-    for slug in apps:
-        try:
-            tools = client.tools.get(user_id, toolkits=[slug], limit=1000)
-        except Exception:  # noqa: BLE001
+    for t in tools:
+        fn = t.get("function", t) if isinstance(t, dict) else getattr(t, "function", t)
+        name = (fn.get("name") if isinstance(fn, dict) else getattr(fn, "name", "")) or ""
+        if not name:
             continue
-        for t in tools:
-            fn = t.get("function", t) if isinstance(t, dict) else getattr(t, "function", t)
-            name = (fn.get("name") if isinstance(fn, dict) else getattr(fn, "name", "")) or ""
-            if not name:
-                continue
-            desc = fn.get("description", "") if isinstance(fn, dict) else getattr(fn, "description", "")
-            params = fn.get("parameters", {}) if isinstance(fn, dict) else getattr(fn, "parameters", {})
-            specs.append({
-                "type": "function",
-                "function": {
-                    "name": f"composio__{slug}__{name}",
-                    "description": desc or f"Composio {slug} tool {name}",
-                    "parameters": params or {"type": "object", "properties": {}},
-                },
-            })
+        desc = fn.get("description", "") if isinstance(fn, dict) else getattr(fn, "description", "")
+        params = fn.get("parameters", {}) if isinstance(fn, dict) else getattr(fn, "parameters", {})
+        specs.append({
+            "type": "function",
+            "function": {
+                "name": _spec_name(name),
+                "description": desc or f"Composio tool {name}",
+                "parameters": params or {"type": "object", "properties": {}},
+            },
+        })
     return specs
 
 
@@ -223,27 +256,45 @@ def is_composio_tool(name: str) -> bool:
     return name.startswith("composio__")
 
 
+# Phrases that specifically mean "the app isn't connected", vs. a generic
+# failure (rate limit, bad args). Adapted from Plandot's detect.py. Matched
+# case-insensitively anywhere in the tool output.
+_AUTH_PHRASES = (
+    "not connected", "no active connection", "no connection",
+    "authentication required", "authorization required", "please authorize",
+    "please connect", "not authenticated", "unauthorized", "connect your",
+    "requires authentication", "needs to be connected",
+)
+
+
+def looks_like_auth_error(text: str) -> bool:
+    """True if ``text`` indicates a missing/expired Composio connection (as
+    opposed to a generic failure)."""
+    low = text.lower()
+    return any(p in low for p in _AUTH_PHRASES)
+
+
 def execute_tool(name: str, arguments: dict) -> str:
-    """Run a namespaced composio tool. ``name`` is composio__<slug>__<TOOL_SLUG>."""
+    """Run a Composio Tool Router meta-tool. ``name`` is ``composio__<tool>``;
+    execution goes through the session so discovery/scoping is honored."""
+    tool_slug = name[len("composio__"):]
+    session = _session()
+    if session is None:
+        return "error: Composio session unavailable (not configured?)"
     try:
-        _, _, tool_slug = name.split("__", 2)
-    except ValueError:
-        return f"error: malformed composio tool name {name!r}"
-    try:
-        client, user_id = _client()
-        # skip the toolkit-version check — we execute the latest, same as Plandot
-        # (otherwise the SDK raises ToolVersionRequiredError).
-        res = client.tools.execute(
-            tool_slug, arguments or {},
-            user_id=user_id, dangerously_skip_version_check=True,
-        )
+        res = session.execute(tool_slug, arguments=arguments or {})
     except Exception as exc:  # noqa: BLE001
         return f"error: composio execution failed: {type(exc).__name__}: {exc}"
-    # ToolExecutionResponse — prefer a JSON dump of its data/successful fields.
     data = getattr(res, "data", None)
     if data is None and isinstance(res, dict):
         data = res.get("data", res)
     try:
-        return json.dumps(data if data is not None else res, default=str)[:8000]
+        out = json.dumps(data if data is not None else res, default=str)[:8000]
     except Exception:  # noqa: BLE001
-        return str(res)[:8000]
+        out = str(res)[:8000]
+    # If the failure is an auth/connection problem, tell the user how to fix it
+    # (connect the app) instead of surfacing a raw "not connected" error.
+    if looks_like_auth_error(out):
+        out += ("\n\n[opendot] This looks like an unconnected app — run /composio "
+                "to connect it, then retry.")
+    return out

--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -307,15 +307,16 @@ class Toolbox:
                     "parameters": mt.input_schema,
                 },
             })
-        # External Composio tools (never in read-only explorer boxes).
+        # External Composio tools — the Tool Router keeps this a small, bounded
+        # meta-tool set, so we don't need a total-count cap here.
         if not self.read_only:
-            from opendot import composio_tools
+            from opendot.tools import composio as composio_tools
             specs.extend(composio_tools.build_tool_specs())
         return specs
 
     def call(self, name: str, args: dict[str, Any]) -> str:
         # Composio tools are external + opaque like MCP: confirm + mark irreversible.
-        from opendot import composio_tools
+        from opendot.tools import composio as composio_tools
         if composio_tools.is_composio_tool(name):
             reason = "external Composio tool — opendot cannot undo it"
             if not self._confirm(f"Run {name}?  {reason}"):

--- a/src/opendot/tui/app.py
+++ b/src/opendot/tui/app.py
@@ -49,10 +49,10 @@ class OpendotTUI(App):
     #welcome { width: auto; height: 6; }
     Screen.-welcome #transcript { display: none; }
     Screen.-welcome #sidebar { display: none; }
-    /* Anchor the welcome group near the top-center with fixed padding rather
-       than dynamic middle-centering — so opening the command popup grows the
-       column downward instead of re-centering (and shoving) the logo. */
-    Screen.-welcome #main { width: 1fr; height: 1fr; align: center top; padding-top: 9; }
+    /* Center the welcome group vertically. Safe to use middle-align because the
+       command popup is a floating overlay (layer: overlay) — opening it doesn't
+       change this column's height, so the logo never shifts. */
+    Screen.-welcome #main { width: 1fr; height: 1fr; align: center middle; }
     /* All three welcome children share width:60% so #main's align centers them
        as one column. The logo image inside is centered by its Center wrapper. */
     Screen.-welcome #welcome-wrap {
@@ -82,7 +82,7 @@ class OpendotTUI(App):
     .answer { color: $text; border-left: solid #2dd4bf; padding: 0 1; }
     .tool   { color: $text-muted; margin: 1 0 0 2; }
     .toolout{ color: $text-muted; margin: 0 0 0 4; }
-    .err    { color: $error; text-style: bold; border-left: thick $error; padding: 0 1; }
+    .err    { color: $error; text-style: bold; border-left: solid $error; padding: 0 1; }
     .sys    { color: $text-muted; text-style: italic; }
     """
 
@@ -526,7 +526,7 @@ class OpendotTUI(App):
         import asyncio
         import webbrowser
 
-        from opendot import composio_tools as cx
+        from opendot.tools import composio as cx
 
         if not cx.composio_available():
             # composio is a core dep, so this only trips on a broken install.

--- a/src/opendot/tui/sidebar.py
+++ b/src/opendot/tui/sidebar.py
@@ -78,7 +78,7 @@ class Sidebar(Static):
 
         # -- Composio (show once a key is set; then list enabled apps) --
         try:
-            from opendot import composio_tools
+            from opendot.tools import composio as composio_tools
             cx_configured = composio_tools.is_configured()
             capps = composio_tools.enabled_apps()
         except Exception:  # noqa: BLE001

--- a/tests/test_composio.py
+++ b/tests/test_composio.py
@@ -8,7 +8,7 @@ import stat
 
 import pytest
 
-from opendot import composio_tools as cx
+from opendot.tools import composio as cx
 
 
 @pytest.fixture(autouse=True)
@@ -48,12 +48,23 @@ def test_namespacing_helpers():
     assert not cx.is_composio_tool("mcp__github__create_issue")
 
 
-def test_execute_malformed_name_is_soft_error():
+def test_execute_without_session_is_soft_error():
+    # Configured but no enabled apps → no Tool Router session → soft error,
+    # never a crash.
     cx.set_api_key("k")
-    out = cx.execute_tool("composio__bad", {})
-    assert out.startswith("error: malformed")
+    out = cx.execute_tool("composio__COMPOSIO_SEARCH_TOOLS", {})
+    assert out.startswith("error:")
 
 
 def test_build_specs_empty_without_enabled_apps():
     cx.set_api_key("k")  # configured but no apps enabled
     assert cx.build_tool_specs() == []
+
+
+def test_looks_like_auth_error_distinguishes_auth_from_generic():
+    assert cx.looks_like_auth_error('{"error": "Gmail not connected"}')
+    assert cx.looks_like_auth_error("401 Unauthorized")
+    assert cx.looks_like_auth_error("please connect your account")
+    # generic failures are NOT auth errors
+    assert not cx.looks_like_auth_error("rate limit exceeded")
+    assert not cx.looks_like_auth_error('{"error": "invalid argument: to"}')


### PR DESCRIPTION
Fixes the "tools: array too long" crash when a large Composio app (e.g. GitHub)
is enabled, plus assorted robustness and UX fixes.

Composio:
- Rewire to Composio's Tool Router (composio.create(user_id, toolkits=[...]) →
  session). session.tools() is a small, bounded meta-tool set (search/execute),
  so the tools array never exceeds the model's 128 limit — nothing truncated.
  Execution routes through session.execute(); session is cached per enabled-app
  set. (Mirrors plandot-integrations/session.py.)
- Remove the total-tools cap in Toolbox.specs() — no longer needed now that the
  Composio surface is inherently bounded.
- Detect auth/connection failures in tool output (adapted from Plandot's
  detect.py) and tell the user to run /composio to connect the app, instead of
  surfacing a raw "not connected" error.
- Move src/opendot/composio_tools.py → src/opendot/tools/composio.py (it's a
  tool provider; belongs with local.py/office.py). Import sites + tests updated.
- Prompt nudge teaching the agent the search → execute discovery flow.

TUI:
- Welcome logo + input now vertically center on any terminal size (safe again
  now that the command popup is a floating overlay, so it doesn't reflow).
- Error message block uses the same thin accent strip as user/answer blocks
  (was a thicker border).

Docs:
- CONTRIBUTING.md points newcomers at the "good first issue" label; fix stale
  project-layout (tui/ package, catalog.py).

Bump version to 0.0.9. Tests: 79 pass (added Tool Router + auth-detection cases).