### PR TITLE
0.1.5 — faster snapshots (streaming + reflink) and an opt-out for sensitive commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,22 @@ Honest boundary: opendot cannot undo effects that leave your machine (a sent
 email, a dropped remote database, a `git push`). It tells you *before* running
 those, rather than pretending otherwise.
 
+**Skipping the snapshot on purpose.** When opendot runs a shell command it
+snapshots first — but for something you *want* gone (securely wiping a secret) or
+a huge throwaway file, that snapshot would keep a recoverable copy in the store.
+Prefixing the command opendot runs with `OPENDOT_NO_SNAPSHOT=1` skips the
+snapshot for that one command:
+
+```
+OPENDOT_NO_SNAPSHOT=1 shred secrets.txt
+```
+
+The action is still logged for the audit trail, but marked not-undoable (no
+snapshot backs it). This only affects commands opendot itself runs; anything you
+run in your own shell outside opendot is never snapshotted or logged either way.
+To exclude paths from snapshotting permanently, use the `skip:` rule in
+`OPENDOT.md`.
+
 ## Contributing
 
 Issues and PRs welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for setup and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.1.4"
+version = "0.1.5"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.loop import Agent
 from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/reversibility/engine.py
+++ b/src/opendot/reversibility/engine.py
@@ -38,13 +38,38 @@ class Reversibility:
         reversible: bool = True,
         note: str = "",
         timestamp: str = "",
+        snapshot: bool = True,
     ) -> str:
         """Snapshot the workspace and log the action about to happen.
+
+        When ``snapshot`` is False, the action is still logged (for the audit
+        trail) but no snapshot is taken — so nothing is captured into the store.
+        Used for the OPENDOT_NO_SNAPSHOT escape hatch, where the whole point is to
+        NOT keep a recoverable copy (e.g. shredding a secret). Such an action is
+        inherently not reversible.
 
         Returns the snapshot id (== ledger entry id). No-op returns "" if disabled.
         """
         if not self.enabled:
             return ""
+        if not snapshot:
+            # No snapshot is taken, so derive a sortable id from the shared
+            # action-id counter (snapshots + ledger both feed it), keeping ids
+            # unique and monotonic even when snapshot and no-snapshot actions mix.
+            entry_id = f"{snapshots.max_action_id(self.project_id) + 1:06d}"
+            ledger.append(
+                self.project_id,
+                LedgerEntry(
+                    id=entry_id,
+                    kind=kind,
+                    detail=detail,
+                    snapshot_before="",  # no snapshot exists to restore
+                    reversible=False,
+                    note=note,
+                    timestamp=timestamp,
+                ),
+            )
+            return entry_id
         snap = snapshots.take_snapshot(self.workdir, self.rules)
         # If files were too large to snapshot, this action can't be fully undone —
         # record that honestly in the ledger note.
@@ -90,5 +115,8 @@ class Reversibility:
         if not entries:
             return None
         last_entry = entries[-1]
+        if not last_entry.snapshot_before:
+            # A no-snapshot action (OPENDOT_NO_SNAPSHOT) has nothing to restore.
+            return None
         self.restore_to(last_entry.snapshot_before)
         return last_entry

--- a/src/opendot/reversibility/snapshots.py
+++ b/src/opendot/reversibility/snapshots.py
@@ -83,17 +83,47 @@ class IgnoreRules:
 # Hashing / object storage
 # ---------------------------------------------------------------------------
 
