### PR TITLE
chore: adopt ruff for linting and formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,17 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ruff
+      - run: ruff check src/ tests/
+      - run: ruff format --check src/ tests/
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+# Auto-fix lint + format on commit. One-time setup:  pre-commit install
+# Then `git commit` runs ruff on staged files, fixing what it can automatically.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.4
+    hooks:
+      - id: ruff          # lint, auto-fixing what's safe
+        args: [--fix]
+      - id: ruff-format   # format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.1.6"
+version = "0.1.7"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"
@@ -42,6 +42,16 @@ Repository = "https://github.com/vedaant00/opendot"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/opendot"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W"]
+# The formatter owns line width; E501 only fires on lines it can't split
+# (long string literals, Rich markup, CSS), so enforcing it adds noise, not value.
+ignore = ["E501"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -9,10 +9,10 @@ Public SDK surface (so CLI, and future clients, are thin layers over this):
         ...
 """
 
-from opendot.agent.loop import Agent
 from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
+from opendot.agent.loop import Agent
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/agent/events.py
+++ b/src/opendot/agent/events.py
@@ -11,24 +11,24 @@ from dataclasses import dataclass, field
 from typing import Any, Literal
 
 EventType = Literal[
-    "thinking",    # a streamed chunk of the model's reasoning (reasoning models)
-    "text",        # a streamed chunk of the assistant's answer
+    "thinking",  # a streamed chunk of the model's reasoning (reasoning models)
+    "text",  # a streamed chunk of the assistant's answer
     "tool_start",  # the agent is about to run a tool
-    "tool_end",    # a tool finished (result attached)
-    "final",       # the assistant's turn is complete
-    "error",       # something went wrong
+    "tool_end",  # a tool finished (result attached)
+    "final",  # the assistant's turn is complete
+    "error",  # something went wrong
     # parallel read-only explorers
     "explorer_start",  # a subagent lane started (text=task, lane=index)
-    "explorer_step",   # a subagent did something (text=summary, lane=index)
-    "explorer_done",   # a subagent finished (text=finding summary, lane=index)
+    "explorer_step",  # a subagent did something (text=summary, lane=index)
+    "explorer_done",  # a subagent finished (text=finding summary, lane=index)
 ]
 
 
 @dataclass
 class Event:
     type: EventType
-    text: str = ""                       # for "text" / "error" / explorer_*
-    tool: str = ""                       # for tool_start / tool_end
+    text: str = ""  # for "text" / "error" / explorer_*
+    tool: str = ""  # for tool_start / tool_end
     args: dict[str, Any] = field(default_factory=dict)  # tool_start
-    result: str = ""                     # tool_end
-    lane: int = -1                       # explorer lane index (-1 = main agent)
+    result: str = ""  # tool_end
+    lane: int = -1  # explorer lane index (-1 = main agent)

--- a/src/opendot/agent/explorers.py
+++ b/src/opendot/agent/explorers.py
@@ -18,7 +18,7 @@ Events are lane-tagged (lane = subagent index) so the TUI can show parallel
 from __future__ import annotations
 
 import asyncio
-from typing import Any, AsyncIterator
+from typing import AsyncIterator
 
 from opendot.agent.events import Event
 
@@ -33,9 +33,7 @@ anything; those tools are not available to you.
 """
 
 
-async def run_explorers(
-    tasks: list[str], *, model: str, workdir: str
-) -> AsyncIterator[Event]:
+async def run_explorers(tasks: list[str], *, model: str, workdir: str) -> AsyncIterator[Event]:
     """Run each task as a concurrent read-only subagent, yielding lane-tagged
     events, and finally a merged findings summary the caller can use."""
     from opendot.agent.config import AgentConfig
@@ -52,11 +50,16 @@ async def run_explorers(
 
     async def one(lane: int, task: str) -> None:
         await q.put(Event("explorer_start", text=task, lane=lane))
-        agent = Agent(AgentConfig(
-            model=model, workdir=workdir, system_prompt=_EXPLORER_SYSTEM,
-        ))
+        agent = Agent(
+            AgentConfig(
+                model=model,
+                workdir=workdir,
+                system_prompt=_EXPLORER_SYSTEM,
+            )
+        )
         # Force a read-only toolbox regardless of defaults.
         from opendot.tools.local import Toolbox
+
         agent.toolbox = Toolbox(workdir, reversibility=None, read_only=True)
         answer_parts: list[str] = []
         try:
@@ -87,7 +90,7 @@ async def run_explorers(
 
     # Attach the merged findings as the tool's textual result via a final event.
     merged = "\n\n".join(
-        f"[explorer {i+1}] {tasks[i]}\n{findings.get(i, '(no findings)')}"
+        f"[explorer {i + 1}] {tasks[i]}\n{findings.get(i, '(no findings)')}"
         for i in range(len(tasks))
     )
     yield Event("tool_end", tool="spawn_explorers", result=merged)

--- a/src/opendot/agent/loop.py
+++ b/src/opendot/agent/loop.py
@@ -17,7 +17,6 @@ from opendot.agent.events import Event
 from opendot.agent.prompt import DEFAULT_SYSTEM_PROMPT
 from opendot.tools.local import Toolbox
 
-
 _SPAWN_EXPLORERS_SPEC = {
     "type": "function",
     "function": {
@@ -33,7 +32,8 @@ _SPAWN_EXPLORERS_SPEC = {
             "type": "object",
             "properties": {
                 "tasks": {
-                    "type": "array", "items": {"type": "string"},
+                    "type": "array",
+                    "items": {"type": "string"},
                     "description": "2-6 independent, self-contained investigation tasks.",
                 }
             },
@@ -59,16 +59,18 @@ def _assistant_msg(content: str, calls: list[dict[str, Any]]) -> dict[str, Any]:
     msg: dict[str, Any] = {"role": "assistant", "content": content or None}
     if calls:
         msg["tool_calls"] = [
-            {"id": c["id"], "type": "function",
-             "function": {"name": c["name"], "arguments": c["args"] or "{}"}}
+            {
+                "id": c["id"],
+                "type": "function",
+                "function": {"name": c["name"], "arguments": c["args"] or "{}"},
+            }
             for c in calls
         ]
     return msg
 
 
 class Agent:
-    def __init__(self, config: AgentConfig | None = None, confirm=None,
-                 mcp_manager=None) -> None:
+    def __init__(self, config: AgentConfig | None = None, confirm=None, mcp_manager=None) -> None:
         self.config = config or AgentConfig()
         self.mcp = mcp_manager
 
@@ -175,7 +177,8 @@ class Agent:
 
                     result = "(no findings)"
                     async for ev in run_explorers(
-                        args.get("tasks", []), model=self.config.model,
+                        args.get("tasks", []),
+                        model=self.config.model,
                         workdir=self.config.workdir,
                     ):
                         if ev.type == "tool_end" and ev.tool == "spawn_explorers":
@@ -192,11 +195,10 @@ class Agent:
                 # a confirm-callback safely block for a UI prompt (e.g. the TUI
                 # modal) without freezing the loop.
                 import asyncio
+
                 result = await asyncio.to_thread(self.toolbox.call, name, args)
                 yield Event("tool_end", tool=name, result=result)
-                self.messages.append(
-                    {"role": "tool", "tool_call_id": call_id, "content": result}
-                )
+                self.messages.append({"role": "tool", "tool_call_id": call_id, "content": result})
 
         yield Event("error", text=f"stopped: hit max_steps ({self.config.max_steps})")
 
@@ -207,8 +209,11 @@ class Agent:
         tool calls as plain text (so the caller can fall back to non-streaming).
         """
         stream = await litellm.acompletion(
-            model=self.config.model, messages=self.messages, tools=tools,
-            temperature=self.config.temperature, stream=True,
+            model=self.config.model,
+            messages=self.messages,
+            tools=tools,
+            temperature=self.config.temperature,
+            stream=True,
             stream_options={"include_usage": True},
             api_base=self.config.api_base,  # None => provider default
         )
@@ -245,23 +250,30 @@ class Agent:
 
         calls = [
             {"id": c["id"] or f"call_{i}", "name": c["name"], "args": c["args"]}
-            for i, c in sorted(tool_calls.items()) if c["name"]
+            for i, c in sorted(tool_calls.items())
+            if c["name"]
         ]
         yield _Assembled(_assistant_msg("".join(content_parts), calls), calls)
 
     async def _nonstream_turn(self, litellm, tools):
         """Non-streaming fallback (reliable tool calls; no live tokens)."""
         resp = await litellm.acompletion(
-            model=self.config.model, messages=self.messages, tools=tools,
-            temperature=self.config.temperature, stream=False,
+            model=self.config.model,
+            messages=self.messages,
+            tools=tools,
+            temperature=self.config.temperature,
+            stream=False,
             api_base=self.config.api_base,  # None => provider default
         )
         self.usage.add_response(resp, litellm, model=self.config.model)
         msg = resp.choices[0].message
         raw = getattr(msg, "tool_calls", None) or []
         calls = [
-            {"id": tc.id or f"call_{i}", "name": tc.function.name,
-             "args": tc.function.arguments or "{}"}
+            {
+                "id": tc.id or f"call_{i}",
+                "name": tc.function.name,
+                "args": tc.function.arguments or "{}",
+            }
             for i, tc in enumerate(raw)
         ]
         if msg.content:

--- a/src/opendot/catalog.py
+++ b/src/opendot/catalog.py
@@ -27,6 +27,7 @@ _BARE_OK_PROVIDERS = {"openai", "anthropic"}
 
 def _litellm():
     import litellm
+
     return litellm
 
 
@@ -47,8 +48,11 @@ def provider_ids() -> set[str]:
 def _pretty(provider_id: str) -> str:
     """A display name for a provider id (best-effort title-casing)."""
     special = {
-        "openai": "OpenAI", "xai": "xAI", "ai21": "AI21",
-        "openrouter": "OpenRouter", "huggingface": "Hugging Face",
+        "openai": "OpenAI",
+        "xai": "xAI",
+        "ai21": "AI21",
+        "openrouter": "OpenRouter",
+        "huggingface": "Hugging Face",
     }
     if provider_id in special:
         return special[provider_id]
@@ -86,7 +90,13 @@ def list_models() -> list[dict]:
         if model in seen:  # registry may list both bare and prefixed variants
             continue
         seen.add(model)
-        out.append({"model": model, "name": name, "provider": _pretty(prov) if prov else "other"})
+        out.append(
+            {
+                "model": model,
+                "name": name,
+                "provider": _pretty(prov) if prov else "other",
+            }
+        )
     out.sort(key=lambda d: (d["provider"].lower(), d["name"].lower()))
     return out
 

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -17,12 +17,11 @@ import sys
 from pathlib import Path
 
 from rich.console import Console
-from rich.markdown import Markdown
 from rich.panel import Panel
 
 from opendot import __version__
-from opendot.agent.loop import Agent
 from opendot.agent.config import AgentConfig
+from opendot.agent.loop import Agent
 from opendot.agent.prompt import DEFAULT_SYSTEM_PROMPT
 
 console = Console()
@@ -86,12 +85,15 @@ def _build_agent(model: str, workdir: str, confirm=None, api_base: str | None = 
     # model's key isn't set but another provider's is, switch to that provider.
     if not api_base:
         from opendot.providers import env_var_for, model_for_available_key
+
         var = env_var_for(model)
         if var and not os.environ.get(var):
             alt = model_for_available_key()
             if alt and alt != model:
-                console.print(f"[dim]no {var}; using [cyan]{alt}[/cyan] "
-                              f"(found its key in your environment)[/dim]")
+                console.print(
+                    f"[dim]no {var}; using [cyan]{alt}[/cyan] "
+                    f"(found its key in your environment)[/dim]"
+                )
                 model = alt
 
     system = DEFAULT_SYSTEM_PROMPT
@@ -103,6 +105,7 @@ def _build_agent(model: str, workdir: str, confirm=None, api_base: str | None = 
     mcp_manager = None
     try:
         from opendot.mcp import MCPManager, load_mcp_config
+
         cfg = load_mcp_config()
         if cfg:
             mcp_manager = MCPManager(cfg)
@@ -125,8 +128,10 @@ def _cmd_log(workdir: str, clear: bool = False) -> None:
     rev = Reversibility(workdir=workdir, rules=load_rules(workdir))
     if clear:
         n = rev.clear_history()
-        console.print(f"[green]cleared[/green] {n} ledger entr{'y' if n == 1 else 'ies'} "
-                      "(undo history discarded)")
+        console.print(
+            f"[green]cleared[/green] {n} ledger entr{'y' if n == 1 else 'ies'} "
+            "(undo history discarded)"
+        )
         return
     entries = rev.history()
     if not entries:
@@ -159,12 +164,16 @@ def _cmd_undo(workdir: str, snap_id: str | None) -> None:
             console.print(f"[red]no action with id {snap_id}[/red]  (see: opendot log)")
             return
         changed_locks = rev.restore_to(target.snapshot_before)
-        console.print(f"[green]restored[/green] workspace to before action {snap_id} ({target.kind}: {target.detail[:50]})")
+        console.print(
+            f"[green]restored[/green] workspace to before action {snap_id} ({target.kind}: {target.detail[:50]})"
+        )
         _note_lockfiles(console, changed_locks)
     else:
         undone = rev.undo_last()
         if undone is None:
-            console.print("[yellow]nothing to undo[/yellow] (or the last action wasn't snapshotted)")
+            console.print(
+                "[yellow]nothing to undo[/yellow] (or the last action wasn't snapshotted)"
+            )
             return
         console.print(f"[green]undid[/green] last action ({undone.kind}: {undone.detail[:50]})")
         _note_lockfiles(console, rev.last_changed_lockfiles)
@@ -187,7 +196,9 @@ def _note_lockfiles(console, changed: list[str]) -> None:
 def _cmd_mcp(args) -> None:
     """`opendot mcp add|list|remove` — manage external MCP servers."""
     from opendot.mcp import (
-        add_mcp_server, load_mcp_config, remove_mcp_server,
+        add_mcp_server,
+        load_mcp_config,
+        remove_mcp_server,
     )
 
     cmd = getattr(args, "mcp_command", None)
@@ -196,7 +207,9 @@ def _cmd_mcp(args) -> None:
         servers = load_mcp_config()
         if not servers:
             console.print("[dim]no MCP servers configured.[/dim]")
-            console.print("[dim]add one:  opendot mcp add <name> -- <command> [args...]   (or --url <url>)[/dim]")
+            console.print(
+                "[dim]add one:  opendot mcp add <name> -- <command> [args...]   (or --url <url>)[/dim]"
+            )
             return
         console.print("[bold]MCP servers[/bold] (from ~/.opendot/mcp.json)\n")
         for name, spec in servers.items():
@@ -225,7 +238,9 @@ def _cmd_mcp(args) -> None:
         else:
             cmd = list(getattr(args, "post_dashdash", []))
             if not cmd:
-                console.print("[red]provide a launch command after `--`, or use --url for a remote server[/red]")
+                console.print(
+                    "[red]provide a launch command after `--`, or use --url for a remote server[/red]"
+                )
                 return
             spec = {"command": cmd[0]}
             if len(cmd) > 1:
@@ -233,7 +248,9 @@ def _cmd_mcp(args) -> None:
         if env:
             spec["env"] = env
         add_mcp_server(args.name, spec)
-        console.print(f"[green]added[/green] MCP server [cyan]{args.name}[/cyan]. It will connect next time you run opendot.")
+        console.print(
+            f"[green]added[/green] MCP server [cyan]{args.name}[/cyan]. It will connect next time you run opendot."
+        )
         return
 
     if cmd == "remove":
@@ -331,19 +348,25 @@ def _interactive(agent: Agent) -> None:
                 console.print(f"model → [cyan]{agent.config.model}[/cyan]")
                 _warn_if_missing_key(agent.config.model)
             else:
-                console.print(f"model: [cyan]{agent.config.model}[/cyan]  "
-                              "([dim]/model <id> to change[/dim])")
+                console.print(
+                    f"model: [cyan]{agent.config.model}[/cyan]  ([dim]/model <id> to change[/dim])"
+                )
             continue
         if low.startswith("/provider") or low.startswith("/connect"):
             from opendot.providers import register_key
+
             parts = text.split()
             if len(parts) == 3:
                 register_key(parts[1], parts[2])
-                console.print(f"[green]✓[/green] set {parts[1]} for this session — "
-                              f"persist with [dim]export {parts[1]}=…[/dim]")
+                console.print(
+                    f"[green]✓[/green] set {parts[1]} for this session — "
+                    f"persist with [dim]export {parts[1]}=…[/dim]"
+                )
             else:
-                console.print("usage: [dim]/provider <ENV_VAR> <api-key>[/dim]  "
-                              "(the TUI has an interactive picker)")
+                console.print(
+                    "usage: [dim]/provider <ENV_VAR> <api-key>[/dim]  "
+                    "(the TUI has an interactive picker)"
+                )
             continue
         if low == "/log":
             _cmd_log(agent.config.workdir)
@@ -369,27 +392,42 @@ def main() -> None:
     argv = sys.argv[1:]
     if "--" in argv:
         i = argv.index("--")
-        argv, post_dashdash = argv[:i], argv[i + 1:]
+        argv, post_dashdash = argv[:i], argv[i + 1 :]
 
     parser = argparse.ArgumentParser(
         prog="opendot",
         description="An interactive terminal AI agent you can fully undo.",
     )
     parser.add_argument("-p", "--prompt", help="Run a single task and exit (one-shot mode).")
-    parser.add_argument("--model", default=os.environ.get("OPENDOT_MODEL", "gpt-5.1"),
-                        help="Model id (any LiteLLM model, e.g. gpt-5.1, claude-opus-4-5, ollama/qwen3).")
-    parser.add_argument("--api-base", default=os.environ.get("OPENAI_API_BASE"),
-                        help="Base URL of an OpenAI-compatible server "
-                             "(llama.cpp/llama-server, vLLM, LM Studio). "
-                             "Use with --model openai/<name>.")
-    parser.add_argument("-C", "--dir", default=os.getcwd(), help="Working directory (default: cwd).")
-    parser.add_argument("--repl", action="store_true", help="Use the plain REPL instead of the full-screen TUI.")
+    parser.add_argument(
+        "--model",
+        default=os.environ.get("OPENDOT_MODEL", "gpt-5.1"),
+        help="Model id (any LiteLLM model, e.g. gpt-5.1, claude-opus-4-5, ollama/qwen3).",
+    )
+    parser.add_argument(
+        "--api-base",
+        default=os.environ.get("OPENAI_API_BASE"),
+        help="Base URL of an OpenAI-compatible server "
+        "(llama.cpp/llama-server, vLLM, LM Studio). "
+        "Use with --model openai/<name>.",
+    )
+    parser.add_argument(
+        "-C", "--dir", default=os.getcwd(), help="Working directory (default: cwd)."
+    )
+    parser.add_argument(
+        "--repl",
+        action="store_true",
+        help="Use the plain REPL instead of the full-screen TUI.",
+    )
     parser.add_argument("--version", action="version", version=f"opendot {__version__}")
 
     sub = parser.add_subparsers(dest="command")
     p_log = sub.add_parser("log", help="Show the auditable history of actions opendot took.")
-    p_log.add_argument("--clear", action="store_true",
-                       help="Wipe this project's action ledger (discards undo history).")
+    p_log.add_argument(
+        "--clear",
+        action="store_true",
+        help="Wipe this project's action ledger (discards undo history).",
+    )
     p_undo = sub.add_parser("undo", help="Restore the workspace (last action, or to a given id).")
     p_undo.add_argument("id", nargs="?", help="Action id from `opendot log` (default: last).")
 
@@ -397,17 +435,28 @@ def main() -> None:
     p_mcp = sub.add_parser("mcp", help="Manage MCP servers opendot connects to.")
     mcp_sub = p_mcp.add_subparsers(dest="mcp_command")
     p_add = mcp_sub.add_parser(
-        "add", help="Add an MCP server.",
+        "add",
+        help="Add an MCP server.",
         epilog="For a stdio server, put its launch command after `--`. "
-               "For a remote server, pass --url instead.",
+        "For a remote server, pass --url instead.",
     )
     p_add.add_argument("name", help="A short name for the server.")
     p_add.add_argument("--url", help="A remote MCP server URL (http/sse) instead of a command.")
-    p_add.add_argument("--env", action="append", default=[], metavar="KEY=VAL",
-                       help="Environment variable for the server (repeatable).")
-    p_add.add_argument("--header", action="append", default=[], metavar="KEY=VAL",
-                       help="HTTP header for a remote (--url) server, e.g. "
-                            "'Authorization=Bearer <token>' (repeatable).")
+    p_add.add_argument(
+        "--env",
+        action="append",
+        default=[],
+        metavar="KEY=VAL",
+        help="Environment variable for the server (repeatable).",
+    )
+    p_add.add_argument(
+        "--header",
+        action="append",
+        default=[],
+        metavar="KEY=VAL",
+        help="HTTP header for a remote (--url) server, e.g. "
+        "'Authorization=Bearer <token>' (repeatable).",
+    )
     # The launch command (after `--`) is captured from argv in main(), not here,
     # so its own flags (e.g. -y) aren't parsed by argparse.
     mcp_sub.add_parser("list", help="List configured MCP servers.")

--- a/src/opendot/mcp/__init__.py
+++ b/src/opendot/mcp/__init__.py
@@ -9,6 +9,9 @@ from opendot.mcp.manager import (
 )
 
 __all__ = [
-    "MCPManager", "load_mcp_config", "save_mcp_config",
-    "add_mcp_server", "remove_mcp_server",
+    "MCPManager",
+    "load_mcp_config",
+    "save_mcp_config",
+    "add_mcp_server",
+    "remove_mcp_server",
 ]

--- a/src/opendot/mcp/manager.py
+++ b/src/opendot/mcp/manager.py
@@ -30,7 +30,7 @@ import asyncio
 import json
 import threading
 from concurrent.futures import Future
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -80,7 +80,7 @@ def remove_mcp_server(name: str) -> bool:
 @dataclass
 class MCPTool:
     server: str
-    name: str            # bare tool name on the server
+    name: str  # bare tool name on the server
     description: str
     input_schema: dict[str, Any]
 
@@ -124,23 +124,25 @@ class MCPManager:
         from contextlib import AsyncExitStack
 
         from mcp import ClientSession
+
         self._stack = AsyncExitStack()
         for name, spec in self.config.items():
             try:
                 read, write = await self._open_transport(spec)
-                session = await self._stack.enter_async_context(
-                    ClientSession(read, write)
-                )
+                session = await self._stack.enter_async_context(ClientSession(read, write))
                 await session.initialize()
                 self._sessions[name] = session
                 self.connected.append(name)
                 resp = await session.list_tools()
                 for t in resp.tools:
-                    self.tools.append(MCPTool(
-                        server=name, name=t.name,
-                        description=t.description or "",
-                        input_schema=t.inputSchema or {"type": "object", "properties": {}},
-                    ))
+                    self.tools.append(
+                        MCPTool(
+                            server=name,
+                            name=t.name,
+                            description=t.description or "",
+                            input_schema=t.inputSchema or {"type": "object", "properties": {}},
+                        )
+                    )
             except Exception as exc:  # noqa: BLE001 - a bad server must not kill the rest
                 self.errors[name] = f"{type(exc).__name__}: {exc}"
         ready.set()
@@ -152,14 +154,20 @@ class MCPManager:
             headers = spec.get("headers") or None  # e.g. {"Authorization": "Bearer ..."}
             if url.rstrip("/").endswith("/sse"):
                 from mcp.client.sse import sse_client
+
                 return (await self._stack.enter_async_context(sse_client(url, headers=headers)))[:2]
             from mcp.client.streamable_http import streamablehttp_client
-            return (await self._stack.enter_async_context(streamablehttp_client(url, headers=headers)))[:2]
+
+            return (
+                await self._stack.enter_async_context(streamablehttp_client(url, headers=headers))
+            )[:2]
         # stdio
         from mcp import StdioServerParameters
         from mcp.client.stdio import stdio_client
+
         params = StdioServerParameters(
-            command=spec["command"], args=spec.get("args", []),
+            command=spec["command"],
+            args=spec.get("args", []),
             env=spec.get("env") or None,
         )
         return await self._stack.enter_async_context(stdio_client(params))
@@ -195,9 +203,11 @@ class MCPManager:
 
     def shutdown(self) -> None:
         if self._loop and self._loop.is_running():
+
             async def _close():
                 if self._stack:
                     await self._stack.aclose()
+
             try:
                 self._run(_close(), timeout=10)
             except Exception:  # noqa: BLE001

--- a/src/opendot/providers.py
+++ b/src/opendot/providers.py
@@ -15,7 +15,7 @@ import os
 # (including GPT-via-Azure, OpenRouter, etc.) is derived from the convention.
 _ENV_OVERRIDES: dict[str, str] = {
     "huggingface": "HF_TOKEN",
-    "gemini": "GEMINI_API_KEY",     # provider id is 'gemini', not 'google'
+    "gemini": "GEMINI_API_KEY",  # provider id is 'gemini', not 'google'
     "vertex_ai": "GOOGLE_APPLICATION_CREDENTIALS",
     "bedrock": "AWS_ACCESS_KEY_ID",
     "azure": "AZURE_API_KEY",
@@ -23,8 +23,14 @@ _ENV_OVERRIDES: dict[str, str] = {
 
 # Local providers that need no API key. LiteLLM lists these in provider_list
 # but doesn't flag "keyless", so we name them. Matches LiteLLM's local set.
-_KEYLESS_PROVIDERS = {"ollama", "ollama_chat", "vllm", "hosted_vllm",
-                      "lm_studio", "llamafile"}
+_KEYLESS_PROVIDERS = {
+    "ollama",
+    "ollama_chat",
+    "vllm",
+    "hosted_vllm",
+    "lm_studio",
+    "llamafile",
+}
 # Model-string prefixes for those providers (derived — keep in one place).
 NO_KEY_PREFIXES = tuple(f"{p}/" for p in sorted(_KEYLESS_PROVIDERS))
 
@@ -33,6 +39,7 @@ def connectable_providers() -> list[tuple[str, str]]:
     """(display name, env var) pairs for the `/provider` flow — the LiteLLM-
     routable providers that have text models, from the catalog."""
     from opendot import catalog
+
     return [(p["name"], p["env"]) for p in catalog.list_providers()]
 
 
@@ -42,6 +49,7 @@ def known_key_vars() -> list[str]:
     catalog's connectable providers, falling back to the override set."""
     try:
         from opendot import catalog
+
         vars_ = [p["env"] for p in catalog.list_providers()]
         if vars_:
             return vars_
@@ -65,8 +73,12 @@ def _env_for_provider_id(provider: str) -> str | None:
 
 # Bare-model routing: LiteLLM sends these prefixes to a canonical provider.
 # Used only when a bare model id isn't found in the registry.
-_BARE_ROUTING = {"gpt-": "openai", "o1": "openai", "o3": "openai",
-                 "claude": "anthropic"}
+_BARE_ROUTING = {
+    "gpt-": "openai",
+    "o1": "openai",
+    "o3": "openai",
+    "claude": "anthropic",
+}
 
 
 def _provider_id_for(model: str) -> str | None:
@@ -94,6 +106,7 @@ def _provider_id_for(model: str) -> str | None:
 def _model_registry() -> dict:
     try:
         import litellm
+
         return litellm.model_cost
     except Exception:  # noqa: BLE001
         return {}
@@ -112,9 +125,18 @@ def env_var_for(model: str) -> str | None:
 
 
 # Preference order for auto-selecting a model when several provider keys are set.
-_AUTO_ORDER = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY",
-               "DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY",
-               "XAI_API_KEY", "COHERE_API_KEY", "OPENROUTER_API_KEY", "HF_TOKEN"]
+_AUTO_ORDER = [
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "GROQ_API_KEY",
+    "MISTRAL_API_KEY",
+    "XAI_API_KEY",
+    "COHERE_API_KEY",
+    "OPENROUTER_API_KEY",
+    "HF_TOKEN",
+]
 
 
 def model_for_available_key() -> str | None:
@@ -154,6 +176,7 @@ def list_models() -> list[str]:
     """
     try:
         from opendot import catalog
+
         return sorted({m["model"] for m in catalog.list_models()})
     except Exception:  # noqa: BLE001 - registry unavailable
         return []

--- a/src/opendot/reversibility/classifier.py
+++ b/src/opendot/reversibility/classifier.py
@@ -22,29 +22,84 @@ from pathlib import Path
 # Commands whose whole job is contained, read-only, or trivially reversible.
 # Only these auto-run without confirmation.
 _SAFE_COMMANDS = {
-    "ls", "cat", "head", "tail", "pwd", "echo", "grep", "rg", "find", "wc",
-    "diff", "tree", "stat", "file", "which", "env", "date", "whoami",
-    "clear", "cls",  # harmless read-only terminal commands
-    "python", "python3", "node", "pytest", "go", "cargo",  # running code in-workspace
-    "touch", "mkdir", "cp", "mv",  # in-workspace fs ops (snapshot covers them)
-    "sed", "awk", "sort", "uniq", "cut", "tr",
+    "ls",
+    "cat",
+    "head",
+    "tail",
+    "pwd",
+    "echo",
+    "grep",
+    "rg",
+    "find",
+    "wc",
+    "diff",
+    "tree",
+    "stat",
+    "file",
+    "which",
+    "env",
+    "date",
+    "whoami",
+    "clear",
+    "cls",  # harmless read-only terminal commands
+    "python",
+    "python3",
+    "node",
+    "pytest",
+    "go",
+    "cargo",  # running code in-workspace
+    "touch",
+    "mkdir",
+    "cp",
+    "mv",  # in-workspace fs ops (snapshot covers them)
+    "sed",
+    "awk",
+    "sort",
+    "uniq",
+    "cut",
+    "tr",
 }
 
 # Signals that a command escapes the workspace or is hard/impossible to undo.
 _NETWORK = {"curl", "wget", "ssh", "scp", "rsync", "ftp", "nc", "telnet"}
 _VCS_REMOTE = ("git push", "git pull", "git fetch", "git clone")
-_PKG_INSTALL = ("pip install", "pip3 install", "npm install", "npm i ",
-                "yarn add", "apt install", "apt-get install", "brew install",
-                "uv pip install", "uv add", "cargo install", "gem install")
+_PKG_INSTALL = (
+    "pip install",
+    "pip3 install",
+    "npm install",
+    "npm i ",
+    "yarn add",
+    "apt install",
+    "apt-get install",
+    "brew install",
+    "uv pip install",
+    "uv add",
+    "cargo install",
+    "gem install",
+)
 _PRIVILEGE = {"sudo", "doas", "su"}
 _DESTRUCTIVE_DB = re.compile(r"\b(drop|truncate|delete)\s+(table|database|from)\b", re.I)
 
 # Directory names snapshots SKIP by default (mirrors snapshots._DEFAULT_IGNORE_DIRS).
 # Deleting one of these is NOT undoable — it was never captured — so an `rm`
 # that targets them must be treated as irreversible, not auto-run.
-_NOT_SNAPSHOTTED = {".git", ".hg", ".svn", "node_modules", "__pycache__",
-                    ".venv", "venv", ".opendot", ".mypy_cache", ".pytest_cache",
-                    ".ruff_cache", "dist", "build", ".next", ".cache"}
+_NOT_SNAPSHOTTED = {
+    ".git",
+    ".hg",
+    ".svn",
+    "node_modules",
+    "__pycache__",
+    ".venv",
+    "venv",
+    ".opendot",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    "dist",
+    "build",
+    ".next",
+    ".cache",
+}
 
 
 def _hits_unsnapshotted_path(command: str) -> str | None:
@@ -115,8 +170,10 @@ def classify(command: str, workdir: str) -> Verdict:
         # undone — it was never captured. Flag it rather than silently run it.
         skipped = _hits_unsnapshotted_path(cmd)
         if skipped:
-            return Verdict(False, f"deletes '{skipped}', which opendot doesn't "
-                                  f"snapshot — this can't be undone")
+            return Verdict(
+                False,
+                f"deletes '{skipped}', which opendot doesn't snapshot — this can't be undone",
+            )
         # in-workspace rm is reversible via snapshot
         return Verdict(True)
     if _mentions_outside_path(cmd, workdir):

--- a/src/opendot/reversibility/engine.py
+++ b/src/opendot/reversibility/engine.py
@@ -78,8 +78,7 @@ class Reversibility:
         # record that honestly in the ledger note.
         if snap.skipped_large:
             n = len(snap.skipped_large)
-            big_note = (f"{n} file(s) too large to snapshot — "
-                        f"changes to them can't be undone")
+            big_note = f"{n} file(s) too large to snapshot — changes to them can't be undone"
             note = f"{note}; {big_note}" if note else big_note
         ledger.append(
             self.project_id,

--- a/src/opendot/reversibility/ledger.py
+++ b/src/opendot/reversibility/ledger.py
@@ -13,7 +13,7 @@ deterministic/testable); callers pass a timestamp string or leave it blank.
 from __future__ import annotations
 
 import json
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Literal
 
@@ -24,12 +24,12 @@ ActionKind = Literal["write", "shell"]
 
 @dataclass
 class LedgerEntry:
-    id: str                 # matches the snapshot id taken before this action
+    id: str  # matches the snapshot id taken before this action
     kind: ActionKind
-    detail: str             # path written, or the shell command
-    snapshot_before: str    # snapshot id capturing state BEFORE the action
+    detail: str  # path written, or the shell command
+    snapshot_before: str  # snapshot id capturing state BEFORE the action
     reversible: bool = True
-    note: str = ""          # e.g. "escapes workspace: git push"
+    note: str = ""  # e.g. "escapes workspace: git push"
     timestamp: str = ""
 
 

--- a/src/opendot/reversibility/snapshots.py
+++ b/src/opendot/reversibility/snapshots.py
@@ -27,6 +27,7 @@ from pathlib import Path
 # Store location
 # ---------------------------------------------------------------------------
 
+
 def store_root() -> Path:
     """Root of the global opendot store (override with OPENDOT_HOME, for tests)."""
     root = Path(os.environ.get("OPENDOT_HOME", Path.home() / ".opendot"))
@@ -55,9 +56,20 @@ def project_id_for(workdir: str | Path) -> str:
 # Ignore rules
 # ---------------------------------------------------------------------------
 
-_DEFAULT_IGNORE_DIRS = {".git", ".hg", ".svn", "node_modules", "__pycache__",
-                        ".venv", "venv", "env", ".mypy_cache", ".pytest_cache",
-                        ".opendot", ".DS_Store"}
+_DEFAULT_IGNORE_DIRS = {
+    ".git",
+    ".hg",
+    ".svn",
+    "node_modules",
+    "__pycache__",
+    ".venv",
+    "venv",
+    "env",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".opendot",
+    ".DS_Store",
+}
 
 
 @dataclass
@@ -109,6 +121,7 @@ def _clone_or_copy(src: Path, dst: Path) -> None:
         # Python 3.14+ / platforms with clonefile (APFS) or FICLONE (Btrfs/XFS)
         # honor copy-on-write here; elsewhere it's a normal copy.
         import shutil
+
         shutil.copyfile(src, dst)  # uses OS CoW fast-copy when available
     except OSError:
         with open(src, "rb") as fin, open(dst, "wb") as fout:
@@ -147,8 +160,9 @@ _MAX_FILE_BYTES = 25 * 1024 * 1024  # 25 MB
 class FileEntry:
     """One captured file: content hash, POSIX mode bits, and (mtime, size) so a
     later snapshot can skip re-hashing an unchanged file."""
+
     h: str
-    mode: int | None = None   # st_mode & 0o777, or None if unknown (old snapshots)
+    mode: int | None = None  # st_mode & 0o777, or None if unknown (old snapshots)
     mtime: float | None = None
     size: int | None = None
 
@@ -202,8 +216,7 @@ def take_snapshot(workdir: str | Path, rules: IgnoreRules | None = None) -> Snap
         mode = st.st_mode & 0o777
         # Fast path: unchanged since the last snapshot → reuse its hash, no read.
         old = prev.get(rel)
-        if (old is not None and old.mtime == st.st_mtime and old.size == st.st_size
-                and old.h):
+        if old is not None and old.mtime == st.st_mtime and old.size == st.st_size and old.h:
             files[rel] = FileEntry(h=old.h, mode=mode, mtime=st.st_mtime, size=st.st_size)
             continue
         if st.st_size > _MAX_FILE_BYTES:
@@ -216,8 +229,13 @@ def take_snapshot(workdir: str | Path, rules: IgnoreRules | None = None) -> Snap
         files[rel] = FileEntry(h=h, mode=mode, mtime=st.st_mtime, size=st.st_size)
 
     snap_id = _next_snapshot_id(pid)
-    snap = Snapshot(id=snap_id, project_id=pid, workdir=str(wd),
-                    files=files, skipped_large=skipped_large)
+    snap = Snapshot(
+        id=snap_id,
+        project_id=pid,
+        workdir=str(wd),
+        files=files,
+        skipped_large=skipped_large,
+    )
     _write_manifest(snap)
 
     # Bound disk growth: drop this project's oldest snapshots beyond the
@@ -280,7 +298,7 @@ def prune_project_snapshots(project_id: str, keep: int | None = None) -> int:
     ids = list_snapshots(project_id)
     if len(ids) <= keep:
         return 0
-    to_drop = ids[:len(ids) - keep]  # ids are zero-padded, sorted oldest→newest
+    to_drop = ids[: len(ids) - keep]  # ids are zero-padded, sorted oldest→newest
     d = _snapshots_dir(project_id)
     removed = 0
     for sid in to_drop:
@@ -348,10 +366,16 @@ def _write_manifest(snap: Snapshot) -> None:
     path = _snapshots_dir(snap.project_id) / f"{snap.id}.json"
     path.write_text(
         json.dumps(
-            {"id": snap.id, "project_id": snap.project_id, "workdir": snap.workdir,
-             "files": {rel: {"h": e.h, "m": e.mode, "t": e.mtime, "s": e.size}
-                       for rel, e in snap.files.items()},
-             "skipped_large": snap.skipped_large},
+            {
+                "id": snap.id,
+                "project_id": snap.project_id,
+                "workdir": snap.workdir,
+                "files": {
+                    rel: {"h": e.h, "m": e.mode, "t": e.mtime, "s": e.size}
+                    for rel, e in snap.files.items()
+                },
+                "skipped_large": snap.skipped_large,
+            },
             indent=0,
         ),
         encoding="utf-8",
@@ -367,10 +391,14 @@ def load_snapshot(project_id: str, snap_id: str) -> Snapshot:
         if isinstance(v, str):
             files[rel] = FileEntry(h=v, mode=None)
         else:
-            files[rel] = FileEntry(h=v["h"], mode=v.get("m"),
-                                   mtime=v.get("t"), size=v.get("s"))
-    return Snapshot(id=d["id"], project_id=d["project_id"], workdir=d["workdir"],
-                    files=files, skipped_large=d.get("skipped_large", []))
+            files[rel] = FileEntry(h=v["h"], mode=v.get("m"), mtime=v.get("t"), size=v.get("s"))
+    return Snapshot(
+        id=d["id"],
+        project_id=d["project_id"],
+        workdir=d["workdir"],
+        files=files,
+        skipped_large=d.get("skipped_large", []),
+    )
 
 
 def list_snapshots(project_id: str) -> list[str]:
@@ -384,9 +412,18 @@ def list_snapshots(project_id: str) -> list[str]:
 # user must re-run their package manager to actually match it. (Ledger principle:
 # never let "files restored" be mistaken for "environment restored".)
 _LOCKFILES = {
-    "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "npm-shrinkwrap.json",
-    "uv.lock", "poetry.lock", "Pipfile.lock", "requirements.txt",
-    "Cargo.lock", "Gemfile.lock", "composer.lock", "go.sum",
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "npm-shrinkwrap.json",
+    "uv.lock",
+    "poetry.lock",
+    "Pipfile.lock",
+    "requirements.txt",
+    "Cargo.lock",
+    "Gemfile.lock",
+    "composer.lock",
+    "go.sum",
 }
 
 

--- a/src/opendot/tools/composio.py
+++ b/src/opendot/tools/composio.py
@@ -127,7 +127,7 @@ def _revoke_connections(slug: str) -> int:
     except Exception:  # noqa: BLE001
         return 0
     n = 0
-    for acc in (getattr(resp, "items", None) or []):
+    for acc in getattr(resp, "items", None) or []:
         acc_id = getattr(acc, "id", None) or getattr(acc, "nanoid", None)
         if not acc_id:
             continue
@@ -142,6 +142,7 @@ def _revoke_connections(slug: str) -> int:
 def composio_available() -> bool:
     try:
         import composio  # noqa: F401
+
         return True
     except Exception:  # noqa: BLE001
         return False
@@ -159,6 +160,7 @@ def _client():
 
 
 # ---- catalog / connection management (used by the /composio TUI flow) ----
+
 
 def list_apps(search: str | None = None, limit: int = 200) -> list[dict]:
     """Available Composio toolkits: [{slug, name, description}]. Empty on failure."""
@@ -216,9 +218,11 @@ def _friendly_error(exc: Exception) -> str:
     # A read-only key is the common one: it authenticates (apps list fine) but
     # can't create connections. Give the exact fix, not the JSON blob.
     if "InsufficientPermissions" in text or "write access" in text:
-        return ("your Composio API key is read-only — it can't connect apps. "
-                "Create a key with 'connected_accounts' write access in the "
-                "Composio dashboard, then run /composio to re-enter it.")
+        return (
+            "your Composio API key is read-only — it can't connect apps. "
+            "Create a key with 'connected_accounts' write access in the "
+            "Composio dashboard, then run /composio to re-enter it."
+        )
     # Prefer the actionable 'suggested_fix'; fall back to the human 'message'.
     for field in ("suggested_fix", "message"):
         m = re.search(rf"'{field}':\s*'([^']+)'", text)
@@ -261,7 +265,7 @@ def begin_connect(slug: str) -> ConnectResult:
 # execute). The agent discovers the specific tool it needs at runtime via those,
 # and we route calls through `session.execute()`. No cap, nothing truncated.
 
-_SESSION = None            # cached ToolRouterSession
+_SESSION = None  # cached ToolRouterSession
 _SESSION_APPS: tuple = ()  # the enabled-apps set the cached session was built for
 
 
@@ -312,14 +316,16 @@ def build_tool_specs() -> list[dict]:
             continue
         desc = fn.get("description", "") if isinstance(fn, dict) else getattr(fn, "description", "")
         params = fn.get("parameters", {}) if isinstance(fn, dict) else getattr(fn, "parameters", {})
-        specs.append({
-            "type": "function",
-            "function": {
-                "name": _spec_name(name),
-                "description": desc or f"Composio tool {name}",
-                "parameters": params or {"type": "object", "properties": {}},
-            },
-        })
+        specs.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": _spec_name(name),
+                    "description": desc or f"Composio tool {name}",
+                    "parameters": params or {"type": "object", "properties": {}},
+                },
+            }
+        )
     return specs
 
 
@@ -331,10 +337,18 @@ def is_composio_tool(name: str) -> bool:
 # failure (rate limit, bad args). Adapted from Plandot's detect.py. Matched
 # case-insensitively anywhere in the tool output.
 _AUTH_PHRASES = (
-    "not connected", "no active connection", "no connection",
-    "authentication required", "authorization required", "please authorize",
-    "please connect", "not authenticated", "unauthorized", "connect your",
-    "requires authentication", "needs to be connected",
+    "not connected",
+    "no active connection",
+    "no connection",
+    "authentication required",
+    "authorization required",
+    "please authorize",
+    "please connect",
+    "not authenticated",
+    "unauthorized",
+    "connect your",
+    "requires authentication",
+    "needs to be connected",
 )
 
 
@@ -348,7 +362,7 @@ def looks_like_auth_error(text: str) -> bool:
 def execute_tool(name: str, arguments: dict) -> str:
     """Run a Composio Tool Router meta-tool. ``name`` is ``composio__<tool>``;
     execution goes through the session so discovery/scoping is honored."""
-    tool_slug = name[len("composio__"):]
+    tool_slug = name[len("composio__") :]
     session = _session()
     if session is None:
         return "error: Composio session unavailable (not configured?)"
@@ -366,6 +380,8 @@ def execute_tool(name: str, arguments: dict) -> str:
     # If the failure is an auth/connection problem, tell the user how to fix it
     # (connect the app) instead of surfacing a raw "not connected" error.
     if looks_like_auth_error(out):
-        out += ("\n\n[opendot] This looks like an unconnected app — run /composio "
-                "to connect it, then retry.")
+        out += (
+            "\n\n[opendot] This looks like an unconnected app — run /composio "
+            "to connect it, then retry."
+        )
     return out

--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -25,10 +25,15 @@ def _unified_diff(old: str, new: str, path: str, max_lines: int = 200) -> str:
     opendot shows what it changed (not just 'wrote N chars') — that transparency
     is the point. The TUI colors +/- lines; the model reads the same text.
     """
-    diff = list(difflib.unified_diff(
-        old.splitlines(), new.splitlines(),
-        fromfile=f"a/{path}", tofile=f"b/{path}", lineterm="",
-    ))
+    diff = list(
+        difflib.unified_diff(
+            old.splitlines(),
+            new.splitlines(),
+            fromfile=f"a/{path}",
+            tofile=f"b/{path}",
+            lineterm="",
+        )
+    )
     if not diff:
         return "(no change)"
     if len(diff) > max_lines:
@@ -73,8 +78,14 @@ class Toolbox:
     #: tools that only observe — never mutate the filesystem or run commands.
     READ_ONLY = {"list_files", "read_file", "grep", "glob", "read_xlsx", "read_pptx"}
 
-    def __init__(self, workdir: str, reversibility=None, confirm=None,
-                 read_only: bool = False, mcp_manager=None) -> None:
+    def __init__(
+        self,
+        workdir: str,
+        reversibility=None,
+        confirm=None,
+        read_only: bool = False,
+        mcp_manager=None,
+    ) -> None:
         self.workdir = Path(workdir).resolve()
         self.rev = reversibility
         self._confirm = confirm or (lambda prompt: True)
@@ -83,6 +94,7 @@ class Toolbox:
         tools = self._build()
         # Office tools (.xlsx/.pptx) only when the optional deps are installed.
         from opendot.tools.office import build_office_tools
+
         tools += build_office_tools(self)
         if read_only:
             tools = [t for t in tools if t.name in self.READ_ONLY]
@@ -114,7 +126,6 @@ class Toolbox:
 
     def _walk_files(self, base: Path):
         """Yield files under base, skipping ignored dirs (for grep)."""
-        import os
         for dirpath, dirnames, filenames in os.walk(base):
             dirnames[:] = [d for d in dirnames if d not in self._IGNORE]
             for fn in filenames:
@@ -130,7 +141,10 @@ class Toolbox:
                 return str(base)
             entries = []
             for e in sorted(base.iterdir()):
-                if e.name.startswith(".git") or e.name in {"node_modules", "__pycache__"}:
+                if e.name.startswith(".git") or e.name in {
+                    "node_modules",
+                    "__pycache__",
+                }:
                     continue
                 entries.append(e.name + ("/" if e.is_dir() else ""))
             return _truncate("\n".join(entries) or "(empty)")
@@ -175,7 +189,7 @@ class Toolbox:
             for prefix in ("OPENDOT_NO_SNAPSHOT=1 ", "OPENDOT_NO_SNAPSHOT=true "):
                 if stripped.startswith(prefix):
                     no_snapshot = True
-                    command = stripped[len(prefix):]
+                    command = stripped[len(prefix) :]
                     break
 
             # Classify the command: safe/contained vs. irreversible/escaping.
@@ -184,8 +198,7 @@ class Toolbox:
             verdict = classify(command, str(self.workdir))
             if not verdict.reversible:
                 ok = self._confirm(
-                    f"This command may not be undoable ({verdict.reason}):\n"
-                    f"  {command}\nRun it?"
+                    f"This command may not be undoable ({verdict.reason}):\n  {command}\nRun it?"
                 )
                 if not ok:
                     return "skipped: user declined an irreversible command"
@@ -195,13 +208,17 @@ class Toolbox:
             if self.rev is not None:
                 if no_snapshot:
                     self.rev.before_action(
-                        "shell", command, snapshot=False,
+                        "shell",
+                        command,
+                        snapshot=False,
                         note="snapshot skipped (OPENDOT_NO_SNAPSHOT) — not undoable",
                     )
                 else:
                     self.rev.before_action(
-                        "shell", command,
-                        reversible=verdict.reversible, note=verdict.reason,
+                        "shell",
+                        command,
+                        reversible=verdict.reversible,
+                        note=verdict.reason,
                     )
             try:
                 proc = subprocess.run(
@@ -227,6 +244,7 @@ class Toolbox:
         def grep(pattern: str, path: str = ".", max_matches: int = 100) -> str:
             """Search file contents for a regex, returning path:line:text matches."""
             import re
+
             base = self._resolve(path)
             try:
                 rx = re.compile(pattern)
@@ -236,12 +254,16 @@ class Toolbox:
             roots = [base] if base.is_file() else self._walk_files(base)
             for f in roots:
                 try:
-                    for i, line in enumerate(f.read_text(encoding="utf-8", errors="ignore").splitlines(), 1):
+                    for i, line in enumerate(
+                        f.read_text(encoding="utf-8", errors="ignore").splitlines(), 1
+                    ):
                         if rx.search(line):
                             rel = f.relative_to(self.workdir)
                             hits.append(f"{rel}:{i}:{line.strip()[:200]}")
                             if len(hits) >= max_matches:
-                                return _truncate("\n".join(hits) + f"\n... (capped at {max_matches})")
+                                return _truncate(
+                                    "\n".join(hits) + f"\n... (capped at {max_matches})"
+                                )
                 except OSError:
                     continue
             return _truncate("\n".join(hits)) if hits else "no matches"
@@ -249,8 +271,11 @@ class Toolbox:
         def glob(pattern: str) -> str:
             """Find files matching a glob pattern (e.g. '**/*.py')."""
             base = self.workdir
-            matches = [str(p.relative_to(base)) for p in base.glob(pattern)
-                       if p.is_file() and not self._is_ignored(p)]
+            matches = [
+                str(p.relative_to(base))
+                for p in base.glob(pattern)
+                if p.is_file() and not self._is_ignored(p)
+            ]
             return _truncate("\n".join(sorted(matches))) if matches else "no files match"
 
         def edit(path: str, find: str, replace: str, count: int = 0) -> str:
@@ -274,43 +299,108 @@ class Toolbox:
             p.write_text(new, encoding="utf-8")
             replaced = n if count == 0 else min(n, count)
             rel = self._rel(p)
-            return (f"edited {rel} ({replaced} replacement(s))\n"
-                    + _unified_diff(text, new, rel))
+            return f"edited {rel} ({replaced} replacement(s))\n" + _unified_diff(text, new, rel)
 
         return [
             Tool(
-                "list_files", "List files and directories at a path (relative to the working dir).",
-                {"type": "object", "properties": {"path": {"type": "string", "description": "Path to list; defaults to '.'."}}},
+                "list_files",
+                "List files and directories at a path (relative to the working dir).",
+                {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Path to list; defaults to '.'.",
+                        }
+                    },
+                },
                 list_files,
             ),
             Tool(
-                "read_file", "Read a text file's contents.",
-                {"type": "object", "properties": {"path": {"type": "string"}}, "required": ["path"]},
+                "read_file",
+                "Read a text file's contents.",
+                {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                },
                 read_file,
             ),
             Tool(
-                "write_file", "Create or overwrite a file with the given content.",
-                {"type": "object", "properties": {"path": {"type": "string"}, "content": {"type": "string"}}, "required": ["path", "content"]},
+                "write_file",
+                "Create or overwrite a file with the given content.",
+                {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                        "content": {"type": "string"},
+                    },
+                    "required": ["path", "content"],
+                },
                 write_file,
             ),
             Tool(
-                "run_shell", "Run a shell command in the working directory (npm, git, build, mv, cp, etc.).",
-                {"type": "object", "properties": {"command": {"type": "string"}, "timeout": {"type": "integer", "description": "Seconds before timeout (default 120)."}}, "required": ["command"]},
+                "run_shell",
+                "Run a shell command in the working directory (npm, git, build, mv, cp, etc.).",
+                {
+                    "type": "object",
+                    "properties": {
+                        "command": {"type": "string"},
+                        "timeout": {
+                            "type": "integer",
+                            "description": "Seconds before timeout (default 120).",
+                        },
+                    },
+                    "required": ["command"],
+                },
                 run_shell,
             ),
             Tool(
-                "grep", "Search file contents for a regular expression. Returns path:line:text matches.",
-                {"type": "object", "properties": {"pattern": {"type": "string"}, "path": {"type": "string", "description": "Dir or file to search (default '.')."}, "max_matches": {"type": "integer"}}, "required": ["pattern"]},
+                "grep",
+                "Search file contents for a regular expression. Returns path:line:text matches.",
+                {
+                    "type": "object",
+                    "properties": {
+                        "pattern": {"type": "string"},
+                        "path": {
+                            "type": "string",
+                            "description": "Dir or file to search (default '.').",
+                        },
+                        "max_matches": {"type": "integer"},
+                    },
+                    "required": ["pattern"],
+                },
                 grep,
             ),
             Tool(
-                "glob", "Find files matching a glob pattern, e.g. '**/*.py' or 'src/*.ts'.",
-                {"type": "object", "properties": {"pattern": {"type": "string"}}, "required": ["pattern"]},
+                "glob",
+                "Find files matching a glob pattern, e.g. '**/*.py' or 'src/*.ts'.",
+                {
+                    "type": "object",
+                    "properties": {"pattern": {"type": "string"}},
+                    "required": ["pattern"],
+                },
                 glob,
             ),
             Tool(
-                "edit", "Make a targeted find-and-replace edit in a file (surgical, undoable). Prefer this over rewriting whole files.",
-                {"type": "object", "properties": {"path": {"type": "string"}, "find": {"type": "string", "description": "Exact text to find."}, "replace": {"type": "string"}, "count": {"type": "integer", "description": "Max replacements; 0 = all (default)."}}, "required": ["path", "find", "replace"]},
+                "edit",
+                "Make a targeted find-and-replace edit in a file (surgical, undoable). Prefer this over rewriting whole files.",
+                {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                        "find": {
+                            "type": "string",
+                            "description": "Exact text to find.",
+                        },
+                        "replace": {"type": "string"},
+                        "count": {
+                            "type": "integer",
+                            "description": "Max replacements; 0 = all (default).",
+                        },
+                    },
+                    "required": ["path", "find", "replace"],
+                },
                 edit,
             ),
         ]
@@ -319,24 +409,28 @@ class Toolbox:
         specs = [t.spec() for t in self._tools.values()]
         # External MCP tools, namespaced mcp__server__tool.
         for mt in self._mcp_tools.values():
-            specs.append({
-                "type": "function",
-                "function": {
-                    "name": mt.qualified,
-                    "description": f"[MCP:{mt.server}] {mt.description}",
-                    "parameters": mt.input_schema,
-                },
-            })
+            specs.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": mt.qualified,
+                        "description": f"[MCP:{mt.server}] {mt.description}",
+                        "parameters": mt.input_schema,
+                    },
+                }
+            )
         # External Composio tools — the Tool Router keeps this a small, bounded
         # meta-tool set, so we don't need a total-count cap here.
         if not self.read_only:
             from opendot.tools import composio as composio_tools
