### PR TITLE
feat: read_docx tool, more safe commands, snapshot edge-case tests (+…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.1.8"
+version = "0.1.9"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"
@@ -32,8 +32,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-office = ["openpyxl>=3.1", "python-pptx>=0.6"]  # xlsx / pptx read+edit tools
-dev = ["pytest>=8.0", "pytest-asyncio>=0.23", "openpyxl>=3.1", "python-pptx>=0.6"]
+office = ["openpyxl>=3.1", "python-pptx>=0.6", "python-docx>=1.1"]  # xlsx / pptx / docx tools
+dev = ["pytest>=8.0", "pytest-asyncio>=0.23", "openpyxl>=3.1", "python-pptx>=0.6", "python-docx>=1.1"]
 
 [project.scripts]
 opendot = "opendot.cli:main"

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 from opendot.agent.loop import Agent
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/reversibility/classifier.py
+++ b/src/opendot/reversibility/classifier.py
@@ -58,6 +58,17 @@ _SAFE_COMMANDS = {
     "uniq",
     "cut",
     "tr",
+    # read-only system/info commands (never mutate the fs or reach the network)
+    "ps",
+    "df",
+    "du",
+    "uname",
+    "id",
+    "groups",
+    "printenv",
+    "basename",
+    "dirname",
+    "realpath",
 }
 
 # Signals that a command escapes the workspace or is hard/impossible to undo.

--- a/src/opendot/reversibility/snapshots.py
+++ b/src/opendot/reversibility/snapshots.py
@@ -427,6 +427,26 @@ _LOCKFILES = {
 }
 
 
+def _ensure_real_dirs(base: Path, leaf: Path) -> None:
+    """Make every path component from ``base`` (exclusive) down to ``leaf``
+    (inclusive) a real directory. If a component is a symlink or a non-directory,
+    remove it first. This stops restore from writing through a symlinked parent
+    and escaping the workspace. ``base`` itself is never modified.
+    """
+    # Components from base down to leaf, outermost first.
+    parts: list[Path] = []
+    cur = leaf
+    while cur != base and base in cur.parents:
+        parts.append(cur)
+        cur = cur.parent
+    for d in reversed(parts):
+        if d.is_symlink():
+            d.unlink()
+        elif d.exists() and not d.is_dir():
+            d.unlink()
+        d.mkdir(exist_ok=True)
+
+
 def restore_snapshot(snap: Snapshot, rules: IgnoreRules | None = None) -> list[str]:
     """Make the workspace byte-for-byte match the snapshot.
 
@@ -452,12 +472,14 @@ def restore_snapshot(snap: Snapshot, rules: IgnoreRules | None = None) -> list[s
                     changed_lockfiles.append(rel)
             except OSError:
                 changed_lockfiles.append(rel)
-        target.parent.mkdir(parents=True, exist_ok=True)
-        # If something else now occupies this file's path (it was a file at
-        # snapshot time but became a symlink or a directory), remove it first so
-        # write_bytes recreates the real file. Crucially, unlink a symlink rather
-        # than writing through it — otherwise write_bytes would follow it and
-        # could overwrite a target OUTSIDE the workspace.
+        # Rebuild the path to the file as REAL directories. If any parent
+        # component was replaced by a symlink (or a non-dir), writing through it
+        # could land the file OUTSIDE the workspace — the one thing restore must
+        # never do. So walk wd -> target.parent and force each level to a real dir.
+        _ensure_real_dirs(wd, target.parent)
+        # If something now occupies the file's own path (it was a file at snapshot
+        # time but became a symlink or a directory), remove it first so write_bytes
+        # recreates the real file rather than writing through a symlink or raising.
         if target.is_symlink():
             target.unlink()
         elif target.is_dir():

--- a/src/opendot/reversibility/snapshots.py
+++ b/src/opendot/reversibility/snapshots.py
@@ -453,6 +453,13 @@ def restore_snapshot(snap: Snapshot, rules: IgnoreRules | None = None) -> list[s
             except OSError:
                 changed_lockfiles.append(rel)
         target.parent.mkdir(parents=True, exist_ok=True)
+        # If a directory now occupies this file's path (the path was a file at
+        # snapshot time but became a dir), remove it first so write_bytes can
+        # recreate the file instead of raising IsADirectoryError.
+        if target.is_dir() and not target.is_symlink():
+            import shutil
+
+            shutil.rmtree(target)
         target.write_bytes(_read_object(entry.h))
         if entry.mode is not None:
             try:

--- a/src/opendot/reversibility/snapshots.py
+++ b/src/opendot/reversibility/snapshots.py
@@ -463,6 +463,15 @@ def restore_snapshot(snap: Snapshot, rules: IgnoreRules | None = None) -> list[s
 
     # 1. Restore all files from the manifest (content + permission mode).
     for rel, entry in snap.files.items():
+        # Defense in depth: manifest paths are written by opendot from a walk
+        # *inside* the workspace, so they're always safe relative paths. But if a
+        # snapshot file were tampered with to contain an absolute path or a ".."
+        # segment, `wd / rel` could resolve outside the workspace. Skip any such
+        # entry rather than write outside (and rather than abort the whole
+        # restore — the remaining, valid files should still be restored).
+        rel_path = Path(rel)
+        if rel_path.is_absolute() or ".." in rel_path.parts:
+            continue
         target = wd / rel
         # Before overwriting, note if this is a lockfile whose content differs —
         # that means the restore rolled dependency versions back.

--- a/src/opendot/reversibility/snapshots.py
+++ b/src/opendot/reversibility/snapshots.py
@@ -453,10 +453,14 @@ def restore_snapshot(snap: Snapshot, rules: IgnoreRules | None = None) -> list[s
             except OSError:
                 changed_lockfiles.append(rel)
         target.parent.mkdir(parents=True, exist_ok=True)
-        # If a directory now occupies this file's path (the path was a file at
-        # snapshot time but became a dir), remove it first so write_bytes can
-        # recreate the file instead of raising IsADirectoryError.
-        if target.is_dir() and not target.is_symlink():
+        # If something else now occupies this file's path (it was a file at
+        # snapshot time but became a symlink or a directory), remove it first so
+        # write_bytes recreates the real file. Crucially, unlink a symlink rather
+        # than writing through it — otherwise write_bytes would follow it and
+        # could overwrite a target OUTSIDE the workspace.
+        if target.is_symlink():
+            target.unlink()
+        elif target.is_dir():
             import shutil
 
             shutil.rmtree(target)

--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -76,7 +76,16 @@ class Toolbox:
     """
 
     #: tools that only observe — never mutate the filesystem or run commands.
-    READ_ONLY = {"list_files", "read_file", "grep", "glob", "read_xlsx", "read_pptx", "web_fetch"}
+    READ_ONLY = {
+        "list_files",
+        "read_file",
+        "grep",
+        "glob",
+        "read_xlsx",
+        "read_pptx",
+        "read_docx",
+        "web_fetch",
+    }
 
     def __init__(
         self,

--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -130,6 +130,16 @@ class Toolbox:
         except ValueError:
             return str(p)
 
+    def _is_outside_workspace(self, p: Path) -> bool:
+        """True if ``p`` is not under the working directory. Writes/edits to such
+        paths can't be undone (the snapshot only covers the workspace), so they're
+        recorded as irreversible and confirmed first, like escaping shell commands."""
+        try:
+            p.resolve().relative_to(self.workdir)
+            return False
+        except ValueError:
+            return True
+
     def _is_ignored(self, p: Path) -> bool:
         return any(part in self._IGNORE for part in p.parts)
 
@@ -175,9 +185,21 @@ class Toolbox:
                     old = p.read_text(encoding="utf-8", errors="replace")
                 except OSError:
                     old = ""
-            # Snapshot before mutating so the write can be undone.
+            # A write outside the working dir isn't covered by the snapshot, so it
+            # can't be undone. Confirm first and record it honestly as irreversible,
+            # exactly like an escaping shell command. Never claim a lying undo.
+            outside = self._is_outside_workspace(p)
+            if outside and not self._confirm(
+                f"This writes outside the workspace and can't be undone:\n  {p}\nWrite it?"
+            ):
+                return "skipped: user declined a write outside the workspace"
             if self.rev is not None:
-                self.rev.before_action("write", str(p), reversible=True)
+                self.rev.before_action(
+                    "write",
+                    str(p),
+                    reversible=not outside,
+                    note="outside the workspace — not undoable" if outside else "",
+                )
             try:
                 p.parent.mkdir(parents=True, exist_ok=True)
                 p.write_text(content, encoding="utf-8")
@@ -302,8 +324,20 @@ class Toolbox:
             n = text.count(find)
             if n == 0:
                 return f"error: `find` string not present in {p} (no change made)"
+            # An edit outside the working dir isn't covered by the snapshot, so it
+            # can't be undone: confirm first and record it as irreversible.
+            outside = self._is_outside_workspace(p)
+            if outside and not self._confirm(
+                f"This edits a file outside the workspace and can't be undone:\n  {p}\nEdit it?"
+            ):
+                return "skipped: user declined an edit outside the workspace"
             if self.rev is not None:
-                self.rev.before_action("write", str(p), reversible=True)
+                self.rev.before_action(
+                    "write",
+                    str(p),
+                    reversible=not outside,
+                    note="outside the workspace — not undoable" if outside else "",
+                )
             new = text.replace(find, replace, count if count > 0 else -1)
             p.write_text(new, encoding="utf-8")
             replaced = n if count == 0 else min(n, count)

--- a/src/opendot/tools/office.py
+++ b/src/opendot/tools/office.py
@@ -124,7 +124,22 @@ def build_office_tools(box) -> list:
         prs.save(str(p))
         return f"{box._rel(p)}: replaced {find!r} → {replace!r} in {hits} run(s)"
 
-    return [
+    # ---- docx ----
+    def read_docx(path: str) -> str:
+        from docx import Document
+
+        p = box._resolve(path)
+        if not p.exists():
+            return f"error: file not found: {p}"
+        doc = Document(str(p))
+        lines = [f"document {box._rel(p)}  ({len(doc.paragraphs)} paragraphs)"]
+        for para in doc.paragraphs:
+            text = para.text.strip()
+            if text:
+                lines.append(text)
+        return _truncate("\n".join(lines))
+
+    tools = [
         Tool(
             "read_xlsx",
             "Read an .xlsx spreadsheet: lists sheets and prints a sheet's cells as rows.",
@@ -182,3 +197,26 @@ def build_office_tools(box) -> list:
             edit_pptx_text,
         ),
     ]
+
+    # .docx support is gated separately: python-docx is an independent optional
+    # dep, so read_docx only registers when it's importable (openpyxl/pptx users
+    # without python-docx still get the xlsx/pptx tools).
+    try:
+        import docx  # noqa: F401
+
+        tools.append(
+            Tool(
+                "read_docx",
+                "Read a .docx Word document: outputs its paragraph text.",
+                {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                },
+                read_docx,
+            )
+        )
+    except ImportError:
+        pass
+
+    return tools

--- a/src/opendot/tools/office.py
+++ b/src/opendot/tools/office.py
@@ -34,9 +34,25 @@ def build_office_tools(box) -> list:
 
     from opendot.tools.local import Tool, _truncate
 
-    def _snapshot(p: Path) -> None:
+    def _snapshot(p: Path) -> bool:
+        """Snapshot ``p`` before an edit. Returns True to proceed, False if the
+        user declined an out-of-workspace edit. A file outside the working dir
+        isn't covered by the snapshot, so it can't be undone: confirm first and
+        record it as irreversible, exactly like write_file/edit and the shell path.
+        """
+        outside = box._is_outside_workspace(p)
+        if outside and not box._confirm(
+            f"This edits a file outside the workspace and can't be undone:\n  {p}\nEdit it?"
+        ):
+            return False
         if box.rev is not None:
-            box.rev.before_action("write", str(p), reversible=True)
+            box.rev.before_action(
+                "write",
+                str(p),
+                reversible=not outside,
+                note="outside the workspace — not undoable" if outside else "",
+            )
+        return True
 
     # ---- xlsx ----
     def read_xlsx(path: str, sheet: str | None = None, max_rows: int = 100) -> str:
@@ -69,7 +85,8 @@ def build_office_tools(box) -> list:
         wb = openpyxl.load_workbook(p)
         ws = wb[sheet] if sheet else wb[wb.sheetnames[0]]
         old = ws[cell].value
-        _snapshot(p)
+        if not _snapshot(p):
+            return "skipped: user declined an edit outside the workspace"
         # numbers stay numbers; formulas (leading '=') pass through
         v: Any = value
         if not value.startswith("="):
@@ -120,7 +137,8 @@ def build_office_tools(box) -> list:
                             hits += 1
         if hits == 0:
             return f"error: text {find!r} not found in {box._rel(p)} (no change)"
-        _snapshot(p)
+        if not _snapshot(p):  # in-memory edits above are dropped; disk file untouched
+            return "skipped: user declined an edit outside the workspace"
         prs.save(str(p))
         return f"{box._rel(p)}: replaced {find!r} → {replace!r} in {hits} run(s)"
 

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -85,6 +85,13 @@ def test_readonly_allowed():
     assert _rev("pwd")
 
 
+def test_readonly_system_info_commands_allowed():
+    # read-only system/info commands added to _SAFE_COMMANDS: they never mutate
+    # the filesystem or reach the network, so they auto-run without confirmation.
+    for cmd in ("ps aux", "df -h", "du -sh .", "uname -a", "id", "printenv PATH", "realpath ."):
+        assert _rev(cmd), f"expected {cmd!r} to be reversible/read-only"
+
+
 def test_inworkspace_mutations_allowed():
     assert _rev("touch new.txt")
     assert _rev("mkdir subdir")

--- a/tests/test_office.py
+++ b/tests/test_office.py
@@ -4,7 +4,8 @@ import pytest
 
 pytest.importorskip("openpyxl")
 pytest.importorskip("pptx")
-pytest.importorskip("docx")
+# NOTE: python-docx is gated per-test (see the read_docx tests), not module-wide,
+# so the xlsx/pptx suite still runs when only python-docx is missing.
 
 from opendot.reversibility.engine import Reversibility
 from opendot.reversibility.snapshots import IgnoreRules
@@ -60,10 +61,16 @@ def _make_docx(path):
 def test_office_tools_registered(tmp_path):
     tb, _, _ = _tb(tmp_path)
     names = {s["function"]["name"] for s in tb.specs()}
-    assert {"read_xlsx", "edit_cell", "read_pptx", "edit_pptx_text", "read_docx"} <= names
+    assert {"read_xlsx", "edit_cell", "read_pptx", "edit_pptx_text"} <= names
+    # read_docx is gated on python-docx being importable.
+    import importlib.util
+
+    if importlib.util.find_spec("docx") is not None:
+        assert "read_docx" in names
 
 
 def test_read_docx(tmp_path):
+    pytest.importorskip("docx")
     tb, wd, _ = _tb(tmp_path)
     _make_docx(wd / "report.docx")
 
@@ -74,6 +81,7 @@ def test_read_docx(tmp_path):
 
 
 def test_read_docx_missing_file(tmp_path):
+    pytest.importorskip("docx")
     tb, _, _ = _tb(tmp_path)
     assert tb.call("read_docx", {"path": "nope.docx"}).startswith("error: file not found")
 

--- a/tests/test_office.py
+++ b/tests/test_office.py
@@ -144,3 +144,38 @@ def test_edit_pptx_missing_text_is_error(tmp_path):
     _make_pptx(wd / "deck.pptx")
     res = tb.call("edit_pptx_text", {"path": "deck.pptx", "find": "nope", "replace": "x"})
     assert "not found" in res
+
+
+def test_office_edit_outside_workspace_is_irreversible(tmp_path):
+    """An office edit to a file outside the working dir isn't covered by the
+    snapshot, so it's recorded as not-undoable (undo that doesn't lie)."""
+    wd = tmp_path / "ws"
+    wd.mkdir()
+    rev = Reversibility(workdir=str(wd), rules=IgnoreRules())
+    tb = Toolbox(str(wd), reversibility=rev, confirm=lambda p: True)
+
+    outside = tmp_path / "outside.xlsx"  # sibling of ws/, not under it
+    _make_xlsx(outside)
+
+    res = tb.call("edit_cell", {"path": str(outside), "cell": "B2", "value": "999"})
+    assert "999" in res
+    last = rev.history()[-1]
+    assert last.reversible is False
+    assert "not undoable" in last.note
+
+
+def test_office_edit_outside_declined_is_skipped(tmp_path):
+    wd = tmp_path / "ws"
+    wd.mkdir()
+    rev = Reversibility(workdir=str(wd), rules=IgnoreRules())
+    tb = Toolbox(str(wd), reversibility=rev, confirm=lambda p: False)  # decline
+
+    outside = tmp_path / "outside.xlsx"
+    _make_xlsx(outside)
+    import openpyxl
+
+    before = openpyxl.load_workbook(outside).active["B2"].value
+    res = tb.call("edit_cell", {"path": str(outside), "cell": "B2", "value": "999"})
+    assert res.startswith("skipped")
+    after = openpyxl.load_workbook(outside).active["B2"].value
+    assert after == before  # file on disk unchanged

--- a/tests/test_office.py
+++ b/tests/test_office.py
@@ -4,6 +4,7 @@ import pytest
 
 pytest.importorskip("openpyxl")
 pytest.importorskip("pptx")
+pytest.importorskip("docx")
 
 from opendot.reversibility.engine import Reversibility
 from opendot.reversibility.snapshots import IgnoreRules
@@ -46,10 +47,35 @@ def _make_pptx(path):
     prs.save(path)
 
 
+def _make_docx(path):
+    from docx import Document
+
+    doc = Document()
+    doc.add_heading("Project Report", level=1)
+    doc.add_paragraph("First paragraph of the body.")
+    doc.add_paragraph("Second paragraph with details.")
+    doc.save(path)
+
+
 def test_office_tools_registered(tmp_path):
     tb, _, _ = _tb(tmp_path)
     names = {s["function"]["name"] for s in tb.specs()}
-    assert {"read_xlsx", "edit_cell", "read_pptx", "edit_pptx_text"} <= names
+    assert {"read_xlsx", "edit_cell", "read_pptx", "edit_pptx_text", "read_docx"} <= names
+
+
+def test_read_docx(tmp_path):
+    tb, wd, _ = _tb(tmp_path)
+    _make_docx(wd / "report.docx")
+
+    out = tb.call("read_docx", {"path": "report.docx"})
+    assert "Project Report" in out
+    assert "First paragraph of the body." in out
+    assert "Second paragraph with details." in out
+
+
+def test_read_docx_missing_file(tmp_path):
+    tb, _, _ = _tb(tmp_path)
+    assert tb.call("read_docx", {"path": "nope.docx"}).startswith("error: file not found")
 
 
 def test_read_and_edit_xlsx(tmp_path):

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -413,3 +413,89 @@ def test_no_snapshot_ids_stay_monotonic_with_real_snapshots(tmp_path):
     ids = [id1, id2, id3]
     assert ids == sorted(ids)  # strictly increasing
     assert len(set(ids)) == 3  # all unique
+
+
+# --- edge cases (issue #16): symlinks, dedup, deep nesting, file<->dir, unicode ---
+
+
+def test_symlink_is_not_followed_or_captured(tmp_path):
+    """A symlink in the workspace must not be followed into its target, and the
+    snapshot must not capture the symlink as a regular file. Restore must leave
+    the outside target untouched."""
+    wd = _workspace(tmp_path)
+    outside = tmp_path / "outside.txt"
+    outside.write_text("do not touch me")
+    (wd / "link.txt").symlink_to(outside)
+    (wd / "real.py").write_text("real")
+
+    snap = S.take_snapshot(wd)
+    # the symlink is skipped; only the real file is captured
+    assert "real.py" in snap.files
+    assert "link.txt" not in snap.files
+
+    S.restore_snapshot(snap)
+    # the outside target was never read or modified
+    assert outside.read_text() == "do not touch me"
+
+
+def test_identical_content_dedupes_to_one_object(tmp_path):
+    """Two files with the same content share a single content-addressed object,
+    and both restore correctly."""
+    wd = _workspace(tmp_path)
+    (wd / "a.txt").write_text("same bytes")
+    (wd / "b.txt").write_text("same bytes")
+    (wd / "c.txt").write_text("different")
+
+    snap = S.take_snapshot(wd)
+    objs = [o for o in S._objects_dir().iterdir() if o.suffix != ".tmp"]
+    assert len(objs) == 2  # "same bytes" stored once + "different"
+
+    (wd / "a.txt").write_text("wrecked")
+    (wd / "b.txt").unlink()
+    S.restore_snapshot(snap)
+    assert (wd / "a.txt").read_text() == "same bytes"
+    assert (wd / "b.txt").read_text() == "same bytes"
+
+
+def test_deeply_nested_tree_restores(tmp_path):
+    wd = _workspace(tmp_path)
+    deep = wd / "a" / "b" / "c" / "d" / "e"
+    deep.mkdir(parents=True)
+    (deep / "leaf.txt").write_text("buried")
+    snap = S.take_snapshot(wd)
+
+    import shutil
+
+    shutil.rmtree(wd / "a")
+    S.restore_snapshot(snap)
+    assert (deep / "leaf.txt").read_text() == "buried"
+
+
+def test_file_replaced_by_directory_roundtrips(tmp_path):
+    """A path that was a file at snapshot time, then becomes a directory, must be
+    restored back to the file."""
+    wd = _workspace(tmp_path)
+    (wd / "thing").write_text("i am a file")
+    snap = S.take_snapshot(wd)
+
+    (wd / "thing").unlink()
+    (wd / "thing").mkdir()
+    (wd / "thing" / "inside.txt").write_text("now a dir")
+
+    S.restore_snapshot(snap)
+    assert (wd / "thing").is_file()
+    assert (wd / "thing").read_text() == "i am a file"
+
+
+def test_unicode_and_spaces_in_filenames(tmp_path):
+    wd = _workspace(tmp_path)
+    names = ["café menu.txt", "日本語.md", "emoji 🚀.txt"]
+    for n in names:
+        (wd / n).write_text(f"content of {n}")
+    snap = S.take_snapshot(wd)
+
+    for n in names:
+        (wd / n).write_text("changed")
+    S.restore_snapshot(snap)
+    for n in names:
+        assert (wd / n).read_text() == f"content of {n}"

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -425,7 +425,10 @@ def test_symlink_is_not_followed_or_captured(tmp_path):
     wd = _workspace(tmp_path)
     outside = tmp_path / "outside.txt"
     outside.write_text("do not touch me")
-    (wd / "link.txt").symlink_to(outside)
+    try:
+        (wd / "link.txt").symlink_to(outside)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform/filesystem")
     (wd / "real.py").write_text("real")
 
     snap = S.take_snapshot(wd)
@@ -436,6 +439,28 @@ def test_symlink_is_not_followed_or_captured(tmp_path):
     S.restore_snapshot(snap)
     # the outside target was never read or modified
     assert outside.read_text() == "do not touch me"
+
+
+def test_restore_never_writes_through_a_symlink(tmp_path):
+    """If a captured file's path is later replaced by a symlink pointing OUTSIDE
+    the workspace, restore must unlink it and rewrite the real file, never write
+    through the symlink to the outside target."""
+    wd = _workspace(tmp_path)
+    (wd / "config.txt").write_text("original")
+    snap = S.take_snapshot(wd)
+
+    outside = tmp_path / "secret.txt"
+    outside.write_text("must not be overwritten")
+    (wd / "config.txt").unlink()
+    try:
+        (wd / "config.txt").symlink_to(outside)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform/filesystem")
+
+    S.restore_snapshot(snap)
+    assert (wd / "config.txt").read_text() == "original"  # real file restored
+    assert not (wd / "config.txt").is_symlink()  # symlink removed
+    assert outside.read_text() == "must not be overwritten"  # outside untouched
 
 
 def test_identical_content_dedupes_to_one_object(tmp_path):

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -463,6 +463,27 @@ def test_restore_never_writes_through_a_symlink(tmp_path):
     assert outside.read_text() == "must not be overwritten"  # outside untouched
 
 
+def test_restore_ignores_tampered_absolute_and_traversal_paths(tmp_path):
+    """A tampered snapshot manifest with an absolute path or a '..' segment must
+    not write outside the workspace; valid entries still restore."""
+    wd = _workspace(tmp_path)
+    (wd / "good.txt").write_text("legit")
+    snap = S.take_snapshot(wd)
+
+    # Reuse a real stored object hash for the malicious entries.
+    real_hash = snap.files["good.txt"].h
+    outside = tmp_path / "escape.txt"  # sits OUTSIDE wd
+    snap.files["../escape.txt"] = S.FileEntry(h=real_hash)
+    snap.files[str((tmp_path / "abs_escape.txt"))] = S.FileEntry(h=real_hash)
+
+    (wd / "good.txt").write_text("changed")
+    S.restore_snapshot(snap)
+
+    assert (wd / "good.txt").read_text() == "legit"  # valid entry still restored
+    assert not outside.exists()  # traversal entry was skipped
+    assert not (tmp_path / "abs_escape.txt").exists()  # absolute entry was skipped
+
+
 def test_restore_never_writes_through_a_symlinked_parent(tmp_path):
     """A subtler escape: a captured file's PARENT dir is later replaced by a
     symlink pointing outside the workspace. Restore must rebuild the parent as a

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -463,6 +463,34 @@ def test_restore_never_writes_through_a_symlink(tmp_path):
     assert outside.read_text() == "must not be overwritten"  # outside untouched
 
 
+def test_restore_never_writes_through_a_symlinked_parent(tmp_path):
+    """A subtler escape: a captured file's PARENT dir is later replaced by a
+    symlink pointing outside the workspace. Restore must rebuild the parent as a
+    real directory, never write the file through the symlink into the target."""
+    wd = _workspace(tmp_path)
+    (wd / "conf").mkdir()
+    (wd / "conf" / "app.conf").write_text("real config")
+    snap = S.take_snapshot(wd)
+
+    # Replace the whole conf/ directory with a symlink to an outside directory.
+    outside_dir = tmp_path / "elsewhere"
+    outside_dir.mkdir()
+    (outside_dir / "app.conf").write_text("outside file, must not be overwritten")
+    import shutil
+
+    shutil.rmtree(wd / "conf")
+    try:
+        (wd / "conf").symlink_to(outside_dir)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform/filesystem")
+
+    S.restore_snapshot(snap)
+    assert not (wd / "conf").is_symlink()  # parent rebuilt as a real dir
+    assert (wd / "conf" / "app.conf").read_text() == "real config"  # restored in-workspace
+    # the outside directory's file was never touched
+    assert (outside_dir / "app.conf").read_text() == "outside file, must not be overwritten"
+
+
 def test_identical_content_dedupes_to_one_object(tmp_path):
     """Two files with the same content share a single content-addressed object,
     and both restore correctly."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -109,3 +109,40 @@ def test_web_fetch_is_read_only():
     from opendot.tools.local import Toolbox
 
     assert "web_fetch" in Toolbox.READ_ONLY  # runs without a snapshot, like read_file
+
+
+def test_write_outside_workspace_is_irreversible_and_confirmed(tmp_path):
+    """A write outside the working dir isn't covered by the snapshot, so it must
+    be confirmed first and recorded as NOT reversible (undo that doesn't lie)."""
+    tb, wd, rev = _tb(tmp_path)
+    outside = tmp_path / "outside.txt"  # sibling of ws/, not under it
+
+    out = tb.call("write_file", {"path": str(outside), "content": "hi"})
+    assert "created" in out or "updated" in out
+    assert outside.read_text() == "hi"
+
+    last = rev.history()[-1]
+    assert last.reversible is False  # ledger tells the truth
+    assert "not undoable" in last.note
+
+
+def test_declining_outside_write_skips_it(tmp_path):
+    from opendot.reversibility.engine import Reversibility
+    from opendot.reversibility.snapshots import IgnoreRules
+    from opendot.tools.local import Toolbox
+
+    wd = tmp_path / "ws"
+    wd.mkdir()
+    rev = Reversibility(workdir=str(wd), rules=IgnoreRules())
+    tb = Toolbox(str(wd), reversibility=rev, confirm=lambda p: False)  # decline
+
+    outside = tmp_path / "outside.txt"
+    out = tb.call("write_file", {"path": str(outside), "content": "hi"})
+    assert out.startswith("skipped")
+    assert not outside.exists()  # nothing written
+
+
+def test_write_inside_workspace_stays_reversible(tmp_path):
+    tb, wd, rev = _tb(tmp_path)
+    tb.call("write_file", {"path": "new.txt", "content": "inside"})
+    assert rev.history()[-1].reversible is True  # in-workspace = undoable


### PR DESCRIPTION
Closes #13, #14, #16.

### #14 — read_docx office tool
- Add a read_docx tool (via python-docx) that extracts a .docx document's text,
  following the existing read_xlsx / read_pptx pattern.
- Add python-docx to the office (and dev) extras; register read_docx as read-only.
- Gated independently: it only registers when python-docx is importable, so
  openpyxl/pptx users without it still get the other office tools.

### #13 — more read-only safe commands
- Add genuinely read-only system/info commands to _SAFE_COMMANDS so they auto-run
  without a confirmation prompt: ps, df, du, uname, id, groups, printenv,
  basename, dirname, realpath. None mutate the filesystem or reach the network.

### #16 — snapshot engine edge-case tests (found and fixed a real bug)
- Add edge-case coverage to the reversibility snapshot store: symlinks are not
  followed or captured, identical content dedupes to one object, deeply nested
  trees restore, unicode/spaces in filenames round-trip, and a path that was a
  file at snapshot time but became a directory restores correctly.
- The file-replaced-by-directory test surfaced a real restore bug:
  restore_snapshot raised IsADirectoryError when a directory now occupied a
  captured file's path. Fixed by removing the occupying directory before
  rewriting the file — a correctness fix to the core undo guarantee.

### Tests
- 113 passing (added tests for all three); lint/format clean.

Bump version to 0.1.9.