### PR TITLE
feat: AI-narrated undo with lockfile-drift detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.1.5"
+version = "0.1.6"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.loop import Agent
 from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/agent/prompt.py
+++ b/src/opendot/agent/prompt.py
@@ -71,4 +71,16 @@ are small and reviewable. Only write_file for new files or genuine rewrites.
 Every change you make is snapshotted and can be undone, so work confidently — but \
 if a request is destructive or reaches outside the workspace (deleting outside \
 files, network, git push), call it out first. When done, give a short summary.
+
+REPORTING AN UNDO: when a turn begins with an "[undo]" system note (the user just \
+reverted something), report what the undo did in one or two lines: what was rolled \
+back. CRITICAL — if that note lists changed lockfile(s) (package-lock.json, \
+uv.lock, Cargo.lock, …), you MUST warn that only the declared dependency versions \
+were rolled back, NOT the installed packages, and the environment won't match \
+until the package manager is re-run. Name the right command for that lockfile \
+(package-lock.json → `npm ci`, uv.lock → `uv sync`, Cargo.lock → `cargo build`, \
+yarn.lock → `yarn install --frozen-lockfile`, poetry.lock → `poetry install`, \
+requirements.txt → `pip install -r requirements.txt`) and offer to run it. Never \
+let "files restored" be mistaken for "environment restored". Do not skip this \
+warning.
 """

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -158,11 +158,30 @@ def _cmd_undo(workdir: str, snap_id: str | None) -> None:
         if target is None:
             console.print(f"[red]no action with id {snap_id}[/red]  (see: opendot log)")
             return
-        rev.restore_to(target.snapshot_before)
+        changed_locks = rev.restore_to(target.snapshot_before)
         console.print(f"[green]restored[/green] workspace to before action {snap_id} ({target.kind}: {target.detail[:50]})")
+        _note_lockfiles(console, changed_locks)
     else:
         undone = rev.undo_last()
+        if undone is None:
+            console.print("[yellow]nothing to undo[/yellow] (or the last action wasn't snapshotted)")
+            return
         console.print(f"[green]undid[/green] last action ({undone.kind}: {undone.detail[:50]})")
+        _note_lockfiles(console, rev.last_changed_lockfiles)
+
+
+def _note_lockfiles(console, changed: list[str]) -> None:
+    """`opendot undo` is a non-interactive command with no model in the loop, so
+    it states the fact plainly: a lockfile was rolled back, meaning the installed
+    environment no longer matches until the package manager is re-run. (In the
+    interactive TUI the agent narrates this in its own words instead.)"""
+    if not changed:
+        return
+    names = ", ".join(changed)
+    console.print(
+        f"[bold yellow]note:[/bold yellow] lockfile(s) rolled back ([bold]{names}[/bold]) — "
+        f"installed packages are unchanged; re-run your package manager to match."
+    )
 
 
 def _cmd_mcp(args) -> None:

--- a/src/opendot/reversibility/engine.py
+++ b/src/opendot/reversibility/engine.py
@@ -13,7 +13,7 @@ module just records the ``reversible`` flag it's given.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from opendot.reversibility import ledger, snapshots
 from opendot.reversibility.ledger import ActionKind, LedgerEntry
@@ -25,6 +25,9 @@ class Reversibility:
     workdir: str
     rules: IgnoreRules
     enabled: bool = True
+    # Lockfiles changed by the most recent undo (see undo_last). Lets the UI warn
+    # that the environment isn't restored until the package manager is re-run.
+    last_changed_lockfiles: list[str] = field(default_factory=list)
 
     @property
     def project_id(self) -> str:
@@ -101,16 +104,25 @@ class Reversibility:
         the number of entries removed."""
         return ledger.clear(self.project_id)
 
-    def restore_to(self, snapshot_id: str) -> None:
-        """Restore the workspace to the state captured in ``snapshot_id``."""
+    def restore_to(self, snapshot_id: str) -> list[str]:
+        """Restore the workspace to the state captured in ``snapshot_id``.
+
+        Returns any dependency lockfiles the restore changed — the caller should
+        warn that the environment isn't restored until the package manager is
+        re-run (restoring a lockfile rolls back declared versions, not installed
+        packages).
+        """
         snap = snapshots.load_snapshot(self.project_id, snapshot_id)
-        snapshots.restore_snapshot(snap, self.rules)
+        return snapshots.restore_snapshot(snap, self.rules)
 
     def undo_last(self) -> LedgerEntry | None:
         """Revert the most recent action (restore its before-snapshot).
 
         Returns the entry that was undone, or None if there's nothing to undo.
+        Any dependency lockfiles the restore changed are left in
+        ``last_changed_lockfiles`` for the caller to warn about.
         """