+
             specs.extend(composio_tools.build_tool_specs())
         return specs
 
     def call(self, name: str, args: dict[str, Any]) -> str:
         # Composio tools are external + opaque like MCP: confirm + mark irreversible.
         from opendot.tools import composio as composio_tools
+
         if composio_tools.is_composio_tool(name):
             reason = "external Composio tool — opendot cannot undo it"
             if not self._confirm(f"Run {name}?  {reason}"):

--- a/src/opendot/tools/office.py
+++ b/src/opendot/tools/office.py
@@ -14,13 +14,14 @@ aren't installed, the tools aren't registered (see build_office_tools).
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 
 def office_available() -> bool:
     try:
         import openpyxl  # noqa: F401
         import pptx  # noqa: F401
+
         return True
     except ImportError:
         return False
@@ -40,14 +41,17 @@ def build_office_tools(box) -> list:
     # ---- xlsx ----
     def read_xlsx(path: str, sheet: str | None = None, max_rows: int = 100) -> str:
         import openpyxl
+
         p = box._resolve(path)
         if not p.exists():
             return f"error: file not found: {p}"
         wb = openpyxl.load_workbook(p, data_only=True)
         names = wb.sheetnames
         ws = wb[sheet] if sheet else wb[names[0]]
-        lines = [f"workbook {box._rel(p)}  sheets: {', '.join(names)}",
-                 f"sheet '{ws.title}'  ({ws.max_row} rows x {ws.max_column} cols)"]
+        lines = [
+            f"workbook {box._rel(p)}  sheets: {', '.join(names)}",
+            f"sheet '{ws.title}'  ({ws.max_row} rows x {ws.max_column} cols)",
+        ]
         for r, row in enumerate(ws.iter_rows(values_only=True), 1):
             if r > max_rows:
                 lines.append(f"... ({ws.max_row - max_rows} more rows)")
