### PR TITLE
Implement size formatting function in local.py

### DIFF
--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -152,6 +152,15 @@ class Toolbox:
 
     # -- the tools --
     def _build(self) -> list[Tool]:
+        def _format_size(size: int) -> str:
+            if size < 1024:
+                return f"{size} B"
+            if size < 1024 * 1024:
+                return f"{size / 1024:.1f} KB"
+            if size < 1024 * 1024 * 1024:
+                return f"{size / (1024 * 1024):.1f} MB"
+            return f"{size / (1024 * 1024 * 1024):.1f} GB"
+            
         def list_files(path: str = ".") -> str:
             base = self._resolve(path)
             if not base.exists():
@@ -165,7 +174,12 @@ class Toolbox:
                     "__pycache__",
                 }:
                     continue
-                entries.append(e.name + ("/" if e.is_dir() else ""))
+                if e.is_dir():
+                    entries.append(f"{e.name}/")
+                else:
+                    size = _format_size(e.stat().st_size)
+                    entries.append(f"{e.name} ({size})")
+                     
             return _truncate("\n".join(entries) or "(empty)")
 
         def read_file(path: str) -> str:


### PR DESCRIPTION
Added a helper function to format file sizes in human-readable format.

<!-- Keep it short and in your own words. See CONTRIBUTING.md. -->

## What & why

<!-- What does this change, and why? One or two sentences. -->

## How I verified it

<!-- What did you test, and how can a reviewer reproduce/confirm it? -->

## Checklist

- [ ] Small and focused (one change)
- [ ] Added/updated tests; `pytest` passes locally
- [ ] If it touches `reversibility/` or a mutating tool: actions are snapshotted and undo still restores exactly (tests added)
- [ ] If it changes the UI: screenshot / short recording included below

<!-- UI screenshots (before / after) go here if applicable. -->
