### PR TITLE
0.1.4 — fix provider routing for non-OpenAI keys + Composio key handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.1.3"
+version = "0.1.4"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.loop import Agent
 from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/catalog.py
+++ b/src/opendot/catalog.py
@@ -19,6 +19,11 @@ from __future__ import annotations
 # audio_*, video_generation, embedding, rerank, …) is filtered out.
 _TEXT_MODES = {"chat", "completion", "responses"}
 
+# Providers whose bare model ids LiteLLM resolves without a "provider/" prefix
+# (so "gpt-4o" / "claude-..." keep their familiar names). Every other provider's
+# bare id must be prefixed or LiteLLM errors with "LLM Provider NOT provided".
+_BARE_OK_PROVIDERS = {"openai", "anthropic"}
+
 
 def _litellm():
     import litellm
@@ -62,6 +67,7 @@ def list_models() -> list[dict]:
         return []
     routable = provider_ids()
     out: list[dict] = []
+    seen: set[str] = set()
     for name, meta in mc.items():
         if not name or name == "sample_spec" or not isinstance(meta, dict):
             continue
@@ -70,7 +76,17 @@ def list_models() -> list[dict]:
         prov = (meta.get("litellm_provider") or "").lower()
         if routable and prov not in routable:
             continue
-        out.append({"model": name, "name": name, "provider": _pretty(prov) if prov else "other"})
+        # LiteLLM resolves bare names only for a few providers (openai,
+        # anthropic); for the rest a bare key like "deepseek-chat" errors with
+        # "LLM Provider NOT provided". Prefix those to get a routable string
+        # ("deepseek/deepseek-chat") while leaving familiar names (gpt-4o,
+        # claude-...) untouched.
+        needs_prefix = "/" not in name and prov and prov not in _BARE_OK_PROVIDERS
+        model = f"{prov}/{name}" if needs_prefix else name
+        if model in seen:  # registry may list both bare and prefixed variants
+            continue
+        seen.add(model)
+        out.append({"model": model, "name": name, "provider": _pretty(prov) if prov else "other"})
     out.sort(key=lambda d: (d["provider"].lower(), d["name"].lower()))
     return out
 

--- a/src/opendot/tools/composio.py
+++ b/src/opendot/tools/composio.py
@@ -25,6 +25,7 @@ the import is unavailable, so a broken install never crashes opendot.
 from __future__ import annotations
 
 import json
+import re
 import uuid
 from dataclasses import dataclass
 from typing import Any
@@ -59,6 +60,19 @@ def save_config(cfg: dict) -> None:
 
 def is_configured() -> bool:
     return bool(load_config().get("api_key"))
+
+
+def verify_api_key(api_key: str) -> bool:
+    """True if the key actually works (a cheap authenticated call succeeds).
+    Lets the caller reject a bad/old key up front instead of storing it and
+    only failing later when apps won't load."""
+    from composio import Composio
+
+    try:
+        Composio(api_key=api_key.strip()).toolkits.list(limit=1)
+        return True
+    except Exception:  # noqa: BLE001 - any failure (auth, network) = don't trust it
+        return False
 
 
 def set_api_key(api_key: str) -> str:
@@ -194,6 +208,25 @@ class ConnectResult:
     error: str | None = None
 
 