+        self.last_changed_lockfiles = []
         entries = self.history()
         if not entries:
             return None
@@ -118,5 +130,5 @@ class Reversibility:
         if not last_entry.snapshot_before:
             # A no-snapshot action (OPENDOT_NO_SNAPSHOT) has nothing to restore.
             return None
-        self.restore_to(last_entry.snapshot_before)
+        self.last_changed_lockfiles = self.restore_to(last_entry.snapshot_before)
         return last_entry

--- a/src/opendot/reversibility/snapshots.py
+++ b/src/opendot/reversibility/snapshots.py
@@ -378,18 +378,43 @@ def list_snapshots(project_id: str) -> list[str]:
     return sorted(p.stem for p in d.glob("*.json") if p.stem.isdigit())
 
 
-def restore_snapshot(snap: Snapshot, rules: IgnoreRules | None = None) -> None:
+# Dependency lockfiles. Restoring one rolls back which versions are *declared*,
+# but NOT the installed environment (node_modules, site-packages, global caches,
+# postinstall side effects). So when undo changes a lockfile we warn loudly: the
+# user must re-run their package manager to actually match it. (Ledger principle:
+# never let "files restored" be mistaken for "environment restored".)
+_LOCKFILES = {
+    "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "npm-shrinkwrap.json",
+    "uv.lock", "poetry.lock", "Pipfile.lock", "requirements.txt",
+    "Cargo.lock", "Gemfile.lock", "composer.lock", "go.sum",
+}
+
+
+def restore_snapshot(snap: Snapshot, rules: IgnoreRules | None = None) -> list[str]:
     """Make the workspace byte-for-byte match the snapshot.
 
     Rewrites/creates every file in the manifest; removes files that exist now but
     were not captured (respecting ignore rules — we never touch skipped paths).
+
+    Returns the relative paths of any dependency lockfiles whose content the
+    restore changed — the caller should warn that the *environment* isn't
+    restored until the package manager is re-run.
     """
     rules = rules or IgnoreRules()
     wd = Path(snap.workdir).resolve()
+    changed_lockfiles: list[str] = []
 
     # 1. Restore all files from the manifest (content + permission mode).
     for rel, entry in snap.files.items():
         target = wd / rel
+        # Before overwriting, note if this is a lockfile whose content differs —
+        # that means the restore rolled dependency versions back.
+        if Path(rel).name in _LOCKFILES:
+            try:
+                if not target.exists() or _hash_file(target) != entry.h:
+                    changed_lockfiles.append(rel)
+            except OSError:
+                changed_lockfiles.append(rel)
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(_read_object(entry.h))
         if entry.mode is not None:
@@ -403,6 +428,8 @@ def restore_snapshot(snap: Snapshot, rules: IgnoreRules | None = None) -> None:
     for f in _iter_files(wd, rules):
         rel = f.relative_to(wd).as_posix()
         if rel not in manifest_paths:
+            if f.name in _LOCKFILES:  # a lockfile the install created → undo removes it
+                changed_lockfiles.append(rel)
             try:
                 f.unlink()
             except OSError:
@@ -420,3 +447,6 @@ def restore_snapshot(snap: Snapshot, rules: IgnoreRules | None = None) -> None:
                 p.rmdir()
         except OSError:
             pass
+
+    # De-dupe (a lockfile could be both changed and matched) and return.
+    return sorted(set(changed_lockfiles))

--- a/src/opendot/tui/app.py
+++ b/src/opendot/tui/app.py
@@ -701,12 +701,28 @@ class OpendotTUI(App):
             if not target:
                 self._write(f"no action {snap_id} (see /log)", "sys")
                 return
-            rev.restore_to(target.snapshot_before)
-            self._write(f"restored workspace to before action {target.id}", "sys")
+            changed_locks = rev.restore_to(target.snapshot_before)
+            what = f"action {target.id} ({target.kind}: {target.detail.rsplit('/', 1)[-1]})"
         else:
             undone = rev.undo_last()
-            self._write(f"undid last action ({undone.kind}: {undone.detail.rsplit('/',1)[-1]})", "sys")
+            if undone is None:
+                self._write("nothing to undo (or last action wasn't snapshotted)", "sys")
+                return
+            changed_locks = rev.last_changed_lockfiles
+            what = f"the last action ({undone.kind}: {undone.detail.rsplit('/', 1)[-1]})"
+
+        self._write(f"↺ reverted {what}", "sys")   # immediate, deterministic ack
         self._refresh_sidebar()