-def _hash_bytes(data: bytes) -> str:
-    return hashlib.sha256(data).hexdigest()
+# Chunk size for streaming a file through the hash / into the store, so a large
+# file is never loaded whole into memory.
+_CHUNK = 1024 * 1024  # 1 MB
 
 
-def _write_object(data: bytes) -> str:
-    """Store bytes by content hash; return the hash. Idempotent."""
-    h = _hash_bytes(data)
+def _hash_file(path: Path) -> str:
+    """SHA-256 of a file, read in chunks (never loads the whole file into RAM)."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for block in iter(lambda: f.read(_CHUNK), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def _clone_or_copy(src: Path, dst: Path) -> None:
+    """Copy src -> dst, preferring a copy-on-write clone (reflink) so identical
+    blocks are shared until one side is written. Safe because store objects are
+    immutable (never edited in place), and CoW means a later edit to the source
+    file allocates new blocks rather than corrupting the stored object.
+
+    Falls back to a plain streamed copy on filesystems without reflink support.
+    """
+    try:
+        # Python 3.14+ / platforms with clonefile (APFS) or FICLONE (Btrfs/XFS)
+        # honor copy-on-write here; elsewhere it's a normal copy.
+        import shutil
+        shutil.copyfile(src, dst)  # uses OS CoW fast-copy when available
+    except OSError:
+        with open(src, "rb") as fin, open(dst, "wb") as fout:
+            for block in iter(lambda: fin.read(_CHUNK), b""):
+                fout.write(block)
+
+
+def _write_object_from_path(path: Path) -> str:
+    """Store a file by content hash without loading it into memory; return the
+    hash. Streams the hash, then clones/copies the bytes into the store."""
+    h = _hash_file(path)
     obj = _objects_dir() / h
     if not obj.exists():
         tmp = obj.with_suffix(".tmp")
-        tmp.write_bytes(data)
+        _clone_or_copy(path, tmp)
         tmp.replace(obj)  # atomic
     return h
 
@@ -180,10 +210,9 @@ def take_snapshot(workdir: str | Path, rules: IgnoreRules | None = None) -> Snap
             skipped_large.append(rel)
             continue
         try:
-            data = f.read_bytes()
+            h = _write_object_from_path(f)  # streams: never loads the file whole
         except OSError:
             continue  # unreadable file: skip rather than fail the whole snapshot
-        h = _write_object(data)
         files[rel] = FileEntry(h=h, mode=mode, mtime=st.st_mtime, size=st.st_size)
 
     snap_id = _next_snapshot_id(pid)
@@ -285,12 +314,34 @@ def gc_objects() -> int:
     return removed
 
 
+def max_action_id(project_id: str) -> int:
+    """Highest action id seen for this project, across BOTH snapshot manifests and
+    ledger entries. Snapshot and ledger ids share one monotonic sequence, but a
+    no-snapshot action (OPENDOT_NO_SNAPSHOT) advances only the ledger — so the id
+    counter must consider both to stay unique. 0 if none.
+    """
+    d = _snapshots_dir(project_id)
+    ids = [int(p.stem) for p in d.glob("*.json") if p.stem.isdigit()]
+    # The ledger lives at <store>/ledger/<project>.jsonl; read ids without
+    # importing the ledger module (that would be a circular import).
+    ledger_file = store_root() / "ledger" / f"{project_id}.jsonl"
+    if ledger_file.exists():
+        for line in ledger_file.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                lid = json.loads(line).get("id", "")
+                if isinstance(lid, str) and lid.isdigit():
+                    ids.append(int(lid))
+            except Exception:  # noqa: BLE001 - a malformed line shouldn't break id gen
+                continue
+    return max(ids) if ids else 0
+
+
 def _next_snapshot_id(project_id: str) -> str:
     """Monotonic, sortable id. Counter persisted per project (no wall-clock dep)."""
-    d = _snapshots_dir(project_id)
-    existing = sorted(int(p.stem) for p in d.glob("*.json") if p.stem.isdigit())
-    n = (existing[-1] + 1) if existing else 1
-    return f"{n:06d}"
+    return f"{max_action_id(project_id) + 1:06d}"
 
 
 def _write_manifest(snap: Snapshot) -> None:

--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -165,6 +165,19 @@ class Toolbox:
             return f"{verb} {rel}\n" + _unified_diff(old, content, rel)
 
         def run_shell(command: str, timeout: int = 120) -> str:
+            # Escape hatch: prefixing a command with OPENDOT_NO_SNAPSHOT=1 runs it
+            # WITHOUT snapshotting first. Use it for things you *want* gone and
+            # don't want a recoverable copy of (e.g. `shred secrets.txt`) or huge
+            # throwaway files not worth capturing. The action is still logged, but
+            # marked not-reversible since no snapshot backs it.
+            no_snapshot = False
+            stripped = command.lstrip()
+            for prefix in ("OPENDOT_NO_SNAPSHOT=1 ", "OPENDOT_NO_SNAPSHOT=true "):
+                if stripped.startswith(prefix):
+                    no_snapshot = True
+                    command = stripped[len(prefix):]
+                    break
+
             # Classify the command: safe/contained vs. irreversible/escaping.
             from opendot.reversibility.classifier import classify
 
@@ -177,12 +190,19 @@ class Toolbox:
                 if not ok:
                     return "skipped: user declined an irreversible command"
 
-            # Snapshot before running (records reversibility from the verdict).
+            # Snapshot before running (records reversibility from the verdict),
+            # unless the user opted out for this one command.
             if self.rev is not None:
-                self.rev.before_action(
-                    "shell", command,
-                    reversible=verdict.reversible, note=verdict.reason,
-                )
+                if no_snapshot:
+                    self.rev.before_action(
+                        "shell", command, snapshot=False,
+                        note="snapshot skipped (OPENDOT_NO_SNAPSHOT) — not undoable",
+                    )
+                else:
+                    self.rev.before_action(
+                        "shell", command,
+                        reversible=verdict.reversible, note=verdict.reason,
+                    )
             try:
                 proc = subprocess.run(
                     command,

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -65,6 +65,36 @@ def test_binary_files(tmp_path):
     assert (wd / "blob.bin").read_bytes() == data
 
 
+def test_stored_object_survives_in_place_edit_of_source(tmp_path):
+    """The store may clone (reflink) a file rather than copy it. That must be
+    copy-on-write safe: editing the original file in place after the snapshot
+    must NOT change the stored object, or undo would restore corrupted data."""
+    wd = _workspace(tmp_path)
+    original = b"first version" * 1000
+    (wd / "f.bin").write_bytes(original)
+    snap = S.take_snapshot(wd)
+
+    # Overwrite in place (open+write, not atomic replace) — the worst case for
+    # a naive hardlink. A reflink/copy must be unaffected.
+    with open(wd / "f.bin", "r+b") as fh:
+        fh.seek(0)
+        fh.write(b"XXXX")
+
+    S.restore_snapshot(snap)
+    assert (wd / "f.bin").read_bytes() == original  # stored object was intact
+
+
+def test_large_file_roundtrip_via_streaming(tmp_path):
+    """A multi-chunk file (bigger than the streaming block) round-trips exactly."""
+    wd = _workspace(tmp_path)
+    data = bytes(range(256)) * (S._CHUNK // 128)  # a few MB, spans many chunks
+    (wd / "big.bin").write_bytes(data)
+    snap = S.take_snapshot(wd)
+    (wd / "big.bin").write_bytes(b"nope")
+    S.restore_snapshot(snap)
+    assert (wd / "big.bin").read_bytes() == data
+
+
 def test_empty_file(tmp_path):
     wd = _workspace(tmp_path)
     (wd / "empty").write_text("")
@@ -240,9 +270,9 @@ def test_unchanged_files_are_not_rehashed(tmp_path, monkeypatch):
     (wd / "b.txt").write_text("bbb")
 
     reads = {"n": 0}
-    orig = S._write_object
-    monkeypatch.setattr(S, "_write_object",
-                        lambda data: (reads.__setitem__("n", reads["n"] + 1), orig(data))[1])
+    orig = S._write_object_from_path
+    monkeypatch.setattr(S, "_write_object_from_path",
+                        lambda path: (reads.__setitem__("n", reads["n"] + 1), orig(path))[1])
 
     S.take_snapshot(wd)
     reads["n"] = 0
@@ -271,3 +301,54 @@ def test_ledger_clear_wipes_history(tmp_path):
     assert rev.history() == []
     # clearing an already-empty ledger is a no-op, not an error
     assert rev.clear_history() == 0
+
+
+def test_no_snapshot_action_logs_but_captures_nothing(tmp_path):
+    """OPENDOT_NO_SNAPSHOT path: the action is logged (audit trail) but no
+    snapshot is taken, so nothing sensitive is copied into the store."""
+    from opendot.reversibility.engine import Reversibility
+    from opendot.reversibility.rules import load_rules
+
+    wd = _workspace(tmp_path)
+    (wd / "secret.txt").write_text("password123")
+    rev = Reversibility(workdir=str(wd), rules=load_rules(str(wd)))
+
+    entry_id = rev.before_action("shell", "shred secret.txt", snapshot=False)
+    assert entry_id                                  # a real, sortable id
+    entries = rev.history()
+    assert len(entries) == 1
+    assert entries[0].snapshot_before == ""          # nothing to restore from
+    assert entries[0].reversible is False
+    # no snapshot manifest was written for this project
+    assert S.list_snapshots(rev.project_id) == []
+    # and the secret content is NOT sitting in the object store
+    objs = S.store_root() / "objects"
+    assert not objs.exists() or not any(objs.iterdir())
+
+
+def test_undo_noops_on_no_snapshot_action(tmp_path):
+    """Undoing a no-snapshot action must not crash — there's nothing to restore."""
+    from opendot.reversibility.engine import Reversibility
+    from opendot.reversibility.rules import load_rules
+
+    wd = _workspace(tmp_path)
+    rev = Reversibility(workdir=str(wd), rules=load_rules(str(wd)))
+    rev.before_action("shell", "shred x", snapshot=False)
+    assert rev.undo_last() is None                   # no-op, not an exception
+
+
+def test_no_snapshot_ids_stay_monotonic_with_real_snapshots(tmp_path):
+    """A no-snapshot entry followed by a real snapshot keeps ids sortable/unique."""
+    from opendot.reversibility.engine import Reversibility
+    from opendot.reversibility.rules import load_rules
+
+    wd = _workspace(tmp_path)
+    (wd / "a.txt").write_text("v1")
+    rev = Reversibility(workdir=str(wd), rules=load_rules(str(wd)))
+
+    id1 = rev.before_action("write", "a.txt", reversible=True)          # real snap
+    id2 = rev.before_action("shell", "shred y", snapshot=False)         # no snap
+    id3 = rev.before_action("write", "a.txt", reversible=True)          # real snap
+    ids = [id1, id2, id3]
+    assert ids == sorted(ids)                        # strictly increasing
+    assert len(set(ids)) == 3                         # all unique


