### PR TITLE
feat: add web_fetch tool — read any URL as LLM-ready markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ htmlcov/
 
 # Environment / secrets
 .env
+
+# uv lockfile — opendot ships version ranges (published CLI), not a pinned lock.
+uv.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.1.7"
+version = "0.1.8"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"
@@ -28,6 +28,7 @@ dependencies = [
     "mcp>=1.2",          # MCP client: connect to external MCP servers' tools
     "textual-image>=0.8",  # render the logo image on the welcome screen (TGP/Sixel/Unicode)
     "composio>=0.11,<0.12",  # /composio: 3000+ app tools (Gmail, Slack, GitHub, …)
+    "pyscrappy>=1.3.2",  # web_fetch: fetch a URL as LLM-ready markdown
 ]
 
 [project.optional-dependencies]

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 from opendot.agent.loop import Agent
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -76,7 +76,7 @@ class Toolbox:
     """
 
     #: tools that only observe — never mutate the filesystem or run commands.
-    READ_ONLY = {"list_files", "read_file", "grep", "glob", "read_xlsx", "read_pptx"}
+    READ_ONLY = {"list_files", "read_file", "grep", "glob", "read_xlsx", "read_pptx", "web_fetch"}
 
     def __init__(
         self,
@@ -301,6 +301,21 @@ class Toolbox:
             rel = self._rel(p)
             return f"edited {rel} ({replaced} replacement(s))\n" + _unified_diff(text, new, rel)
 
+        def web_fetch(url: str) -> str:
+            """Fetch an http(s) URL and return its content as LLM-ready markdown
+            (structured text, headings, links, tables) via PyScrappy. Read-only:
+            it never mutates the workspace, so it runs without a snapshot, like
+            read_file."""
+            if not url.lower().startswith(("http://", "https://")):
+                return "error: only http:// and https:// URLs are supported"
+            import pyscrappy
+
+            try:
+                result = pyscrappy.scrape(url)
+            except Exception as exc:  # noqa: BLE001 - surface any fetch failure to the model
+                return f"error fetching {url}: {type(exc).__name__}: {exc}"
+            return _truncate(result.to_markdown()) or "(empty response)"
+
         return [
             Tool(
                 "list_files",
@@ -402,6 +417,21 @@ class Toolbox:
                     "required": ["path", "find", "replace"],
                 },
                 edit,
+            ),
+            Tool(
+                "web_fetch",
+                "Fetch an http(s) URL and return its content as markdown (text, headings, links, tables). Read-only.",
+                {
+                    "type": "object",
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "http:// or https:// URL to fetch.",
+                        },
+                    },
+                    "required": ["url"],
+                },
+                web_fetch,
             ),
         ]
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -78,4 +78,34 @@ def test_new_tools_are_in_specs(tmp_path):
         "read_file",
         "write_file",
         "list_files",
+        "web_fetch",
     } <= names
+
+
+def test_web_fetch_returns_markdown(tmp_path, monkeypatch):
+    """web_fetch delegates to PyScrappy and returns its markdown, without hitting
+    the network (PyScrappy's scrape is stubbed)."""
+    import pyscrappy
+
+    class _Result:
+        def to_markdown(self):
+            return "# Example\n\nHello world."
+
+    monkeypatch.setattr(pyscrappy, "scrape", lambda url: _Result())
+    tb, _, _ = _tb(tmp_path)
+    out = tb.call("web_fetch", {"url": "https://example.com"})
+    assert "# Example" in out and "Hello world." in out
+
+
+def test_web_fetch_rejects_non_http_schemes(tmp_path):
+    """Only http(s) — never file:// (would exfiltrate local files) or others."""
+    tb, _, _ = _tb(tmp_path)
+    for bad in ("file:///etc/passwd", "ftp://x/y", "data:text/plain,hi"):
+        out = tb.call("web_fetch", {"url": bad})
+        assert out.startswith("error: only http")
+
+
+def test_web_fetch_is_read_only():
+    from opendot.tools.local import Toolbox
+
+    assert "web_fetch" in Toolbox.READ_ONLY  # runs without a snapshot, like read_file


### PR DESCRIPTION
## What

Adds a `web_fetch` tool so the agent can read web pages, closing the gap versus
agents that have a WebFetch/WebSearch capability.

- `web_fetch(url)` fetches an http(s) URL and returns its content as markdown
  (text, headings, links, tables), powered by PyScrappy's `scrape(...).to_markdown()`.
- Read-only: it never mutates the workspace, so it auto-runs without a snapshot,
  like `read_file` and `grep` (added to `READ_ONLY`).
- Scheme-guarded: only `http://` / `https://` are allowed. `file://`, `ftp://`,
  and `data:` are rejected, so the tool can't be used to read local files off disk.

## Dependency

Adds `pyscrappy>=1.3.2` to core dependencies. PyScrappy's core is lightweight
(httpx, beautifulsoup4, lxml) and gives structured, LLM-ready output rather than
a raw HTML dump.

## Tests

- web_fetch returns markdown (PyScrappy's `scrape` stubbed, so no network in CI)
- rejects non-http(s) schemes (file/ftp/data)
- is registered read-only (no snapshot)
- 105 passing; verified live against a real URL.

Bump version to 0.1.8.