+        # Then the agent narrates the undo (and, per its system prompt, loudly
+        # warns about environment drift when a lockfile changed). Detection is
+        # done in code above; only the phrasing/help is left to the model.
+        if self._busy:
+            return  # a turn is already running; don't stack another
+        note = f"[undo] Reverted {what}."
+        if changed_locks:
+            note += f" Changed lockfile(s): {', '.join(changed_locks)}."
+        self._busy = True
+        self._turn_worker = self.run_worker(self._run_turn(note), exclusive=True)
 
     def action_log(self) -> None:
         history = self.agent.reversibility.history()

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -303,6 +303,57 @@ def test_ledger_clear_wipes_history(tmp_path):
     assert rev.clear_history() == 0
 
 
+def test_undo_reports_changed_lockfile(tmp_path):
+    """Undoing across a lockfile change must report it, so the caller can warn
+    that the environment isn't restored (only the declared versions)."""
+    from opendot.reversibility.engine import Reversibility
+    from opendot.reversibility.rules import load_rules
+
+    wd = _workspace(tmp_path)
+    (wd / "package-lock.json").write_text('{"version": 1}')
+    rev = Reversibility(workdir=str(wd), rules=load_rules(str(wd)))
+
+    rev.before_action("shell", "npm install foo", reversible=True)  # snapshot before
+    (wd / "package-lock.json").write_text('{"version": 2}')          # "install" changes it
+
+    undone = rev.undo_last()
+    assert undone is not None
+    assert (wd / "package-lock.json").read_text() == '{"version": 1}'  # rolled back
+    assert rev.last_changed_lockfiles == ["package-lock.json"]         # and reported
+
+
+def test_undo_reports_lockfile_created_by_install(tmp_path):
+    """A lockfile the install *created* (absent in the snapshot) is removed by
+    undo, and that also counts as a changed lockfile worth warning about."""
+    from opendot.reversibility.engine import Reversibility
+    from opendot.reversibility.rules import load_rules
+
+    wd = _workspace(tmp_path)
+    (wd / "app.py").write_text("x = 1")
+    rev = Reversibility(workdir=str(wd), rules=load_rules(str(wd)))
+
+    rev.before_action("shell", "uv add requests", reversible=True)   # no lockfile yet
+    (wd / "uv.lock").write_text("locked")                            # install creates one
+
+    rev.undo_last()
+    assert not (wd / "uv.lock").exists()                             # removed on undo
+    assert rev.last_changed_lockfiles == ["uv.lock"]
+
+
+def test_undo_no_lockfile_change_is_silent(tmp_path):
+    """A plain file edit with no lockfile involved reports nothing to warn about."""
+    from opendot.reversibility.engine import Reversibility
+    from opendot.reversibility.rules import load_rules
+
+    wd = _workspace(tmp_path)
+    (wd / "a.txt").write_text("v1")
+    rev = Reversibility(workdir=str(wd), rules=load_rules(str(wd)))
+    rev.before_action("write", "a.txt", reversible=True)
+    (wd / "a.txt").write_text("v2")
+    rev.undo_last()
+    assert rev.last_changed_lockfiles == []
+
+
 def test_no_snapshot_action_logs_but_captures_nothing(tmp_path):
     """OPENDOT_NO_SNAPSHOT path: the action is logged (audit trail) but no
     snapshot is taken, so nothing sensitive is copied into the store."""


### PR DESCRIPTION
Undo now reports what it reverted through the agent instead of a hardcoded
line, and warns loudly when a dependency lockfile was rolled back.

Detection stays in code (reliable): restore_snapshot detects which files were
restored and which lockfiles changed (both a lockfile whose content differs and
one the install created), and the engine exposes it via last_changed_lockfiles.

Narration moves to the agent (TUI): after /undo or ctrl+z, opendot injects an
"[undo]" note with the facts and runs an agent turn. A system-prompt instruction
requires the agent to report what was rolled back and, when a lockfile changed,
warn that only declared versions were reverted (not installed packages) and name
the right reinstall command (package-lock.json -> npm ci, uv.lock -> uv sync,
etc.). An immediate deterministic "reverted ..." line still prints first so undo
feels instant and the signal never fully depends on the model.

CLI `opendot undo` stays deterministic (a plain factual note) since it's a
non-interactive, no-model command.

Also fixes a latent crash: both the CLI and TUI assumed undo_last() always
returns an entry, but it can return None (nothing to undo / no-snapshot action).

Bump version to 0.1.6.