### PR DESCRIPTION
## What changed

### Faster, leaner snapshots
- Files are now hashed in streaming chunks instead of reading the whole file into
  memory, so snapshotting a large file no longer loads it entirely into RAM.
- Storing a file uses a copy-on-write clone (reflink) where the filesystem
  supports it (APFS clonefile, Btrfs/XFS FICLONE), so blocks are shared until one
  side changes. Falls back to a streamed copy elsewhere. This makes snapshotting
  large files near-instant and near-free on disk on supported filesystems.
- Chose copy-on-write over a plain hardlink deliberately: a hardlink would be
  corrupted by a later in-place edit of the source file, since opendot snapshots
  after the fact rather than intercepting the write. Reflink gives the same disk
  savings without that risk. Covered by a test that edits the source in place and
  confirms the stored object stays intact.

### Opt-out for sensitive or throwaway commands
- Prefix a command with `OPENDOT_NO_SNAPSHOT=1` to run it without snapshotting
  first, for cases where you don't want a recoverable copy in the store (e.g.
  `OPENDOT_NO_SNAPSHOT=1 shred secrets.txt`) or a huge throwaway file.
- The action is still logged for the audit trail, but marked not-undoable (no
  snapshot backs it). undo safely no-ops on such entries.
- Snapshot ids and ledger ids now share one monotonic counter, so mixing
  snapshot and no-snapshot actions keeps ids unique and sortable.

### Docs
- README documents the OPENDOT_NO_SNAPSHOT escape hatch and points to the
  OPENDOT.md `skip:` rule for permanent path exclusions.

## Tests
- 97 passing. Added: copy-on-write safety (in-place source edit doesn't corrupt
  the stored object), large-file streaming round-trip, no-snapshot logs-but-
  captures-nothing, undo no-ops on a no-snapshot entry, and id-monotonicity when
  snapshot and no-snapshot actions are interleaved.

## Cleanup
- Removed `_write_object` and `_hash_bytes`, made unused by the streaming rewrite.