### PR TITLE
Composio via Tool Router + prompt protocol, /log clear, cleaner tool output (0.1.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.1.0"
+version = "0.1.1"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.loop import Agent
 from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/agent/prompt.py
+++ b/src/opendot/agent/prompt.py
@@ -24,12 +24,41 @@ Don't mask failures: run the bare command (no `|| echo ...` fallback) and read
 the `[exit N]` line run_shell returns — a non-zero exit (e.g. the app isn't
 installed) means it did NOT open, so say so plainly rather than claiming success.
 
-Connected apps (Composio): if `composio__*` tools are available, they are a
-discovery surface, not the app tools themselves. To act on a connected app
-(Gmail, Slack, GitHub, …): first SEARCH for the right tool by intent (e.g.
-"create a GitHub repo"), then execute the tool it returns. If a call comes back
-"not connected", tell the user to run `/composio` to connect that app — don't
-keep retrying.
+INTEGRATIONS — when `composio__*` tools are present, they are Composio's tools
+for Gmail, Linear, Slack, Notion, GitHub, Google Workspace, and 100+ SaaS apps.
+Use these for SaaS actions; don't re-implement them in shell.
+
+INTEGRATION CALL PROTOCOL — every SaaS action follows this exactly:
+
+  1. Identify toolkit (gmail, linear, …) + verb (send_email, create_issue, …).
+  2. If you don't know the tool slug, call `composio__COMPOSIO_SEARCH_TOOLS`
+     with a query like "linear create issue". Don't use shell for this.
+  3. Call `composio__COMPOSIO_MULTI_EXECUTE_TOOL` with the slug. ACTUALLY
+     EXECUTE, even if you suspect the user isn't connected — the runtime detects
+     the auth failure and tells the user to connect. It only fires if you
+     actually invoke the tool.
+  4. On `successful: false` with auth/connection error: STOP and tell the user
+     to run `/composio` to connect that app; don't fall back to shell.
+  5. On `successful: true`: briefly confirm with the relevant ID/link.
+
+Never say "X integration isn't available" without having called
+`composio__COMPOSIO_MULTI_EXECUTE_TOOL` — connection status is invisible to you
+until you make the real call.
+
+UNSUPPORTED TOOLKITS: if `composio__COMPOSIO_SEARCH_TOOLS` returns nothing for a
+toolkit, it's not connected/supported. Tell the user plainly and suggest running
+`/composio` to connect it. Don't fake it via shell or substitute a
+non-equivalent toolkit.
+
+SCHEMA-FIRST for Composio tools: before invoking any Composio action for the
+FIRST time in a session, call `composio__COMPOSIO_GET_TOOL_SCHEMAS` with that
+slug and follow the schema exactly — including nested object shapes. Reuse the
+shape on subsequent calls in the same session without re-fetching. Skipping
+leads to "missing fields" errors and a wasted retry.
+
+Composio argument shapes to know: `GMAIL_SEND_EMAIL.recipient_email` is a single
+STRING ("a@x.com, b@x.com"), not a list. Schema "string" never gets wrapped in a
+list.
 
 How to work:
 - Narrate briefly BEFORE each action: say what you're about to do and why, in one \

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -115,12 +115,17 @@ def _build_agent(model: str, workdir: str, confirm=None) -> Agent:
     )
 
 
-def _cmd_log(workdir: str) -> None:
-    """`opendot log` — show the auditable action history."""
+def _cmd_log(workdir: str, clear: bool = False) -> None:
+    """`opendot log` — show the auditable action history (or --clear it)."""
     from opendot.reversibility.engine import Reversibility
     from opendot.reversibility.rules import load_rules
 
     rev = Reversibility(workdir=workdir, rules=load_rules(workdir))
+    if clear:
+        n = rev.clear_history()
+        console.print(f"[green]cleared[/green] {n} ledger entr{'y' if n == 1 else 'ies'} "
+                      "(undo history discarded)")
+        return
     entries = rev.history()
     if not entries:
         console.print("[dim]no actions recorded yet[/dim]")
@@ -357,7 +362,9 @@ def main() -> None:
     parser.add_argument("--version", action="version", version=f"opendot {__version__}")
 
     sub = parser.add_subparsers(dest="command")
-    sub.add_parser("log", help="Show the auditable history of actions opendot took.")
+    p_log = sub.add_parser("log", help="Show the auditable history of actions opendot took.")
+    p_log.add_argument("--clear", action="store_true",
+                       help="Wipe this project's action ledger (discards undo history).")
     p_undo = sub.add_parser("undo", help="Restore the workspace (last action, or to a given id).")
     p_undo.add_argument("id", nargs="?", help="Action id from `opendot log` (default: last).")
 
@@ -388,7 +395,7 @@ def main() -> None:
 
     # Reversibility subcommands (no model call needed).
     if args.command == "log":
