### PR TITLE
display file sizes in list_files output

### DIFF
--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -154,10 +154,13 @@ class Toolbox:
     def _build(self) -> list[Tool]:
         def _format_size(num_bytes: int) -> str:
             if num_bytes < 1024:
-               return f"{num_bytes} B"
+                return f"{num_bytes} B"
             if num_bytes < 1024 * 1024:
-               return f"{num_bytes / 1024:.1f} KB"
-            return f"{num_bytes / (1024 * 1024):.1f} MB"
+                return f"{num_bytes / 1024:.1f} KB"
+            if num_bytes < 1024 * 1024 * 1024:
+                return f"{num_bytes / (1024 * 1024):.1f} MB"
+            return f"{num_bytes / (1024 * 1024 * 1024):.1f} GB"
+
         def list_files(path: str = ".") -> str:
             base = self._resolve(path)
             if not base.exists():
@@ -174,8 +177,12 @@ class Toolbox:
                 if e.is_dir():
                     entries.append(f"{e.name}/")
                 else:
-                    size = _format_size(e.stat().st_size)
-                    entries.append(f"{e.name} ({size})")
+                    # A broken symlink or unreadable file shouldn't crash the whole
+                    # listing — just show the name without a size.
+                    try:
+                        entries.append(f"{e.name} ({_format_size(e.stat().st_size)})")
+                    except OSError:
+                        entries.append(e.name)
             return _truncate("\n".join(entries) or "(empty)")
 
         def read_file(path: str) -> str:

--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -152,6 +152,12 @@ class Toolbox:
 
     # -- the tools --
     def _build(self) -> list[Tool]:
+        def _format_size(num_bytes: int) -> str:
+            if num_bytes < 1024:
+               return f"{num_bytes} B"
+            if num_bytes < 1024 * 1024:
+               return f"{num_bytes / 1024:.1f} KB"
+            return f"{num_bytes / (1024 * 1024):.1f} MB"
         def list_files(path: str = ".") -> str:
             base = self._resolve(path)
             if not base.exists():
@@ -165,7 +171,11 @@ class Toolbox:
                     "__pycache__",
                 }:
                     continue
-                entries.append(e.name + ("/" if e.is_dir() else ""))
+                if e.is_dir():
+                    entries.append(f"{e.name}/")
+                else:
+                    size = _format_size(e.stat().st_size)
+                    entries.append(f"{e.name} ({size})")
             return _truncate("\n".join(entries) or "(empty)")
 
         def read_file(path: str) -> str:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -42,6 +42,28 @@ def test_glob(tmp_path):
     assert "README.md" not in out
 
 
+def test_list_files_shows_sizes(tmp_path):
+    tb, wd, _ = _tb(tmp_path)
+    out = tb.call("list_files", {"path": "."})
+    # files show a human-readable size; README.md is "hello\n" = 6 bytes
+    assert "README.md (6 B)" in out
+    # directories are marked with a trailing slash and carry no size
+    assert "src/" in out
+    assert "src/ (" not in out
+
+
+def test_list_files_survives_unreadable_entry(tmp_path):
+    """A broken symlink (stat() raises) must not crash the whole listing — the
+    entry is shown without a size instead."""
+    import os
+
+    tb, wd, _ = _tb(tmp_path)
+    os.symlink(wd / "does-not-exist", wd / "dangling")
+    out = tb.call("list_files", {"path": "."})
+    assert "dangling" in out  # listed, no crash
+    assert "README.md (6 B)" in out  # readable files still get sizes
+
+
 def test_edit_replaces_and_reports(tmp_path):
     tb, wd, _ = _tb(tmp_path)
     out = tb.call("edit", {"path": "src/b.py", "find": "z = 3", "replace": "z = 99"})


### PR DESCRIPTION
Added a helper function to format file sizes in bytes.

<!-- Keep it short and in your own words. See CONTRIBUTING.md. -->

## What & why

<!-- What does this change, and why? One or two sentences. -->

## How I verified it

<!-- What did you test, and how can a reviewer reproduce/confirm it? -->

## Checklist

- [ ] Small and focused (one change)
- [ ] Added/updated tests; `pytest` passes locally
- [ ] If it touches `reversibility/` or a mutating tool: actions are snapshotted and undo still restores exactly (tests added)
- [ ] If it changes the UI: screenshot / short recording included below

<!-- UI screenshots (before / after) go here if applicable. -->