@@ -58,6 +62,7 @@ def build_office_tools(box) -> list:
 
     def edit_cell(path: str, cell: str, value: str, sheet: str | None = None) -> str:
         import openpyxl
+
         p = box._resolve(path)
         if not p.exists():
             return f"error: file not found: {p}"
@@ -82,20 +87,23 @@ def build_office_tools(box) -> list:
     # ---- pptx ----
     def read_pptx(path: str) -> str:
         from pptx import Presentation
+
         p = box._resolve(path)
         if not p.exists():
             return f"error: file not found: {p}"
         prs = Presentation(str(p))
         lines = [f"presentation {box._rel(p)}  ({len(prs.slides)} slides)"]
         for i, slide in enumerate(prs.slides, 1):
-            texts = [sh.text.strip() for sh in slide.shapes
-                     if sh.has_text_frame and sh.text.strip()]
+            texts = [
+                sh.text.strip() for sh in slide.shapes if sh.has_text_frame and sh.text.strip()
+            ]
             lines.append(f"— slide {i} —")
             lines.extend(f"   {t}" for t in texts)
         return _truncate("\n".join(lines))
 
     def edit_pptx_text(path: str, find: str, replace: str) -> str:
         from pptx import Presentation
+
         p = box._resolve(path)
         if not p.exists():
             return f"error: file not found: {p}"