-        _cmd_log(workdir)
+        _cmd_log(workdir, clear=getattr(args, "clear", False))
         return
     if args.command == "undo":
         _cmd_undo(workdir, args.id)

--- a/src/opendot/reversibility/engine.py
+++ b/src/opendot/reversibility/engine.py
@@ -64,6 +64,11 @@ class Reversibility:
     def history(self) -> list[LedgerEntry]:
         return ledger.read_all(self.project_id)
 
+    def clear_history(self) -> int:
+        """Clear this project's action ledger (discards undo history). Returns
+        the number of entries removed."""
+        return ledger.clear(self.project_id)
+
     def restore_to(self, snapshot_id: str) -> None:
         """Restore the workspace to the state captured in ``snapshot_id``."""
         snap = snapshots.load_snapshot(self.project_id, snapshot_id)

--- a/src/opendot/reversibility/ledger.py
+++ b/src/opendot/reversibility/ledger.py
@@ -60,3 +60,14 @@ def read_all(project_id: str) -> list[LedgerEntry]:
 def last(project_id: str) -> LedgerEntry | None:
     entries = read_all(project_id)
     return entries[-1] if entries else None
+
+
+def clear(project_id: str) -> int:
+    """Delete this project's ledger file. Returns how many entries were removed.
+    Note: this discards the undo history; snapshot objects on disk are left
+    (harmless, content-addressed) but are no longer referenced by any entry."""
+    path = _ledger_path(project_id)
+    n = len(read_all(project_id))
+    if path.exists():
+        path.unlink()
+    return n

--- a/src/opendot/tui/app.py
+++ b/src/opendot/tui/app.py
@@ -38,7 +38,7 @@ class OpendotTUI(App):
     Screen { layout: vertical; layers: base overlay; }
     #body { height: 1fr; }                     /* main column + sidebar fill the middle */
     #main { width: 3fr; height: 1fr; }         /* left column: transcript + input + mode */
