### PR TITLE
Reversibility hardening: file permissions, snapshot size guard, mtime cache, GC + retention, --api-base (0.1.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ they run, with an honest note about what can't be undone.
 That's the point of opendot: an agent you can let loose because nothing it does
 is a surprise, and (almost) nothing is irreversible.
 
+opendot is model-agnostic — it works with any model through LiteLLM (OpenAI,
+Anthropic, Google, DeepSeek, …) and runs fully local via Ollama. Ollama is just
+the zero-setup local option; use whatever backend you prefer.
+
 ## Installation
 
 ```bash
@@ -83,6 +87,14 @@ Provider names link to where you get a key.
 | [Ollama](https://ollama.com) (local, no key) | — | `ollama/qwen3` |
 
 Reasoning models stream their thinking live.
+
+**Local OpenAI-compatible servers** (llama.cpp / `llama-server`, vLLM, LM Studio):
+point opendot at the server with `--api-base` and an `openai/`-prefixed model.
+
+```bash
+# e.g. llama.cpp: llama-server -m model.gguf --port 8080
+opendot --model openai/local --api-base http://localhost:8080/v1
+```
 
 **Which model runs.** The default is `gpt-5.1`. If its key (`OPENAI_API_KEY`)
 isn't set but another provider's key is, opendot automatically switches to that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.1.2"
+version = "0.1.3"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.loop import Agent
 from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/agent/config.py
+++ b/src/opendot/agent/config.py
@@ -25,3 +25,6 @@ class AgentConfig:
     max_steps: int = 40  # hard bound on tool-calling turns per user message
     temperature: float | None = None
     system_prompt: str | None = None  # None => use the built-in default
+    # Base URL for an OpenAI-compatible server (llama.cpp/llama-server, vLLM,
+    # LM Studio, …). Falls back to $OPENAI_API_BASE / the provider default.
+    api_base: str | None = None

--- a/src/opendot/agent/loop.py
+++ b/src/opendot/agent/loop.py
@@ -210,6 +210,7 @@ class Agent:
             model=self.config.model, messages=self.messages, tools=tools,
             temperature=self.config.temperature, stream=True,
             stream_options={"include_usage": True},
+            api_base=self.config.api_base,  # None => provider default
         )
         content_parts: list[str] = []
         tool_calls: dict[int, dict[str, Any]] = {}
@@ -253,6 +254,7 @@ class Agent:
         resp = await litellm.acompletion(
             model=self.config.model, messages=self.messages, tools=tools,
             temperature=self.config.temperature, stream=False,
+            api_base=self.config.api_base,  # None => provider default
         )
         self.usage.add_response(resp, litellm, model=self.config.model)
         msg = resp.choices[0].message

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -80,17 +80,19 @@ def _warn_if_missing_key(model: str) -> None:
         )
 
 
-def _build_agent(model: str, workdir: str, confirm=None) -> Agent:
-    # If the chosen model's API key isn't set but another provider's key is,
-    # switch to that provider so opendot works with whatever key the user has.
-    from opendot.providers import env_var_for, model_for_available_key
-    var = env_var_for(model)
-    if var and not os.environ.get(var):
-        alt = model_for_available_key()
-        if alt and alt != model:
-            console.print(f"[dim]no {var}; using [cyan]{alt}[/cyan] "
-                          f"(found its key in your environment)[/dim]")
-            model = alt
+def _build_agent(model: str, workdir: str, confirm=None, api_base: str | None = None) -> Agent:
+    # With a custom api_base (local OpenAI-compatible server like llama.cpp), no
+    # provider key is needed — so skip the auto-switch. Otherwise: if the chosen
+    # model's key isn't set but another provider's is, switch to that provider.
+    if not api_base:
+        from opendot.providers import env_var_for, model_for_available_key
+        var = env_var_for(model)
+        if var and not os.environ.get(var):
+            alt = model_for_available_key()
+            if alt and alt != model:
+                console.print(f"[dim]no {var}; using [cyan]{alt}[/cyan] "
+                              f"(found its key in your environment)[/dim]")
+                model = alt
 
     system = DEFAULT_SYSTEM_PROMPT
     ctx = _load_project_context(workdir)
@@ -109,7 +111,7 @@ def _build_agent(model: str, workdir: str, confirm=None) -> Agent:
         mcp_manager = None
 
     return Agent(
-        AgentConfig(model=model, workdir=workdir, system_prompt=system),
+        AgentConfig(model=model, workdir=workdir, system_prompt=system, api_base=api_base),
         confirm=confirm,
         mcp_manager=mcp_manager,
     )
@@ -357,6 +359,10 @@ def main() -> None:
     parser.add_argument("-p", "--prompt", help="Run a single task and exit (one-shot mode).")
     parser.add_argument("--model", default=os.environ.get("OPENDOT_MODEL", "gpt-5.1"),
                         help="Model id (any LiteLLM model, e.g. gpt-5.1, claude-opus-4-5, ollama/qwen3).")
+    parser.add_argument("--api-base", default=os.environ.get("OPENAI_API_BASE"),
+                        help="Base URL of an OpenAI-compatible server "
+                             "(llama.cpp/llama-server, vLLM, LM Studio). "
+                             "Use with --model openai/<name>.")
     parser.add_argument("-C", "--dir", default=os.getcwd(), help="Working directory (default: cwd).")
     parser.add_argument("--repl", action="store_true", help="Use the plain REPL instead of the full-screen TUI.")
     parser.add_argument("--version", action="version", version=f"opendot {__version__}")
@@ -414,10 +420,10 @@ def main() -> None:
 
     if oneshot:
         # Non-interactive: can't prompt, so decline irreversible commands by default.
-        agent = _build_agent(args.model, workdir, confirm=lambda _p: False)
+        agent = _build_agent(args.model, workdir, confirm=lambda _p: False, api_base=args.api_base)
         asyncio.run(_run_turn(agent, oneshot, rich=False))
     elif args.repl:
-        agent = _build_agent(args.model, workdir, confirm=_confirm)
+        agent = _build_agent(args.model, workdir, confirm=_confirm, api_base=args.api_base)
         _interactive(agent)
     else:
         # Default: the full-screen TUI. It installs its own confirm callback
@@ -425,7 +431,7 @@ def main() -> None:
         # confirmed in-app. The placeholder here is replaced in OpendotTUI.__init__.
         from opendot.tui import run_tui
 
-        agent = _build_agent(args.model, workdir, confirm=lambda _p: False)
+        agent = _build_agent(args.model, workdir, confirm=lambda _p: False, api_base=args.api_base)
         run_tui(agent)
 
 

--- a/src/opendot/reversibility/engine.py
+++ b/src/opendot/reversibility/engine.py
@@ -46,6 +46,13 @@ class Reversibility:
         if not self.enabled:
             return ""
         snap = snapshots.take_snapshot(self.workdir, self.rules)
+        # If files were too large to snapshot, this action can't be fully undone —
+        # record that honestly in the ledger note.
+        if snap.skipped_large:
+            n = len(snap.skipped_large)
+            big_note = (f"{n} file(s) too large to snapshot — "
+                        f"changes to them can't be undone")
+            note = f"{note}; {big_note}" if note else big_note
         ledger.append(
             self.project_id,
             LedgerEntry(

--- a/src/opendot/reversibility/snapshots.py
+++ b/src/opendot/reversibility/snapshots.py
@@ -106,12 +106,30 @@ def _read_object(h: str) -> bytes:
 # Snapshot / restore
 # ---------------------------------------------------------------------------
 
+# Files larger than this are NOT snapshotted (skipped), so a giant file can't
+# make every snapshot slow and bloat the store. An action touching such a file
+# is therefore not fully undoable — take_snapshot reports the skipped paths so
+# the caller can say so.
+_MAX_FILE_BYTES = 25 * 1024 * 1024  # 25 MB
+
+
+@dataclass
+class FileEntry:
+    """One captured file: content hash, POSIX mode bits, and (mtime, size) so a
+    later snapshot can skip re-hashing an unchanged file."""
+    h: str
+    mode: int | None = None   # st_mode & 0o777, or None if unknown (old snapshots)
+    mtime: float | None = None
+    size: int | None = None
+
+
 @dataclass
 class Snapshot:
     id: str
     project_id: str
     workdir: str
-    files: dict[str, str]  # relative posix path -> content hash
+    files: dict[str, FileEntry]  # relative posix path -> FileEntry
+    skipped_large: list[str] = field(default_factory=list)  # paths too big to capture
 
 
 def _iter_files(workdir: Path, rules: IgnoreRules):
@@ -129,24 +147,142 @@ def _iter_files(workdir: Path, rules: IgnoreRules):
 
 
 def take_snapshot(workdir: str | Path, rules: IgnoreRules | None = None) -> Snapshot:
-    """Capture the workspace state. Cheap when little changed (content-addressed)."""
+    """Capture the workspace state. Cheap when little changed (content-addressed).
+
+    Files over ``_MAX_FILE_BYTES`` are skipped (recorded in ``skipped_large``) so
+    one huge file can't make snapshots slow/bloated — those are not undoable.
+    """
     rules = rules or IgnoreRules()
     wd = Path(workdir).resolve()
     pid = project_id_for(wd)
-    files: dict[str, str] = {}
+
+    # Previous snapshot's entries, keyed by path — used to skip re-hashing files
+    # whose (mtime, size) are unchanged. This is what makes snapshots of large,
+    # mostly-static workspaces near-instant.
+    prev = _latest_snapshot_files(pid)
+
+    files: dict[str, FileEntry] = {}
+    skipped_large: list[str] = []
     for f in _iter_files(wd, rules):
+        rel = f.relative_to(wd).as_posix()
+        try:
+            st = f.stat()
+        except OSError:
+            continue
+        mode = st.st_mode & 0o777
+        # Fast path: unchanged since the last snapshot → reuse its hash, no read.
+        old = prev.get(rel)
+        if (old is not None and old.mtime == st.st_mtime and old.size == st.st_size
+                and old.h):
+            files[rel] = FileEntry(h=old.h, mode=mode, mtime=st.st_mtime, size=st.st_size)
+            continue
+        if st.st_size > _MAX_FILE_BYTES:
+            skipped_large.append(rel)
+            continue
         try:
             data = f.read_bytes()
         except OSError:
             continue  # unreadable file: skip rather than fail the whole snapshot
         h = _write_object(data)
-        rel = f.relative_to(wd).as_posix()
-        files[rel] = h
+        files[rel] = FileEntry(h=h, mode=mode, mtime=st.st_mtime, size=st.st_size)
 
     snap_id = _next_snapshot_id(pid)
-    snap = Snapshot(id=snap_id, project_id=pid, workdir=str(wd), files=files)
+    snap = Snapshot(id=snap_id, project_id=pid, workdir=str(wd),
+                    files=files, skipped_large=skipped_large)
     _write_manifest(snap)
+
+    # Bound disk growth: drop this project's oldest snapshots beyond the
+    # retention limit, then delete any objects no longer referenced anywhere.
+    if prune_project_snapshots(pid):
+        gc_objects()
     return snap
+
+
+def _latest_snapshot_files(project_id: str) -> dict[str, FileEntry]:
+    """The file map of the most recent snapshot for this project, for the
+    unchanged-file fast path. Empty if none / unreadable."""
+    ids = list_snapshots(project_id)
+    if not ids:
+        return {}
+    try:
+        return load_snapshot(project_id, ids[-1]).files
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+# How many snapshots to keep per project before older ones are pruned. Bounds
+# disk growth on long, edit-heavy sessions. Content is deduped across snapshots,
+# so this is generous.
+MAX_SNAPSHOTS_PER_PROJECT = 50
+
+
+def _referenced_hashes() -> set[str]:
+    """Every content hash referenced by ANY surviving snapshot, across ALL
+    projects. Objects are shared globally (deduped), so GC must consider every
+    project's manifests before deleting an object."""
+    refs: set[str] = set()
+    snaps_root = store_root() / "snapshots"
+    if not snaps_root.exists():
+        return refs
+    for proj_dir in snaps_root.iterdir():
+        if not proj_dir.is_dir():
+            continue
+        for manifest in proj_dir.glob("*.json"):
+            try:
+                d = json.loads(manifest.read_text(encoding="utf-8"))
+            except Exception:  # noqa: BLE001
+                # Unreadable manifest → be conservative, keep its objects by
+                # skipping (we simply can't enumerate them, so we won't GC them
+                # blindly — but we also can't add refs; safest is to abort GC).
+                raise
+            for v in d.get("files", {}).values():
+                h = v if isinstance(v, str) else v.get("h")
+                if h:
+                    refs.add(h)
+    return refs
+
+
+def prune_project_snapshots(project_id: str, keep: int | None = None) -> int:
+    """Delete this project's oldest snapshot manifests beyond ``keep`` (default:
+    MAX_SNAPSHOTS_PER_PROJECT, read at call time). Returns how many manifests
+    were removed. Objects are freed separately by gc_objects."""
+    if keep is None:
+        keep = MAX_SNAPSHOTS_PER_PROJECT
+    ids = list_snapshots(project_id)
+    if len(ids) <= keep:
+        return 0
+    to_drop = ids[:len(ids) - keep]  # ids are zero-padded, sorted oldest→newest
+    d = _snapshots_dir(project_id)
+    removed = 0
+    for sid in to_drop:
+        try:
+            (d / f"{sid}.json").unlink()
+            removed += 1
+        except OSError:
+            pass
+    return removed
+
+
+def gc_objects() -> int:
+    """Delete stored objects not referenced by any surviving snapshot (across
+    all projects). Returns the number of objects removed. Aborts safely (returns
+    0) if any manifest is unreadable, so we never delete a still-referenced blob."""
+    try:
+        refs = _referenced_hashes()
+    except Exception:  # noqa: BLE001 - unreadable manifest: don't risk deleting live data
+        return 0
+    objects = _objects_dir()
+    removed = 0
+    for obj in objects.iterdir():
+        if obj.suffix == ".tmp":
+            continue
+        if obj.name not in refs:
+            try:
+                obj.unlink()
+                removed += 1
+            except OSError:
+                pass
+    return removed
 
 
 def _next_snapshot_id(project_id: str) -> str:
@@ -161,8 +297,10 @@ def _write_manifest(snap: Snapshot) -> None:
     path = _snapshots_dir(snap.project_id) / f"{snap.id}.json"
     path.write_text(
         json.dumps(
-            {"id": snap.id, "project_id": snap.project_id,
-             "workdir": snap.workdir, "files": snap.files},
+            {"id": snap.id, "project_id": snap.project_id, "workdir": snap.workdir,
+             "files": {rel: {"h": e.h, "m": e.mode, "t": e.mtime, "s": e.size}
+                       for rel, e in snap.files.items()},
+             "skipped_large": snap.skipped_large},
             indent=0,
         ),
         encoding="utf-8",
@@ -172,8 +310,16 @@ def _write_manifest(snap: Snapshot) -> None:
 def load_snapshot(project_id: str, snap_id: str) -> Snapshot:
     path = _snapshots_dir(project_id) / f"{snap_id}.json"
     d = json.loads(path.read_text(encoding="utf-8"))
-    return Snapshot(id=d["id"], project_id=d["project_id"],
-                    workdir=d["workdir"], files=d["files"])
+    files: dict[str, FileEntry] = {}
+    for rel, v in d["files"].items():
+        # Back-compat: old manifests stored a bare hash string (no metadata).
+        if isinstance(v, str):
+            files[rel] = FileEntry(h=v, mode=None)
+        else:
+            files[rel] = FileEntry(h=v["h"], mode=v.get("m"),
+                                   mtime=v.get("t"), size=v.get("s"))
+    return Snapshot(id=d["id"], project_id=d["project_id"], workdir=d["workdir"],
+                    files=files, skipped_large=d.get("skipped_large", []))
 
 
 def list_snapshots(project_id: str) -> list[str]:
@@ -190,11 +336,16 @@ def restore_snapshot(snap: Snapshot, rules: IgnoreRules | None = None) -> None:
     rules = rules or IgnoreRules()
     wd = Path(snap.workdir).resolve()
 
-    # 1. Restore all files from the manifest.
-    for rel, h in snap.files.items():
+    # 1. Restore all files from the manifest (content + permission mode).
+    for rel, entry in snap.files.items():
         target = wd / rel
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_bytes(_read_object(h))
+        target.write_bytes(_read_object(entry.h))
+        if entry.mode is not None:
+            try:
+                target.chmod(entry.mode)
+            except OSError:
+                pass  # best-effort: FS may not support the mode
 
     # 2. Remove files present now but absent from the snapshot (only non-skipped).
     manifest_paths = set(snap.files)

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -174,6 +174,88 @@ def test_load_snapshot_roundtrip(tmp_path):
     assert loaded.workdir == s.workdir
 
 
+def test_restore_brings_back_file_permissions(tmp_path):
+    wd = _workspace(tmp_path)
+    script = wd / "run.sh"
+    script.write_text("echo hi")
+    script.chmod(0o755)
+    snap = S.take_snapshot(wd)
+
+    script.chmod(0o644)                       # someone chmods it
+    S.restore_snapshot(S.load_snapshot(snap.project_id, snap.id))
+    assert (os.stat(script).st_mode & 0o777) == 0o755  # mode restored
+
+
+def test_large_files_are_skipped_and_reported(tmp_path, monkeypatch):
+    monkeypatch.setattr(S, "_MAX_FILE_BYTES", 1024)  # 1KB cap for the test
+    wd = _workspace(tmp_path)
+    (wd / "small.txt").write_text("ok")
+    (wd / "big.bin").write_bytes(b"x" * 2048)  # over the cap
+    snap = S.take_snapshot(wd)
+    assert "small.txt" in snap.files
+    assert "big.bin" not in snap.files
+    assert snap.skipped_large == ["big.bin"]
+
+
+def test_retention_prunes_old_snapshots_and_gcs_objects(tmp_path, monkeypatch):
+    monkeypatch.setattr(S, "MAX_SNAPSHOTS_PER_PROJECT", 3)
+    wd = _workspace(tmp_path)
+    f = wd / "f.txt"
+    snap = None
+    for i in range(6):
+        f.write_text(f"version-{i}")
+        os.utime(f, (i + 1, i + 1))  # deterministic mtimes so each version differs
+        snap = S.take_snapshot(wd)
+    kept = S.list_snapshots(snap.project_id)
+    assert len(kept) == 3                      # only the newest 3 survive
+    # orphaned objects from v0..v2 are GC'd; ~3 remain
+    objs = [o for o in (S._objects_dir()).iterdir() if o.suffix != ".tmp"]
+    assert len(objs) <= 4
+    # the newest snapshot is still fully restorable
+    f.write_text("wrecked")
+    S.restore_snapshot(S.load_snapshot(snap.project_id, snap.id))
+    assert f.read_text() == "version-5"
+
+
+def test_gc_never_deletes_objects_shared_by_another_project(tmp_path, monkeypatch):
+    monkeypatch.setattr(S, "MAX_SNAPSHOTS_PER_PROJECT", 2)
+    a = tmp_path / "A"; a.mkdir()
+    b = tmp_path / "B"; b.mkdir()
+    (a / "shared.txt").write_text("SHARED")
+    (b / "shared.txt").write_text("SHARED")   # identical content → one object
+    S.take_snapshot(a)
+    b_snap = S.take_snapshot(b)
+    # churn A past its retention so A's GC runs repeatedly
+    for i in range(4):
+        (a / "x").write_text(str(i)); os.utime(a / "x", (i + 1, i + 1)); S.take_snapshot(a)
+    # B's shared object must survive (still referenced by B) and B must restore
+    (b / "shared.txt").write_text("wrecked")
+    S.restore_snapshot(S.load_snapshot(b_snap.project_id, b_snap.id))
+    assert (b / "shared.txt").read_text() == "SHARED"
+
+
+def test_unchanged_files_are_not_rehashed(tmp_path, monkeypatch):
+    wd = _workspace(tmp_path)
+    (wd / "a.txt").write_text("aaa")
+    (wd / "b.txt").write_text("bbb")
+
+    reads = {"n": 0}
+    orig = S._write_object
+    monkeypatch.setattr(S, "_write_object",
+                        lambda data: (reads.__setitem__("n", reads["n"] + 1), orig(data))[1])
+
+    S.take_snapshot(wd)
+    reads["n"] = 0
+    S.take_snapshot(wd)               # nothing changed
+    assert reads["n"] == 0            # fast path: no re-reads
+
+    import time; time.sleep(0.01)
+    (wd / "a.txt").write_text("changed")
+    reads["n"] = 0
+    S.take_snapshot(wd)
+    assert reads["n"] == 1            # only the changed file re-hashed
+
+
 def test_ledger_clear_wipes_history(tmp_path):
     from opendot.reversibility.engine import Reversibility
     from opendot.reversibility.rules import load_rules


### PR DESCRIPTION
Closes several gaps in the snapshot/undo engine that came up as real questions,
plus adds local-server support. All backward-compatible (old manifests still load).

Snapshot engine:
- Capture file permissions (st_mode) and restore them on undo, so chmod/chown
  are now reversible (was content-only).
- Size guard: files over 25MB are skipped rather than silently snapshotted, and
  the ledger note says those changes can't be undone.
- mtime+size cache: unchanged files are no longer re-read/re-hashed on each
  snapshot — only changed files get read. Snapshots of large, mostly-static
  workspaces are near-instant.
- Retention + GC: keep the last 50 snapshots per project; delete objects no
  longer referenced by ANY surviving snapshot (checked across all projects,
  since objects are deduped globally). Aborts safely if a manifest is
  unreadable, so a still-referenced blob is never deleted. Bounds disk growth
  on long, edit-heavy sessions.

Models:
- `--api-base` flag (and $OPENAI_API_BASE) to point opendot at any
  OpenAI-compatible server — llama.cpp/llama-server, vLLM, LM Studio — with an
  `openai/`-prefixed model. Auto-provider-switch is skipped when set (a local
  server needs no key). README documents it.
- README: note that opendot is model-agnostic (Ollama is one of many backends).

Tests: 88 passing (added permissions-restore, size-guard, mtime-cache,
retention/GC, and cross-project GC-safety cases).