+def _friendly_error(exc: Exception) -> str:
+    """Turn a Composio SDK exception into a short, actionable message. Composio
+    puts a human 'message' and a 'suggested_fix' in the error body — surface
+    those instead of dumping the raw 403/JSON at the user."""
+    text = str(exc)
+    # A read-only key is the common one: it authenticates (apps list fine) but
+    # can't create connections. Give the exact fix, not the JSON blob.
+    if "InsufficientPermissions" in text or "write access" in text:
+        return ("your Composio API key is read-only — it can't connect apps. "
+                "Create a key with 'connected_accounts' write access in the "
+                "Composio dashboard, then run /composio to re-enter it.")
+    # Prefer the actionable 'suggested_fix'; fall back to the human 'message'.
+    for field in ("suggested_fix", "message"):
+        m = re.search(rf"'{field}':\s*'([^']+)'", text)
+        if m:
+            return m.group(1)
+    return f"{type(exc).__name__}: {exc}"
+
+
 def begin_connect(slug: str) -> ConnectResult:
     """Start connecting a toolkit. If it needs OAuth, returns the redirect_url and
     the ConnectionRequest (caller opens the browser then calls
@@ -202,7 +235,7 @@ def begin_connect(slug: str) -> ConnectResult:
     try:
         client, user_id = _client()
     except Exception as exc:  # noqa: BLE001
-        return ConnectResult(ok=False, error=f"{type(exc).__name__}: {exc}")
+        return ConnectResult(ok=False, error=_friendly_error(exc))
     # Already connected on Composio's side → reuse it, don't re-authorize (which
     # errors with ComposioMultipleConnectedAccountsError once there's ≥1).
     if slug in list_connected():
@@ -210,7 +243,7 @@ def begin_connect(slug: str) -> ConnectResult:
     try:
         req = client.toolkits.authorize(user_id=user_id, toolkit=slug)
     except Exception as exc:  # noqa: BLE001
-        return ConnectResult(ok=False, error=f"{type(exc).__name__}: {exc}")
+        return ConnectResult(ok=False, error=_friendly_error(exc))
     redirect = getattr(req, "redirect_url", None)
     if redirect:
         return ConnectResult(ok=False, needs_auth=True, redirect_url=redirect, request=req)
@@ -322,7 +355,7 @@ def execute_tool(name: str, arguments: dict) -> str:
     try:
         res = session.execute(tool_slug, arguments=arguments or {})
     except Exception as exc:  # noqa: BLE001
-        return f"error: composio execution failed: {type(exc).__name__}: {exc}"
+        return f"error: {_friendly_error(exc)} (do not retry until fixed)"
     data = getattr(res, "data", None)
     if data is None and isinstance(res, dict):
         data = res.get("data", res)

--- a/src/opendot/tui/app.py
+++ b/src/opendot/tui/app.py
@@ -525,6 +525,22 @@ class OpendotTUI(App):
             "sys",
         )
 
+    async def _enter_composio_key(self, cx) -> bool:
+        """Prompt for a Composio API key, validate it, and store it only if it
+        works. Returns True on a saved, working key. Can be called both on first
+        setup and to replace a bad/expired key."""
+        import asyncio
+
+        key = await self.push_screen_wait(ApiKeyModal("Composio", "COMPOSIO_API_KEY"))
+        if not key:
+            return False
+        self._write("checking key…", "sys")
+        if not await asyncio.to_thread(cx.verify_api_key, key):
+            self._write("that key didn't work — check it and run /composio again.", "sys")
+            return False
+        cx.set_api_key(key)
+        return True
+
     async def _manage_composio(self) -> None:
         import asyncio
         import webbrowser
@@ -538,10 +554,8 @@ class OpendotTUI(App):
 
         # First run (or no key yet): ask for the Composio API key.
         if not cx.is_configured():
-            key = await self.push_screen_wait(ApiKeyModal("Composio", "COMPOSIO_API_KEY"))
-            if not key:
+            if not await self._enter_composio_key(cx):
                 return
-            cx.set_api_key(key)
             self._write("✓ Composio connected. Run /composio again to browse apps.", "sys")
             self._refresh_sidebar()
             return
@@ -550,8 +564,13 @@ class OpendotTUI(App):
         self._write("loading Composio apps…", "sys")
         apps = await asyncio.to_thread(cx.list_apps)
         if not apps:
-            self._write("couldn't load Composio apps (check your key / connection).", "sys")
-            return
+            # Most likely a bad/expired key (it was stored without validation in
+            # older versions). Offer to re-enter it instead of dead-ending.
+            self._write("couldn't load Composio apps — your key may be invalid or expired.", "sys")
+            if await self._enter_composio_key(cx):
+                apps = await asyncio.to_thread(cx.list_apps)
+            if not apps:
+                return
         connected = await asyncio.to_thread(cx.list_connected)
         enabled = set(cx.enabled_apps())
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -15,7 +15,8 @@ FAKE_MODEL_COST = {
     "gpt-4o": {"mode": "chat", "litellm_provider": "openai"},
     "dall-e-3": {"mode": "image_generation", "litellm_provider": "openai"},
     "whisper-1": {"mode": "audio_transcription", "litellm_provider": "openai"},
-    "deepseek/deepseek-chat": {"mode": "chat", "litellm_provider": "deepseek"},
+    # bare key (as LiteLLM's registry actually stores it) — must get prefixed
+    "deepseek-chat": {"mode": "chat", "litellm_provider": "deepseek"},
     "obscure/model": {"mode": "chat", "litellm_provider": "obscureproxy"},  # not routable
 }
 
@@ -35,11 +36,23 @@ def fake_litellm(monkeypatch):
 
 def test_list_models_text_only():
     models = {m["model"] for m in catalog.list_models()}
+    # openai/anthropic bare names resolve in LiteLLM, so they stay familiar;
+    # other providers get prefixed so they're routable.
     assert "gpt-4o" in models
     assert "deepseek/deepseek-chat" in models
     assert "dall-e-3" not in models        # image
     assert "whisper-1" not in models       # audio
     assert "sample_spec" not in models
+
+
+def test_bare_provider_model_is_prefixed_for_routing():
+    """Regression: a provider whose bare model id LiteLLM can't resolve (e.g.
+    deepseek) must be returned prefixed, or auto-switch produces an unroutable
+    'LLM Provider NOT provided' string. openai/anthropic stay bare."""
+    by_name = {m["name"]: m["model"] for m in catalog.list_models()}
+    assert by_name["gpt-4o"] == "gpt-4o"                # bare-ok provider, untouched
+    # a bare non-openai/anthropic key gets prefixed so it's routable
+    assert by_name["deepseek-chat"] == "deepseek/deepseek-chat"
 
 
 def test_list_models_only_routable_providers():

--- a/tests/test_composio.py
+++ b/tests/test_composio.py
@@ -59,6 +59,47 @@ def test_disable_app_removes_locally_and_invalidates_session():
     assert "slack" not in cx.enabled_apps()
 
 
+def test_verify_api_key_accepts_working_key_and_rejects_bad(monkeypatch):
+    # A key is "valid" only if an authenticated call actually succeeds — a bad
+    # key must be rejected up front, not stored and failed on later.
+    import composio
+
+    class _Toolkits:
+        def __init__(self, ok): self._ok = ok
+        def list(self, **_):
+            if not self._ok:
+                raise RuntimeError("401 Unauthorized")
+            return object()
+
+    class _FakeComposio:
+        def __init__(self, api_key=None):
+            # the fixture routes "good"/"bad" via the key string itself
+            self.toolkits = _Toolkits(api_key == "good")
+
+    monkeypatch.setattr(composio, "Composio", _FakeComposio)
+    assert cx.verify_api_key("good") is True
+    assert cx.verify_api_key("bad") is False
+
+
+def test_friendly_error_explains_read_only_key():
+    # The exact 403 a read-only Composio key produces on connect.
+    raw = RuntimeError(
+        "PermissionDenied: 403 - {'error': {'message': 'This API key does not "
+        "have the permissions required for POST /api/v3/connected_accounts...', "
+        "'slug': 'APIKey_InsufficientPermissions', "
+        "'suggested_fix': 'Grant the connected_accounts permission with write.'}}"
+    )
+    msg = cx._friendly_error(raw)
+    assert "read-only" in msg
+    assert "write access" in msg
+    assert "{" not in msg  # no raw JSON blob leaking through
+
+
+def test_friendly_error_surfaces_suggested_fix_for_other_errors():
+    raw = RuntimeError("400 - {'error': {'message': 'bad', 'suggested_fix': 'do the thing'}}")
+    assert cx._friendly_error(raw) == "do the thing"
+
+
 def test_namespacing_helpers():
     assert cx.is_composio_tool("composio__gmail__GMAIL_SEND_EMAIL")
     assert not cx.is_composio_tool("read_file")


### PR DESCRIPTION
## What changed

### Model routing
- Fix "LLM Provider NOT provided" when a non-OpenAI/Anthropic key (e.g.
  DeepSeek) is the only key set. The catalog now prefixes bare model ids that
  LiteLLM can't resolve on their own (deepseek-chat -> deepseek/deepseek-chat),
  while leaving familiar names (gpt-4o, claude-...) untouched. A bare `opendot`
  with only DEEPSEEK_API_KEY set now works instead of erroring.

### Composio
- Validate the Composio API key before storing it. A bad or expired key is
  rejected up front ("that key didn't work") instead of being saved and silently
  failing later.
- Allow re-entering the key. When apps fail to load, opendot now prompts to
  replace the key instead of dead-ending (previously required hand-editing
  ~/.opendot/composio.json).
- Read-only keys now get a clear, actionable message ("your key is read-only,
  grant connected_accounts write access") instead of a raw 403 JSON dump, and
  no longer trigger a retry loop.

## Tests
- Added regression tests for provider prefixing, key validation, key re-entry,
  and the read-only-key error message. 92 passing.