-    #transcript { height: 1fr; padding: 0 1; } /* fills the space above the input */
+    #transcript { height: 1fr; padding: 0 1 1 1; } /* pad bottom so the last message isn't glued to the input */
     #sidebar { width: 34; height: 1fr; padding: 1; border-left: solid $panel; }
 
     /* Welcome layout: small centered logo with the input right below it,
@@ -432,7 +432,10 @@ class OpendotTUI(App):
         elif cmd == "composio":
             self.run_worker(self._manage_composio(), exclusive=False)
         elif cmd == "log":
-            self.action_log()
+            if rest.strip().lower() == "clear":
+                self.run_worker(self._clear_log(), exclusive=False)
+            else:
+                self.action_log()
         elif cmd == "undo":
             self._do_undo(rest.strip() or None)
         else:
@@ -697,6 +700,23 @@ class OpendotTUI(App):
             mark = "↺" if e.reversible else "✗ irreversible"
             t.append(f"  {e.id}  {mark}  {e.kind}  {e.detail}\n", style="dim")
         self._write(t, "")
+
+    async def _clear_log(self) -> None:
+        """`/log clear` — wipe this project's action ledger after confirming
+        (it discards the undo history, so gate it behind the confirm modal)."""
+        rev = self.agent.reversibility
+        if not rev.history():
+            self._write("no actions to clear", "sys")
+            return
+        ok = await self.push_screen_wait(ConfirmModal(
+            "Clear the action ledger for this project?\n"
+            "This discards the undo history — past actions can no longer be undone."
+        ))
+        if not ok:
+            return
+        n = rev.clear_history()
+        self._write(f"cleared {n} ledger entr{'y' if n == 1 else 'ies'}.", "sys")
+        self._refresh_sidebar()
 
 
 def run_tui(agent: Agent) -> None:

--- a/src/opendot/tui/commands.py
+++ b/src/opendot/tui/commands.py
@@ -8,7 +8,7 @@ SLASH_COMMANDS: list[tuple[str, str]] = [
     ("/provider", "connect a provider + API key"),
     ("/mcp", "manage MCP servers"),
     ("/composio", "connect apps (Gmail, Slack, …)"),
-    ("/log", "show the action ledger"),
+    ("/log", "show the action ledger ( /log clear to wipe it )"),
     ("/undo", "revert the last action ( /undo <id> )"),
     ("/clear", "reset the conversation"),
     ("/compact", "trim old turns to free context"),

--- a/src/opendot/tui/helpers.py
+++ b/src/opendot/tui/helpers.py
@@ -46,11 +46,41 @@ def _title_bar(title: str, hint: str = "esc cancel"):
     return _row_bar(title, hint, right_style="dim", left_style="bold")
 
 
+def _render_composio_result(result: str):
+    """Compact one-line status for a Composio tool result, instead of dumping
+    the raw JSON. Falls back to None if we can't parse it (caller shows the
+    generic preview)."""
+    import json
+
+    try:
+        data = json.loads(result)
+    except Exception:  # noqa: BLE001
+        return None
+    if not isinstance(data, dict):
+        return None
+    # Execute result: {"total_count", "success_count", "error_count", ...}
+    if "success_count" in data or "total_count" in data:
+        ok = int(data.get("success_count", 0))
+        total = int(data.get("total_count", ok))
+        style = "green" if ok and ok == total else ("yellow" if ok else "red")
+        return Text(f"✓ executed · {ok}/{total} ok", style=style)
+    # Search result: {"results": [ ... ]}
+    if isinstance(data.get("results"), list):
+        n = len(data["results"])
+        return Text(f"found {n} tool{'s' if n != 1 else ''}", style="dim")
+    return None
+
+
 def _render_tool_result(tool: str, result: str):
     """Render a tool's result. File edits (write_file/edit) show a colored diff;
-    other tools show a short preview. This is the 'see exactly what changed'
-    transparency that reinforces reversibility."""
+    Composio results show a compact status; other tools show a short preview.
+    This is the 'see exactly what changed' transparency that reinforces
+    reversibility."""
     result = result.rstrip()
+    if tool.startswith("composio__"):
+        compact = _render_composio_result(result)
+        if compact is not None:
+            return compact
     if tool in {"write_file", "edit"} and "@@" in result:
         t = Text()
         for line in result.splitlines():
@@ -65,11 +95,17 @@ def _render_tool_result(tool: str, result: str):
             else:
                 t.append(line + "\n", style="dim")
         return t
-    # non-diff: first couple of lines, dimmed
+    # non-diff: a short preview, dimmed. Cap BOTH lines and total length —
+    # tool results (e.g. Composio search) are often one huge single-line JSON
+    # blob, which line-only truncation wouldn't shorten.
     lines = result.splitlines() or ["(done)"]
     preview = "\n".join(lines[:3])
-    if len(lines) > 3:
-        preview += f"\n  … (+{len(lines) - 3} lines)"
+    extra_lines = len(lines) - 3
+    _MAX = 500
+    if len(preview) > _MAX:
+        preview = preview[:_MAX].rstrip() + " …"
+    elif extra_lines > 0:
+        preview += f"\n  … (+{extra_lines} more lines)"
     return Text(preview, style="dim")
 
 

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -172,3 +172,20 @@ def test_load_snapshot_roundtrip(tmp_path):
     loaded = S.load_snapshot(s.project_id, s.id)
     assert loaded.files == s.files
     assert loaded.workdir == s.workdir
+
+
+def test_ledger_clear_wipes_history(tmp_path):
+    from opendot.reversibility.engine import Reversibility
+    from opendot.reversibility.rules import load_rules
+
+    wd = _workspace(tmp_path)
+    rev = Reversibility(workdir=str(wd), rules=load_rules(str(wd)))
+    rev.before_action("write", "a.txt", reversible=True)
+    rev.before_action("shell", "git init", reversible=False)
+    assert len(rev.history()) == 2
+
+    removed = rev.clear_history()
+    assert removed == 2
+    assert rev.history() == []
+    # clearing an already-empty ledger is a no-op, not an error
+    assert rev.clear_history() == 0


### PR DESCRIPTION
## Composio: actually usable now
- Route Composio through its **Tool Router** (`composio.create` → session): the
  agent gets a small, bounded meta-tool set (search / execute), so the tools
  array never blows past the model's 128-tool limit — fixes the "tools: array
  too long" crash when a big app (e.g. GitHub) was enabled.
- Add the **INTEGRATION CALL PROTOCOL** to the system prompt (adapted from
  Plandot): the agent now SEARCHes → gets schema → EXECUTEs a connected app's
  tools instead of falling back to shell `git`/`curl`. Verified live: it now
  actually sends a Gmail / calls GitHub via Composio.
- **Auth-error detection**: a "not connected" tool result tells the user to run
  `/composio` instead of surfacing a raw error.
- **Real disconnect**: disabling an app now revokes the Composio-side
  connection, and reconnect reuses an existing active account (fixes
  ComposioMultipleConnectedAccountsError on reconnect).

## New: clear the ledger
- `/log clear` (TUI, behind a confirm) and `opendot log --clear` (CLI) wipe the
  current project's action ledger. Gated because it discards undo history.

## TUI polish
- Composio tool results render as a compact status (`✓ executed · 1/1 ok`,
  `found N tools`) instead of a raw JSON wall.
- Long/one-line tool outputs are length-capped, not just line-capped.
- Bottom padding so the last message isn't glued to the input.

## Chore
- Bump version to 0.1.1.

Tests: 81 passing (added ledger-clear + auth-detection + usage-guard cases).