@@ -117,16 +125,60 @@ def build_office_tools(box) -> list:
         return f"{box._rel(p)}: replaced {find!r} → {replace!r} in {hits} run(s)"
 
     return [
-        Tool("read_xlsx", "Read an .xlsx spreadsheet: lists sheets and prints a sheet's cells as rows.",
-             {"type": "object", "properties": {"path": {"type": "string"}, "sheet": {"type": "string"}, "max_rows": {"type": "integer"}}, "required": ["path"]},
-             read_xlsx),
-        Tool("edit_cell", "Set one cell in an .xlsx (e.g. cell 'B4'). Numbers/formulas handled. Undoable.",
-             {"type": "object", "properties": {"path": {"type": "string"}, "cell": {"type": "string", "description": "A1-style ref, e.g. 'B4'."}, "value": {"type": "string"}, "sheet": {"type": "string"}}, "required": ["path", "cell", "value"]},
-             edit_cell),
-        Tool("read_pptx", "Read a .pptx presentation: outputs each slide's text outline.",
-             {"type": "object", "properties": {"path": {"type": "string"}}, "required": ["path"]},
-             read_pptx),
-        Tool("edit_pptx_text", "Find-and-replace text across all slides of a .pptx. Undoable.",
-             {"type": "object", "properties": {"path": {"type": "string"}, "find": {"type": "string"}, "replace": {"type": "string"}}, "required": ["path", "find", "replace"]},
-             edit_pptx_text),
+        Tool(
+            "read_xlsx",
+            "Read an .xlsx spreadsheet: lists sheets and prints a sheet's cells as rows.",
+            {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "sheet": {"type": "string"},
+                    "max_rows": {"type": "integer"},
+                },
+                "required": ["path"],
+            },
+            read_xlsx,
+        ),
+        Tool(
+            "edit_cell",
+            "Set one cell in an .xlsx (e.g. cell 'B4'). Numbers/formulas handled. Undoable.",
+            {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "cell": {
+                        "type": "string",
+                        "description": "A1-style ref, e.g. 'B4'.",
+                    },
+                    "value": {"type": "string"},
+                    "sheet": {"type": "string"},
+                },
+                "required": ["path", "cell", "value"],
+            },
+            edit_cell,
+        ),
+        Tool(
+            "read_pptx",
+            "Read a .pptx presentation: outputs each slide's text outline.",
+            {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            },
+            read_pptx,
+        ),
+        Tool(
+            "edit_pptx_text",
+            "Find-and-replace text across all slides of a .pptx. Undoable.",
+            {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "find": {"type": "string"},
+                    "replace": {"type": "string"},
+                },
+                "required": ["path", "find", "replace"],
+            },
+            edit_pptx_text,
+        ),
     ]

