### PR TITLE
feat: add MCP server connection test

### DIFF
--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -196,6 +196,7 @@ def _note_lockfiles(console, changed: list[str]) -> None:
 def _cmd_mcp(args) -> None:
     """`opendot mcp add|list|remove` — manage external MCP servers."""
     from opendot.mcp import (
+        MCPManager,
         add_mcp_server,
         load_mcp_config,
         remove_mcp_server,
@@ -251,6 +252,26 @@ def _cmd_mcp(args) -> None:
         console.print(
             f"[green]added[/green] MCP server [cyan]{args.name}[/cyan]. It will connect next time you run opendot."
         )
+        return
+
+    if cmd == "test":
+        servers = load_mcp_config()
+        spec = servers.get(args.name)
+        if spec is None:
+            console.print(f"[red]no MCP server named {args.name!r}.[/red]")
+            return
+        manager = MCPManager({args.name: spec})
+        try:
+            manager.start()
+            if args.name in manager.connected:
+                names = [tool.name for tool in manager.tools if tool.server == args.name]
+                suffix = f": {', '.join(names)}" if names else ""
+                console.print(f"[green]✓ connected[/green] — {len(names)} tools{suffix}")
+            else:
+                error = manager.errors.get(args.name, "connection did not complete")
+                console.print(f"[red]✗ connection failed[/red] — {error}")
+        finally:
+            manager.shutdown()
         return
 
     if cmd == "remove":
@@ -462,6 +483,8 @@ def main() -> None:
     mcp_sub.add_parser("list", help="List configured MCP servers.")
     p_rm = mcp_sub.add_parser("remove", help="Remove an MCP server.")
     p_rm.add_argument("name", help="Server name to remove.")
+    p_test = mcp_sub.add_parser("test", help="Connect to one server and list its tools.")
+    p_test.add_argument("name", help="Configured server name to test.")
 
     args = parser.parse_args(argv)
     args.post_dashdash = post_dashdash

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -194,7 +194,7 @@ def _note_lockfiles(console, changed: list[str]) -> None:
 
 
 def _cmd_mcp(args) -> None:
-    """`opendot mcp add|list|remove` — manage external MCP servers."""
+    """`opendot mcp add|list|remove|test` — manage external MCP servers."""
     from opendot.mcp import (
         MCPManager,
         add_mcp_server,
@@ -266,7 +266,10 @@ def _cmd_mcp(args) -> None:
             if args.name in manager.connected:
                 names = [tool.name for tool in manager.tools if tool.server == args.name]
                 suffix = f": {', '.join(names)}" if names else ""
-                console.print(f"[green]✓ connected[/green] — {len(names)} tools{suffix}")
+                tool_label = "tool" if len(names) == 1 else "tools"
+                console.print(
+                    f"[green]✓ connected[/green] — {len(names)} {tool_label}{suffix}"
+                )
             else:
                 error = manager.errors.get(args.name, "connection did not complete")
                 console.print(f"[red]✗ connection failed[/red] — {error}")

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -267,9 +267,7 @@ def _cmd_mcp(args) -> None:
                 names = [tool.name for tool in manager.tools if tool.server == args.name]
                 suffix = f": {', '.join(names)}" if names else ""
                 tool_label = "tool" if len(names) == 1 else "tools"
-                console.print(
-                    f"[green]✓ connected[/green] — {len(names)} {tool_label}{suffix}"
-                )
+                console.print(f"[green]✓ connected[/green] — {len(names)} {tool_label}{suffix}")
             else:
                 error = manager.errors.get(args.name, "connection did not complete")
                 console.print(f"[red]✗ connection failed[/red] — {error}")

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -156,3 +156,62 @@ def test_mcp_add_remote_with_header(tmp_path, monkeypatch):
         "url": "https://mcp.supabase.com/mcp?project_ref=abc",
         "headers": {"Authorization": "Bearer tok123"},
     }
+
+
+def test_mcp_test_cli_reports_connected_tools(tmp_path, monkeypatch, capsys):
+    import sys
+
+    from opendot import cli, mcp
+    from opendot.mcp.manager import MCPTool, add_mcp_server
+
+    add_mcp_server("demo", {"command": "ignored"})
+
+    class FakeManager:
+        def __init__(self, config):
+            assert config == {"demo": {"command": "ignored"}}
+            self.connected = ["demo"]
+            self.errors = {}
+            self.tools = [MCPTool("demo", "ping", "", {})]
+
+        def start(self):
+            pass
+
+        def shutdown(self):
+            pass
+
+    monkeypatch.setattr(mcp, "MCPManager", FakeManager)
+    monkeypatch.setattr(sys, "argv", ["opendot", "mcp", "test", "demo"])
+    cli.main()
+
+    output = capsys.readouterr().out
+    assert "connected" in output
+    assert "1 tools: ping" in output
+
+
+def test_mcp_test_cli_reports_connection_error(tmp_path, monkeypatch, capsys):
+    import sys
+
+    from opendot import cli, mcp
+    from opendot.mcp.manager import add_mcp_server
+
+    add_mcp_server("broken", {"command": "ignored"})
+
+    class FakeManager:
+        def __init__(self, config):
+            self.connected = []
+            self.errors = {"broken": "ConnectionError: refused"}
+            self.tools = []
+
+        def start(self):
+            pass
+
+        def shutdown(self):
+            pass
+
+    monkeypatch.setattr(mcp, "MCPManager", FakeManager)
+    monkeypatch.setattr(sys, "argv", ["opendot", "mcp", "test", "broken"])
+    cli.main()
+
+    output = capsys.readouterr().out
+    assert "connection failed" in output
+    assert "ConnectionError: refused" in output

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -185,7 +185,7 @@ def test_mcp_test_cli_reports_connected_tools(tmp_path, monkeypatch, capsys):
 
     output = capsys.readouterr().out
     assert "connected" in output
-    assert "1 tools: ping" in output
+    assert "1 tool: ping" in output
 
 
 def test_mcp_test_cli_reports_connection_error(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
## What & why

Adds `opendot mcp test <name>` so users can connect to one configured MCP server and see either its tool count/names or the manager's connection error without launching the TUI.

Closes #15

## How I verified it

- `uv run pytest -q tests/test_mcp.py` — 11 passed
- `uvx ruff check src/opendot/cli.py tests/test_mcp.py` — clean
- `uvx ruff format --check src/opendot/cli.py tests/test_mcp.py` — clean
- `git diff --check`

The tests stub the manager at the existing boundary and cover both a successful connection and a surfaced connection failure.
