### PR TITLE
fix: don't silently run `rm` on non-snapshotted paths (0.1.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.1.1"
+version = "0.1.2"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.loop import Agent
 from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/reversibility/classifier.py
+++ b/src/opendot/reversibility/classifier.py
@@ -39,6 +39,23 @@ _PKG_INSTALL = ("pip install", "pip3 install", "npm install", "npm i ",
 _PRIVILEGE = {"sudo", "doas", "su"}
 _DESTRUCTIVE_DB = re.compile(r"\b(drop|truncate|delete)\s+(table|database|from)\b", re.I)
 
+# Directory names snapshots SKIP by default (mirrors snapshots._DEFAULT_IGNORE_DIRS).
+# Deleting one of these is NOT undoable — it was never captured — so an `rm`
+# that targets them must be treated as irreversible, not auto-run.
+_NOT_SNAPSHOTTED = {".git", ".hg", ".svn", "node_modules", "__pycache__",
+                    ".venv", "venv", ".opendot", ".mypy_cache", ".pytest_cache",
+                    ".ruff_cache", "dist", "build", ".next", ".cache"}
+
+
+def _hits_unsnapshotted_path(command: str) -> str | None:
+    """If the command references a directory that snapshots skip (so it can't be
+    restored), return that name; else None."""
+    tokens = re.split(r"[\s/]+", command)
+    for tok in tokens:
+        if tok in _NOT_SNAPSHOTTED:
+            return tok
+    return None
+
 
 @dataclass
 class Verdict:
@@ -94,6 +111,12 @@ def classify(command: str, workdir: str) -> Verdict:
         # rm inside the workspace is covered by the snapshot; rm outside isn't.
         if _mentions_outside_path(cmd, workdir):
             return Verdict(False, "deletes files outside the workspace")
+        # Deleting a path snapshots SKIP (e.g. .git, node_modules) can't be
+        # undone — it was never captured. Flag it rather than silently run it.
+        skipped = _hits_unsnapshotted_path(cmd)
+        if skipped:
+            return Verdict(False, f"deletes '{skipped}', which opendot doesn't "
+                                  f"snapshot — this can't be undone")
         # in-workspace rm is reversible via snapshot
         return Verdict(True)
     if _mentions_outside_path(cmd, workdir):

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -48,6 +48,23 @@ def test_rm_outside_workspace_flagged():
     assert not _rev("rm ~/important")
 
 
+def test_rm_of_unsnapshotted_dirs_is_irreversible():
+    # These dirs are excluded from snapshots, so deleting them can't be undone —
+    # must be flagged (confirm), never silently auto-run. Regression for the
+    # `rm -rf .git` hole.
+    assert not _rev("rm -rf .git")
+    assert not _rev("rm -rf .git some_folder")
+    assert not _rev("rm -rf node_modules")
+    assert not _rev("rm -rf .venv")
+
+
+def test_rm_of_normal_workspace_paths_stays_reversible():
+    # Normal in-workspace deletes ARE snapshotted → still auto-run (no false alarm).
+    assert _rev("rm -rf some_folder")
+    assert _rev("rm file.txt")
+    assert _rev("rm -rf src/old")
+
+
 def test_outside_path_flagged():
     assert not _rev("cp secret.txt /etc/")
     assert not _rev("mv data ../../out")


### PR DESCRIPTION
A user found a real hole in the reversibility guarantee: `rm -rf .git` (and
node_modules, .venv, etc.) was classified reversible and auto-run — but those
dirs are excluded from snapshots, so `undo` could NOT restore them. That's
exactly the "silent un-undoable surprise" the classifier is meant to prevent.

Fix: the classifier now flags an `rm` targeting any directory snapshots skip
(.git, .hg, .svn, node_modules, __pycache__, .venv/venv, .opendot, build/dist,
caches) as **irreversible** — so it hits the confirm gate with an honest "this
can't be undone" note instead of running silently.

- Normal in-workspace deletes (`rm -rf some_folder`, `rm file.txt`) stay
  reversible/auto-run — no false alarms.
- Snapshot behavior is unchanged; we don't start snapshotting .git (too big) —
  we just stop pretending deleting it is undoable.

Note: `_NOT_SNAPSHOTTED` mirrors snapshots' default ignore set; keep them in
sync if either changes.

Tests: 83 passing (added rm-of-ignored-dir + rm-of-normal-path regressions).