--- a/src/opendot/tui/__init__.py
+++ b/src/opendot/tui/__init__.py
@@ -10,10 +10,17 @@ Split across submodules for readability:
 
 from opendot.tui.app import OpendotTUI, run_tui
 from opendot.tui.modals import (
-    ApiKeyModal, ConfirmModal, McpAddModal, SearchListModal,
+    ApiKeyModal,
+    ConfirmModal,
+    McpAddModal,
+    SearchListModal,
 )
 
 __all__ = [
-    "OpendotTUI", "run_tui",
-    "ApiKeyModal", "ConfirmModal", "McpAddModal", "SearchListModal",
+    "OpendotTUI",
+    "run_tui",
+    "ApiKeyModal",
+    "ConfirmModal",
+    "McpAddModal",
+    "SearchListModal",
 ]

--- a/src/opendot/tui/app.py
+++ b/src/opendot/tui/app.py
@@ -110,7 +110,7 @@ class OpendotTUI(App):
             return False
 
     def compose(self) -> ComposeResult:
-        from textual.containers import Center, Vertical
+        from textual.containers import Center
         from textual.widgets import OptionList
 
         yield Header(show_clock=False)
@@ -146,6 +146,7 @@ class OpendotTUI(App):
         of showing a black box."""
         try:
             from textual_image.widget import Image
+
             if _LOGO_PATH.exists():
                 return Image(self._logo_on_theme_bg(), id="welcome")
         except Exception:  # noqa: BLE001 - any failure → text fallback
@@ -162,6 +163,7 @@ class OpendotTUI(App):
         we leave the PNG transparent and let the image protocol composite it."""
         try:
             from PIL import Image as PILImage
+
             logo = PILImage.open(_LOGO_PATH).convert("RGBA")
             bbox = logo.getbbox()  # tight box around non-transparent pixels
             if bbox:
@@ -182,6 +184,7 @@ class OpendotTUI(App):
         background keeps matching the (possibly light) screen. Only matters
         while the welcome screen is still up — it's gone after the first message.
         Recomposites in place (Image.image is settable) to avoid a widget swap."""
+
         def _rebuild():
             try:
                 if not self.screen.has_class("-welcome"):
@@ -198,9 +201,11 @@ class OpendotTUI(App):
 
     def _mode_line(self):
         return Text.assemble(
-            ("  esc ", "bold cyan"), ("interrupt", "dim"),
+            ("  esc ", "bold cyan"),
+            ("interrupt", "dim"),
             ("  ·  ", "dim"),
-            ("ctrl+p ", "bold cyan"), ("commands", "dim"),
+            ("ctrl+p ", "bold cyan"),
+            ("commands", "dim"),
         )
 
     def _dismiss_welcome(self) -> None:
@@ -244,6 +249,7 @@ class OpendotTUI(App):
     # -- slash-command autocomplete --
     def _popup(self):
         from textual.widgets import OptionList
+
         return self.query_one("#cmdpopup", OptionList)
 
     @property
@@ -272,7 +278,9 @@ class OpendotTUI(App):
         # ACTUAL width at render time — no manual padding that can overshoot the
         # width and wrap the description onto a second line.
         for name, desc in matches:
-            popup.add_option(Option(_row_bar(name, desc, right_style="dim", left_style="bold"), id=name))
+            popup.add_option(
+                Option(_row_bar(name, desc, right_style="dim", left_style="bold"), id=name)
+            )
         popup.highlighted = 0
         # Float it just above the input (after layout settles so heights are known).
         self.call_after_refresh(self._position_popup)
@@ -328,13 +336,21 @@ class OpendotTUI(App):
             return
         popup = self._popup()
         if event.key == "down":
-            popup.action_cursor_down(); event.stop(); event.prevent_default()
+            popup.action_cursor_down()
+            event.stop()
+            event.prevent_default()
         elif event.key == "up":
-            popup.action_cursor_up(); event.stop(); event.prevent_default()
+            popup.action_cursor_up()
+            event.stop()
+            event.prevent_default()
         elif event.key == "tab":
-            self._accept_popup(run=False); event.stop(); event.prevent_default()
+            self._accept_popup(run=False)
+            event.stop()
+            event.prevent_default()
         elif event.key == "escape":
-            popup.display = False; event.stop(); event.prevent_default()
+            popup.display = False
+            event.stop()
+            event.prevent_default()
 
     # -- input handling --
     async def on_input_submitted(self, event: Input.Submitted) -> None:
@@ -370,6 +386,7 @@ class OpendotTUI(App):
         # Header: system username + local time, then the message.
         import datetime
         import getpass
+
         try:
             who = getpass.getuser()
         except Exception:  # noqa: BLE001
@@ -394,16 +411,23 @@ class OpendotTUI(App):
         """If the current model needs an API key that isn't set, write a friendly
         hint to the transcript and return True (so the caller skips the turn)."""
         import os
+
         from opendot.providers import env_var_for
 
         var = env_var_for(self.agent.config.model)
         if not var or os.environ.get(var):
             return False
-        self._write(Text.assemble(
-            ("no API key for ", "yellow"), (self.agent.config.model, "bold yellow"), ("\n", ""),
-            (f"Set {var}, or run ", "dim"), ("/provider", "bold"),
-            (" to paste one. Keys: github.com/vedaant00/opendot#any-model", "dim"),
-        ), "err")
+        self._write(
+            Text.assemble(
+                ("no API key for ", "yellow"),
+                (self.agent.config.model, "bold yellow"),
+                ("\n", ""),
+                (f"Set {var}, or run ", "dim"),
+                ("/provider", "bold"),
+                (" to paste one. Keys: github.com/vedaant00/opendot#any-model", "dim"),
+            ),
+            "err",
+        )
         return True
 
     def _slash(self, text: str) -> None:
@@ -411,7 +435,10 @@ class OpendotTUI(App):
         cmd = cmd.lower()
         a = self.agent
         if cmd == "help":
-            self._write("commands: /log /undo [id] /clear /compact /model /provider /mcp /composio /help", "sys")
+            self._write(
+                "commands: /log /undo [id] /clear /compact /model /provider /mcp /composio /help",
+                "sys",
+            )
         elif cmd == "clear":
             a.reset()
             self._clear_transcript()
@@ -448,14 +475,17 @@ class OpendotTUI(App):
         self._write(f"model → {model}", "sys")
         self._refresh_sidebar()
         # Nudge if the key for this model isn't set yet.
-        from opendot.providers import env_var_for
         import os
+
+        from opendot.providers import env_var_for
+
         var = env_var_for(model)
         if var and not os.environ.get(var):
             self._write(f"note: {var} is not set — use /provider to connect.", "sys")
 
     async def _pick_model(self) -> None:
         import asyncio
+
         from opendot import catalog
 
         # Text chat models from LiteLLM's registry, grouped by provider.
@@ -471,6 +501,7 @@ class OpendotTUI(App):
 
     async def _connect_provider(self) -> None:
         import asyncio
+
         from opendot.providers import connectable_providers, register_key
 
         # LiteLLM-routable providers that have text models (from the catalog).
@@ -499,9 +530,7 @@ class OpendotTUI(App):
         # Build the list: each server with a status glyph, then an Add entry.
         items: list[tuple[str, str, str]] = []
         for name, spec in servers.items():
-            target = spec.get("url") or " ".join(
-                [spec.get("command", "")] + spec.get("args", [])
-            )
+            target = spec.get("url") or " ".join([spec.get("command", "")] + spec.get("args", []))
             if name in connected:
                 n = sum(1 for mt in mgr.tools if mt.server == name)
                 status = f"✓ {n} tools"
@@ -566,7 +595,10 @@ class OpendotTUI(App):
         if not apps:
             # Most likely a bad/expired key (it was stored without validation in
             # older versions). Offer to re-enter it instead of dead-ending.
-            self._write("couldn't load Composio apps — your key may be invalid or expired.", "sys")
+            self._write(
+                "couldn't load Composio apps — your key may be invalid or expired.",
+                "sys",
+            )
             if await self._enter_composio_key(cx):
                 apps = await asyncio.to_thread(cx.list_apps)
             if not apps:
@@ -579,7 +611,9 @@ class OpendotTUI(App):
         items: list[tuple[str, str, str, str]] = []
         for app in apps:
             slug = app["slug"]
-            status = "✓ enabled" if slug in enabled else ("· connected" if slug in connected else "")
+            status = (
+                "✓ enabled" if slug in enabled else ("· connected" if slug in connected else "")
+            )
             label = f"{app['name']}   {slug}"
             items.append((slug, label, "Apps", status))
 
@@ -589,11 +623,15 @@ class OpendotTUI(App):
 
         # Already enabled → offer to disable it (remove from opendot's tool set).
         if slug in enabled:
-            choice = await self.push_screen_wait(SearchListModal(
-                f"{slug} — enabled",
-                [("disable", f"Disconnect {slug}", "Manage"),
-                 ("keep", "Keep it enabled", "Manage")],
-            ))
+            choice = await self.push_screen_wait(
+                SearchListModal(
+                    f"{slug} — enabled",
+                    [
+                        ("disable", f"Disconnect {slug}", "Manage"),
+                        ("keep", "Keep it enabled", "Manage"),
+                    ],
+                )
+            )
             if choice == "disable":
                 revoked = await asyncio.to_thread(cx.disable_app, slug)
                 note = "connection revoked" if revoked else "removed locally"
@@ -622,8 +660,7 @@ class OpendotTUI(App):
                 return
         cx.add_enabled_app(slug)
         self._write(
-            f"✓ {slug} connected and enabled. Its tools load on next launch "
-            f"(restart opendot).",
+            f"✓ {slug} connected and enabled. Its tools load on next launch (restart opendot).",
             "sys",
         )
         self._refresh_sidebar()
@@ -635,6 +672,7 @@ class OpendotTUI(App):
         def flush_answer():
             if buf:
                 from rich.console import Group
+
                 self._write(
                     Group(Text("opendot", style="bold green"), Markdown("".join(buf))),
                     "answer",
@@ -653,7 +691,8 @@ class OpendotTUI(App):
                     mode = "answer"
                     buf.append(ev.text)
                 elif ev.type == "tool_start":
-                    flush_answer(); mode = None
+                    flush_answer()
+                    mode = None
                     args = "  ".join(str(v)[:50] for v in ev.args.values())
                     line = Text("→ ", style="dim").append(ev.tool, style="bold")
                     if args:
@@ -663,15 +702,26 @@ class OpendotTUI(App):
                     self._write(_render_tool_result(ev.tool, ev.result), "toolout")
                     self._refresh_sidebar()
                 elif ev.type == "explorer_start":
-                    flush_answer(); mode = None
-                    self._write(Text(f"⇉ explorer {ev.lane + 1}: {ev.text}", style="bold magenta"), "tool")
+                    flush_answer()
+                    mode = None
+                    self._write(
+                        Text(f"⇉ explorer {ev.lane + 1}: {ev.text}", style="bold magenta"),
+                        "tool",
+                    )
                 elif ev.type == "explorer_step":
-                    self._write(Text(f"    [{ev.lane + 1}] {ev.text}", style="magenta"), "toolout")
+                    self._write(
+                        Text(f"    [{ev.lane + 1}] {ev.text}", style="magenta"),
+                        "toolout",
+                    )
                 elif ev.type == "explorer_done":
                     first = (ev.text.strip().splitlines() or ["(done)"])[0]
-                    self._write(Text(f"    [{ev.lane + 1}] ✓ {first[:100]}", style="dim magenta"), "toolout")
+                    self._write(
+                        Text(f"    [{ev.lane + 1}] ✓ {first[:100]}", style="dim magenta"),
+                        "toolout",
+                    )
                 elif ev.type == "error":
-                    flush_answer(); mode = None
+                    flush_answer()
+                    mode = None
                     self._write(Text(ev.text), "err")
             flush_answer()
         finally:
@@ -711,7 +761,7 @@ class OpendotTUI(App):
             changed_locks = rev.last_changed_lockfiles
             what = f"the last action ({undone.kind}: {undone.detail.rsplit('/', 1)[-1]})"
 
-        self._write(f"↺ reverted {what}", "sys")   # immediate, deterministic ack
+        self._write(f"↺ reverted {what}", "sys")  # immediate, deterministic ack
         self._refresh_sidebar()
         # Then the agent narrates the undo (and, per its system prompt, loudly
         # warns about environment drift when a lockfile changed). Detection is
@@ -743,10 +793,12 @@ class OpendotTUI(App):
         if not rev.history():
             self._write("no actions to clear", "sys")
             return
-        ok = await self.push_screen_wait(ConfirmModal(
-            "Clear the action ledger for this project?\n"
-            "This discards the undo history — past actions can no longer be undone."
-        ))
+        ok = await self.push_screen_wait(
+            ConfirmModal(
+                "Clear the action ledger for this project?\n"
+                "This discards the undo history — past actions can no longer be undone."
+            )
+        )
         if not ok:
             return
         n = rev.clear_history()

--- a/src/opendot/tui/helpers.py
+++ b/src/opendot/tui/helpers.py
@@ -4,19 +4,21 @@ and the app can import from here."""
 
 from __future__ import annotations
 
-from pathlib import Path
-
-from rich.text import Text
-
 # Pre-warm textual-image's terminal capability probe at import time — i.e. BEFORE
 # the Textual app puts the terminal in raw mode and focuses the input. The probe
 # sends a Device Attributes query ("\e[c") and reads the reply; if it runs later
 # (lazily during compose), that reply ("^[?1;2c") leaks into the focused input.
 # Guarded to a real TTY so it never hangs in tests / piped / one-shot mode.
 import sys as _sys
+from pathlib import Path
+
+from rich.text import Text
+
 try:
     if _sys.stdin.isatty() and _sys.stdout.isatty():
-        from textual_image.widget import Image as _ProbeImage  # noqa: F401 - import triggers the probe
+        from textual_image.widget import (
+            Image as _ProbeImage,  # noqa: F401 - import triggers the probe
+        )
 except Exception:  # noqa: BLE001 - probe/import failure must never block startup
     pass
 

--- a/src/opendot/tui/modals.py
+++ b/src/opendot/tui/modals.py
@@ -10,7 +10,7 @@ from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Static
 
-from opendot.tui.helpers import _title_bar, _row_bar
+from opendot.tui.helpers import _row_bar, _title_bar
 
 
 class ConfirmModal(ModalScreen[bool]):
@@ -31,10 +31,13 @@ class ConfirmModal(ModalScreen[bool]):
 
     def compose(self) -> ComposeResult:
         with Vertical(id="box"):
-            yield Static(Text.assemble(
-                ("⚠ irreversible action\n\n", "bold yellow"),
-                (self._prompt, ""),
-            ), id="q")
+            yield Static(
+                Text.assemble(
+                    ("⚠ irreversible action\n\n", "bold yellow"),
+                    (self._prompt, ""),
+                ),
+                id="q",
+            )
             with Horizontal(id="buttons"):
                 yield Button("Run it", variant="error", id="yes")
                 yield Button("Skip", variant="primary", id="no")
@@ -93,7 +96,7 @@ class SearchListModal(ModalScreen[str | None]):
         ol.clear_options()
         last_group = None
         self._values: list[str] = []
-        row_index = 0          # index into the OptionList (headers included)
+        row_index = 0  # index into the OptionList (headers included)
         first_selectable = None  # index of the first non-disabled (data) row
         for item in self._items:
             value, label, group = item[0], item[1], item[2]
@@ -202,7 +205,10 @@ class McpAddModal(ModalScreen[dict | None]):
         with Vertical(id="box"):
             yield Static(_title_bar("Add an MCP server"), id="title")
             yield Input(placeholder="name (e.g. github, supabase)", id="name")
-            yield Input(placeholder="https://…/mcp   OR   npx -y @scope/server args…", id="target")
+            yield Input(
+                placeholder="https://…/mcp   OR   npx -y @scope/server args…",
+                id="target",
+            )
             yield Input(placeholder="Authorization header (remote only, optional)", id="header")
             yield Static(
                 "enter submit · a value starting with http(s):// is treated as a remote URL",

--- a/src/opendot/tui/sidebar.py
+++ b/src/opendot/tui/sidebar.py
@@ -62,7 +62,9 @@ class Sidebar(Static):
         # -- Providers (which API keys are set this session) --
         try:
             import os
+
             from opendot.providers import known_key_vars
+
             connected_providers = [var for var in known_key_vars() if os.environ.get(var)]
         except Exception:  # noqa: BLE001
             connected_providers = []
@@ -79,6 +81,7 @@ class Sidebar(Static):
         # -- Composio (show once a key is set; then list enabled apps) --
         try:
             from opendot.tools import composio as composio_tools
+
             cx_configured = composio_tools.is_configured()
             capps = composio_tools.enabled_apps()
         except Exception:  # noqa: BLE001

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -9,7 +9,6 @@ import pytest
 
 from opendot import catalog
 
-
 FAKE_MODEL_COST = {
     "sample_spec": {"mode": "chat", "litellm_provider": "openai"},
     "gpt-4o": {"mode": "chat", "litellm_provider": "openai"},
@@ -17,7 +16,10 @@ FAKE_MODEL_COST = {
     "whisper-1": {"mode": "audio_transcription", "litellm_provider": "openai"},
     # bare key (as LiteLLM's registry actually stores it) — must get prefixed
     "deepseek-chat": {"mode": "chat", "litellm_provider": "deepseek"},
-    "obscure/model": {"mode": "chat", "litellm_provider": "obscureproxy"},  # not routable
+    "obscure/model": {
+        "mode": "chat",
+        "litellm_provider": "obscureproxy",
+    },  # not routable
 }
 
 
@@ -40,8 +42,8 @@ def test_list_models_text_only():
     # other providers get prefixed so they're routable.
     assert "gpt-4o" in models
     assert "deepseek/deepseek-chat" in models
-    assert "dall-e-3" not in models        # image
-    assert "whisper-1" not in models       # audio
+    assert "dall-e-3" not in models  # image
+    assert "whisper-1" not in models  # audio
     assert "sample_spec" not in models
 
 
@@ -50,14 +52,14 @@ def test_bare_provider_model_is_prefixed_for_routing():
     deepseek) must be returned prefixed, or auto-switch produces an unroutable
     'LLM Provider NOT provided' string. openai/anthropic stay bare."""
     by_name = {m["name"]: m["model"] for m in catalog.list_models()}
-    assert by_name["gpt-4o"] == "gpt-4o"                # bare-ok provider, untouched
+    assert by_name["gpt-4o"] == "gpt-4o"  # bare-ok provider, untouched
     # a bare non-openai/anthropic key gets prefixed so it's routable
     assert by_name["deepseek-chat"] == "deepseek/deepseek-chat"
 
 
 def test_list_models_only_routable_providers():
     models = {m["model"] for m in catalog.list_models()}
-    assert "obscure/model" not in models   # provider not in provider_list
+    assert "obscure/model" not in models  # provider not in provider_list
 
 
 def test_list_providers():
@@ -74,6 +76,7 @@ def test_default_model_for_env():
 def test_unavailable_litellm_returns_empty(monkeypatch):
     def boom():
         raise ImportError("no litellm")
+
     monkeypatch.setattr(catalog, "_litellm", boom)
     assert catalog.list_models() == []
     assert catalog.list_providers() == []

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -16,6 +16,7 @@ def _rev(cmd):
 
 # --- should be flagged irreversible (needs confirm) ---
 
+
 def test_sudo_flagged():
     assert not _rev("sudo rm -rf /var")
 
@@ -76,6 +77,7 @@ def test_unknown_command_fails_safe():
 
 # --- should be allowed (reversible via snapshot / read-only) ---
 
+
 def test_readonly_allowed():
     assert _rev("ls -la")
     assert _rev("cat file.py")
@@ -87,7 +89,7 @@ def test_inworkspace_mutations_allowed():
     assert _rev("touch new.txt")
     assert _rev("mkdir subdir")
     assert _rev("echo hi > out.txt")
-    assert _rev("rm old.txt")            # in-workspace rm: snapshot covers it
+    assert _rev("rm old.txt")  # in-workspace rm: snapshot covers it
     assert _rev("python script.py")
 
 

--- a/tests/test_composio.py
+++ b/tests/test_composio.py
@@ -50,8 +50,8 @@ def test_disable_app_removes_locally_and_invalidates_session():
     cx._SESSION = object()  # pretend a session was cached
     revoked = cx.disable_app("gmail")
     assert "gmail" not in cx.enabled_apps()
-    assert revoked == 0            # fake key → no real deletion
-    assert cx._SESSION is None     # cache invalidated
+    assert revoked == 0  # fake key → no real deletion
+    assert cx._SESSION is None  # cache invalidated
 
     # revoke=False skips the network call entirely
     cx.add_enabled_app("slack")
@@ -65,7 +65,9 @@ def test_verify_api_key_accepts_working_key_and_rejects_bad(monkeypatch):
     import composio
 
     class _Toolkits:
-        def __init__(self, ok): self._ok = ok
+        def __init__(self, ok):
+            self._ok = ok
+
         def list(self, **_):
             if not self._ok:
                 raise RuntimeError("401 Unauthorized")

--- a/tests/test_explorers.py
+++ b/tests/test_explorers.py
@@ -5,8 +5,6 @@ import asyncio
 import pytest
 
 from opendot.tools.local import Toolbox
-from opendot.reversibility.engine import Reversibility
-from opendot.reversibility.snapshots import IgnoreRules
 
 
 @pytest.fixture(autouse=True)
@@ -45,6 +43,7 @@ async def test_explorers_run_parallel_readonly_and_return_findings(tmp_path, mon
         def __init__(self, config=None, confirm=None):
             self.config = config
             from opendot.tools.local import Toolbox
+
             self.toolbox = Toolbox(config.workdir, read_only=True)
 
         async def run(self, task):
@@ -78,6 +77,4 @@ async def test_explorers_run_parallel_readonly_and_return_findings(tmp_path, mon
     assert order[0].startswith("start") and order[1].startswith("start")
 
     # nothing was written anywhere (read-only)
-    assert not any(tmp_path.iterdir()) or all(
-        p.name == "store" for p in tmp_path.iterdir()
-    )
+    assert not any(tmp_path.iterdir()) or all(p.name == "store" for p in tmp_path.iterdir())

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -4,9 +4,9 @@ import json
 
 import pytest
 
-from opendot.tools.local import Toolbox
 from opendot.reversibility.engine import Reversibility
 from opendot.reversibility.snapshots import IgnoreRules
+from opendot.tools.local import Toolbox
 
 
 @pytest.fixture(autouse=True)
@@ -17,25 +17,36 @@ def isolated_store(tmp_path, monkeypatch):
 
 def test_load_mcp_config(tmp_path, monkeypatch):
     from opendot.mcp.manager import load_mcp_config
+
     store = tmp_path / "store"
     store.mkdir(parents=True)
-    (store / "mcp.json").write_text(json.dumps(
-        {"mcpServers": {"github": {"command": "x"}}}))
+    (store / "mcp.json").write_text(json.dumps({"mcpServers": {"github": {"command": "x"}}}))
     assert "github" in load_mcp_config()
 
 
 def test_missing_config_is_empty(tmp_path):
     from opendot.mcp.manager import load_mcp_config
+
     assert load_mcp_config() == {}
 
 
 class _FakeMCP:
     """Stand-in MCPManager: exposes one tool, records calls."""
+
     def __init__(self):
         from opendot.mcp.manager import MCPTool
-        self.tools = [MCPTool(server="stub", name="greet",
-                              description="say hi",
-                              input_schema={"type": "object", "properties": {"name": {"type": "string"}}})]
+
+        self.tools = [
+            MCPTool(
+                server="stub",
+                name="greet",
+                description="say hi",
+                input_schema={
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                },
+            )
+        ]
         self.connected = ["stub"]
         self.errors = {}
         self.calls = []
@@ -60,8 +71,8 @@ def test_mcp_call_declined_by_confirm(tmp_path):
     tb, rev = _tb(tmp_path, lambda p: False)
     out = tb.call("mcp__stub__greet", {"name": "x"})
     assert "declined" in out
-    assert tb.mcp.calls == []           # never actually called
-    assert rev.history() == []          # nothing logged
+    assert tb.mcp.calls == []  # never actually called
+    assert rev.history() == []  # nothing logged
 
 
 def test_mcp_call_approved_runs_and_logs_irreversible(tmp_path):
@@ -70,7 +81,7 @@ def test_mcp_call_approved_runs_and_logs_irreversible(tmp_path):
     assert out == "hi!"
     assert tb.mcp.calls == [("stub", "greet", {"name": "world"})]
     entry = rev.history()[-1]
-    assert entry.reversible is False    # MCP calls are marked irreversible
+    assert entry.reversible is False  # MCP calls are marked irreversible
     assert "MCP" in entry.note
 
 
@@ -78,7 +89,7 @@ def test_mcp_hidden_from_readonly_explorer(tmp_path):
     rev = Reversibility(workdir=str(tmp_path), rules=IgnoreRules())
     tb = Toolbox(str(tmp_path), reversibility=rev, read_only=True, mcp_manager=_FakeMCP())
     names = {s["function"]["name"] for s in tb.specs()}
-    assert "mcp__stub__greet" not in names   # explorers can't call external tools
+    assert "mcp__stub__greet" not in names  # explorers can't call external tools
 
 
 def test_config_add_list_remove(tmp_path):
@@ -89,7 +100,7 @@ def test_config_add_list_remove(tmp_path):
 
     cfg = load_mcp_config()
     assert cfg["stdio1"]["command"] == "some-cmd"
-    assert cfg["stdio1"]["args"] == ["-y", "pkg"]     # command flags preserved
+    assert cfg["stdio1"]["args"] == ["-y", "pkg"]  # command flags preserved
     assert cfg["stdio1"]["env"] == {"K": "v"}
     assert cfg["remote1"]["url"] == "https://example.com/mcp"
 
@@ -102,11 +113,15 @@ def test_mcp_add_cli_parses_flags_vs_command(tmp_path, monkeypatch):
     """`opendot mcp add NAME --env K=V -- cmd -y pkg` must keep -y in the command,
     not treat it as an opendot flag (the bug that used to launch the TUI)."""
     import sys
+
     from opendot import cli
     from opendot.mcp.manager import load_mcp_config
 
-    monkeypatch.setattr(sys, "argv",
-                        ["opendot", "mcp", "add", "s", "--env", "K=v", "--", "cmd", "-y", "pkg"])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["opendot", "mcp", "add", "s", "--env", "K=v", "--", "cmd", "-y", "pkg"],
+    )
     cli.main()
     cfg = load_mcp_config()
     assert cfg["s"] == {"command": "cmd", "args": ["-y", "pkg"], "env": {"K": "v"}}
@@ -116,15 +131,25 @@ def test_mcp_add_remote_with_header(tmp_path, monkeypatch):
     """`opendot mcp add NAME --url <u> --header 'Authorization=Bearer x'` stores
     the header so authenticated remote servers (e.g. Supabase PAT) can connect."""
     import sys
+
     from opendot import cli
     from opendot.mcp.manager import load_mcp_config
 
     monkeypatch.setenv("OPENDOT_HOME", str(tmp_path / "store"))
-    monkeypatch.setattr(sys, "argv", [
-        "opendot", "mcp", "add", "supabase",
-        "--url", "https://mcp.supabase.com/mcp?project_ref=abc",
-        "--header", "Authorization=Bearer tok123",
-    ])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "opendot",
+            "mcp",
+            "add",
+            "supabase",
+            "--url",
+            "https://mcp.supabase.com/mcp?project_ref=abc",
+            "--header",
+            "Authorization=Bearer tok123",
+        ],
+    )
     cli.main()
     cfg = load_mcp_config()
     assert cfg["supabase"] == {

--- a/tests/test_office.py
+++ b/tests/test_office.py
@@ -5,9 +5,9 @@ import pytest
 pytest.importorskip("openpyxl")
 pytest.importorskip("pptx")
 
-from opendot.tools.local import Toolbox
 from opendot.reversibility.engine import Reversibility
 from opendot.reversibility.snapshots import IgnoreRules
+from opendot.tools.local import Toolbox
 
 
 @pytest.fixture(autouse=True)
@@ -25,16 +25,20 @@ def _tb(tmp_path):
 
 def _make_xlsx(path):
     import openpyxl
+
     wb = openpyxl.Workbook()
     ws = wb.active
-    ws["A1"] = "name"; ws["B1"] = "score"
-    ws["A2"] = "alice"; ws["B2"] = 100
+    ws["A1"] = "name"
+    ws["B1"] = "score"
+    ws["A2"] = "alice"
+    ws["B2"] = 100
     wb.save(path)
 
 
 def _make_pptx(path):
     from pptx import Presentation
     from pptx.util import Inches
+
     prs = Presentation()
     slide = prs.slides.add_slide(prs.slide_layouts[5])
     tb = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(4), Inches(1))
@@ -59,6 +63,7 @@ def test_read_and_edit_xlsx(tmp_path):
     assert "100" in res and "120" in res
 
     import openpyxl
+
     wb = openpyxl.load_workbook(wd / "data.xlsx")
     assert wb.active["B2"].value == 120  # coerced to int
 
@@ -69,6 +74,7 @@ def test_xlsx_edit_is_undoable(tmp_path):
     tb.call("edit_cell", {"path": "data.xlsx", "cell": "B2", "value": "999"})
 
     import openpyxl
+
     assert openpyxl.load_workbook(wd / "data.xlsx").active["B2"].value == 999
     rev.undo_last()  # restore the binary file exactly
     assert openpyxl.load_workbook(wd / "data.xlsx").active["B2"].value == 100
@@ -81,10 +87,14 @@ def test_read_and_edit_pptx(tmp_path):
     out = tb.call("read_pptx", {"path": "deck.pptx"})
     assert "Old Title" in out
 
-    res = tb.call("edit_pptx_text", {"path": "deck.pptx", "find": "Old Title", "replace": "New Title"})
+    res = tb.call(
+        "edit_pptx_text",
+        {"path": "deck.pptx", "find": "Old Title", "replace": "New Title"},
+    )
     assert "1 run" in res
 
     from pptx import Presentation
+
     prs = Presentation(str(wd / "deck.pptx"))
     texts = [sh.text for sh in prs.slides[0].shapes if sh.has_text_frame]
     assert "New Title" in texts

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -12,8 +12,14 @@ from opendot import providers as p
 
 
 def _clear_keys(monkeypatch):
-    for var in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY",
-                "DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY"):
+    for var in (
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GEMINI_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "GROQ_API_KEY",
+        "MISTRAL_API_KEY",
+    ):
         monkeypatch.delenv(var, raising=False)
 
 
@@ -23,6 +29,7 @@ def fake_catalog(monkeypatch):
     var's provider, so model_for_available_key tests don't depend on the live
     LiteLLM registry."""
     from opendot import catalog
+
     mapping = {
         "OPENAI_API_KEY": "gpt-x",
         "DEEPSEEK_API_KEY": "deepseek/deepseek-x",

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,6 +1,6 @@
 """Tests for OPENDOT.md snapshot rule parsing."""
 
-from opendot.reversibility.rules import parse_rules_text, load_rules
+from opendot.reversibility.rules import load_rules, parse_rules_text
 
 
 def test_no_block_is_defaults():

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -47,6 +47,7 @@ def test_nested_dirs(tmp_path):
     snap = S.take_snapshot(wd)
 
     import shutil
+
     shutil.rmtree(wd / "src")  # delete the whole subtree
     assert not (wd / "src").exists()
 
@@ -211,7 +212,7 @@ def test_restore_brings_back_file_permissions(tmp_path):
     script.chmod(0o755)
     snap = S.take_snapshot(wd)
 
-    script.chmod(0o644)                       # someone chmods it
+    script.chmod(0o644)  # someone chmods it
     S.restore_snapshot(S.load_snapshot(snap.project_id, snap.id))
     assert (os.stat(script).st_mode & 0o777) == 0o755  # mode restored
 
@@ -237,7 +238,7 @@ def test_retention_prunes_old_snapshots_and_gcs_objects(tmp_path, monkeypatch):
         os.utime(f, (i + 1, i + 1))  # deterministic mtimes so each version differs
         snap = S.take_snapshot(wd)
     kept = S.list_snapshots(snap.project_id)
-    assert len(kept) == 3                      # only the newest 3 survive
+    assert len(kept) == 3  # only the newest 3 survive
     # orphaned objects from v0..v2 are GC'd; ~3 remain
     objs = [o for o in (S._objects_dir()).iterdir() if o.suffix != ".tmp"]
     assert len(objs) <= 4
@@ -249,15 +250,19 @@ def test_retention_prunes_old_snapshots_and_gcs_objects(tmp_path, monkeypatch):
 
 def test_gc_never_deletes_objects_shared_by_another_project(tmp_path, monkeypatch):
     monkeypatch.setattr(S, "MAX_SNAPSHOTS_PER_PROJECT", 2)
-    a = tmp_path / "A"; a.mkdir()
-    b = tmp_path / "B"; b.mkdir()
+    a = tmp_path / "A"
+    a.mkdir()
+    b = tmp_path / "B"
+    b.mkdir()
     (a / "shared.txt").write_text("SHARED")
-    (b / "shared.txt").write_text("SHARED")   # identical content → one object
+    (b / "shared.txt").write_text("SHARED")  # identical content → one object
     S.take_snapshot(a)
     b_snap = S.take_snapshot(b)
     # churn A past its retention so A's GC runs repeatedly
     for i in range(4):
-        (a / "x").write_text(str(i)); os.utime(a / "x", (i + 1, i + 1)); S.take_snapshot(a)
+        (a / "x").write_text(str(i))
+        os.utime(a / "x", (i + 1, i + 1))
+        S.take_snapshot(a)
     # B's shared object must survive (still referenced by B) and B must restore
     (b / "shared.txt").write_text("wrecked")
     S.restore_snapshot(S.load_snapshot(b_snap.project_id, b_snap.id))
@@ -271,19 +276,24 @@ def test_unchanged_files_are_not_rehashed(tmp_path, monkeypatch):
 
     reads = {"n": 0}
     orig = S._write_object_from_path
-    monkeypatch.setattr(S, "_write_object_from_path",
-                        lambda path: (reads.__setitem__("n", reads["n"] + 1), orig(path))[1])
+    monkeypatch.setattr(
+        S,
+        "_write_object_from_path",
+        lambda path: (reads.__setitem__("n", reads["n"] + 1), orig(path))[1],
+    )
 
     S.take_snapshot(wd)
     reads["n"] = 0
-    S.take_snapshot(wd)               # nothing changed
-    assert reads["n"] == 0            # fast path: no re-reads
+    S.take_snapshot(wd)  # nothing changed
+    assert reads["n"] == 0  # fast path: no re-reads
 
-    import time; time.sleep(0.01)
+    import time
+
+    time.sleep(0.01)
     (wd / "a.txt").write_text("changed")
     reads["n"] = 0
     S.take_snapshot(wd)
-    assert reads["n"] == 1            # only the changed file re-hashed
+    assert reads["n"] == 1  # only the changed file re-hashed
 
 
 def test_ledger_clear_wipes_history(tmp_path):
@@ -314,12 +324,12 @@ def test_undo_reports_changed_lockfile(tmp_path):
     rev = Reversibility(workdir=str(wd), rules=load_rules(str(wd)))
 
     rev.before_action("shell", "npm install foo", reversible=True)  # snapshot before
-    (wd / "package-lock.json").write_text('{"version": 2}')          # "install" changes it
+    (wd / "package-lock.json").write_text('{"version": 2}')  # "install" changes it
 
     undone = rev.undo_last()
     assert undone is not None
     assert (wd / "package-lock.json").read_text() == '{"version": 1}'  # rolled back
-    assert rev.last_changed_lockfiles == ["package-lock.json"]         # and reported
+    assert rev.last_changed_lockfiles == ["package-lock.json"]  # and reported
 
 
 def test_undo_reports_lockfile_created_by_install(tmp_path):
@@ -332,11 +342,11 @@ def test_undo_reports_lockfile_created_by_install(tmp_path):
     (wd / "app.py").write_text("x = 1")
     rev = Reversibility(workdir=str(wd), rules=load_rules(str(wd)))
 
-    rev.before_action("shell", "uv add requests", reversible=True)   # no lockfile yet
-    (wd / "uv.lock").write_text("locked")                            # install creates one
+    rev.before_action("shell", "uv add requests", reversible=True)  # no lockfile yet
+    (wd / "uv.lock").write_text("locked")  # install creates one
 
     rev.undo_last()
-    assert not (wd / "uv.lock").exists()                             # removed on undo
+    assert not (wd / "uv.lock").exists()  # removed on undo
     assert rev.last_changed_lockfiles == ["uv.lock"]
 
 
@@ -365,10 +375,10 @@ def test_no_snapshot_action_logs_but_captures_nothing(tmp_path):
     rev = Reversibility(workdir=str(wd), rules=load_rules(str(wd)))
 
     entry_id = rev.before_action("shell", "shred secret.txt", snapshot=False)
-    assert entry_id                                  # a real, sortable id
+    assert entry_id  # a real, sortable id
     entries = rev.history()
     assert len(entries) == 1
-    assert entries[0].snapshot_before == ""          # nothing to restore from
+    assert entries[0].snapshot_before == ""  # nothing to restore from
     assert entries[0].reversible is False
     # no snapshot manifest was written for this project
     assert S.list_snapshots(rev.project_id) == []
@@ -385,7 +395,7 @@ def test_undo_noops_on_no_snapshot_action(tmp_path):
     wd = _workspace(tmp_path)
     rev = Reversibility(workdir=str(wd), rules=load_rules(str(wd)))
     rev.before_action("shell", "shred x", snapshot=False)
-    assert rev.undo_last() is None                   # no-op, not an exception
+    assert rev.undo_last() is None  # no-op, not an exception
 
 
 def test_no_snapshot_ids_stay_monotonic_with_real_snapshots(tmp_path):
@@ -397,9 +407,9 @@ def test_no_snapshot_ids_stay_monotonic_with_real_snapshots(tmp_path):
     (wd / "a.txt").write_text("v1")
     rev = Reversibility(workdir=str(wd), rules=load_rules(str(wd)))
 
-    id1 = rev.before_action("write", "a.txt", reversible=True)          # real snap
-    id2 = rev.before_action("shell", "shred y", snapshot=False)         # no snap
-    id3 = rev.before_action("write", "a.txt", reversible=True)          # real snap
+    id1 = rev.before_action("write", "a.txt", reversible=True)  # real snap
+    id2 = rev.before_action("shell", "shred y", snapshot=False)  # no snap
+    id3 = rev.before_action("write", "a.txt", reversible=True)  # real snap
     ids = [id1, id2, id3]
-    assert ids == sorted(ids)                        # strictly increasing
-    assert len(set(ids)) == 3                         # all unique
+    assert ids == sorted(ids)  # strictly increasing
+    assert len(set(ids)) == 3  # all unique

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,13 +1,10 @@
 """Tests for the coding tools (grep, glob, edit) and that edit is undoable."""
 
-import os
-from pathlib import Path
-
 import pytest
 
-from opendot.tools.local import Toolbox
 from opendot.reversibility.engine import Reversibility
 from opendot.reversibility.snapshots import IgnoreRules
+from opendot.tools.local import Toolbox
 
 
 @pytest.fixture(autouse=True)
@@ -73,4 +70,12 @@ def test_edit_is_undoable(tmp_path):
 def test_new_tools_are_in_specs(tmp_path):
     tb, _, _ = _tb(tmp_path)
     names = {s["function"]["name"] for s in tb.specs()}
-    assert {"grep", "glob", "edit", "run_shell", "read_file", "write_file", "list_files"} <= names
+    assert {
+        "grep",
+        "glob",
+        "edit",
+        "run_shell",
+        "read_file",
+        "write_file",
+        "list_files",
+    } <= names

--- a/tests/test_tui_modals.py
+++ b/tests/test_tui_modals.py
@@ -5,10 +5,8 @@ must NEVER bubble up and get submitted as a chat message. This reproduces and
 guards the leak where pressing Enter in ApiKeyModal sent the key to the agent.
 """
 
-import pytest
-
-from opendot.tui import OpendotTUI, ApiKeyModal
 from opendot.agent.events import Event
+from opendot.tui import ApiKeyModal, OpendotTUI
 
 
 class _FakeUsage:

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -40,9 +40,10 @@ def _chunk(with_choices, with_usage):
 class _FakeLiteLLM(types.SimpleNamespace):
     async def acompletion(self, **kw):
         async def gen():
-            yield _chunk(True, False)   # content only
-            yield _chunk(True, True)    # last content chunk WITH usage
-            yield _chunk(False, True)   # final usage-only chunk (duplicate)
+            yield _chunk(True, False)  # content only
+            yield _chunk(True, True)  # last content chunk WITH usage
+            yield _chunk(False, True)  # final usage-only chunk (duplicate)
+
         return gen()
 
     def cost_per_token(self, model, prompt_tokens, completion_tokens):
@@ -66,7 +67,7 @@ def test_streaming_usage_counted_once_not_doubled():
             pass
 
     asyncio.run(run())
-    assert a.usage.total_tokens == 1500          # not 3000
+    assert a.usage.total_tokens == 1500  # not 3000
     assert round(a.usage.cost_usd, 4) == 0.0075  # not 0.015
 
 
@@ -88,5 +89,5 @@ def test_add_response_cost_from_tokens():
     resp = types.SimpleNamespace(usage=_Usage())
     u.add_response(resp, _StubLiteLLM(), model="gpt-4o")
     assert u.total_tokens == 1500
-    assert round(u.cost_usd, 4) == 0.03          # 0.01 + 0.02 from cost_per_token
-    assert calls["completion_cost"] == 0         # token-based path was used
+    assert round(u.cost_usd, 4) == 0.03  # 0.01 + 0.02 from cost_per_token
+    assert calls["completion_cost"] == 0  # token-based path was used


### PR DESCRIPTION
Add ruff-based linting and auto-formatting, matching the setup in PyScrappy.

- pyproject.toml: [tool.ruff] (target py310, line-length 100) and
  [tool.ruff.lint] (select E, F, I, W; ignore E501 since the formatter owns
  line width and E501 only fires on unsplittable string literals).
- CI: add a lint job running `ruff check` and `ruff format --check`.
- .pre-commit-config.yaml: run ruff --fix and ruff-format on staged files at
  commit time (one-time `pre-commit install`).
- Apply the initial auto-fix + format pass: unused imports, import ordering,
  and redefinitions cleaned up; all files formatted. No behavior changes; the
  full test suite still passes.

Bump version to 0.1.7.