### PR TITLE
fix(tools): return clear error when read_file is given a directory

### DIFF
--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -172,6 +172,8 @@ class Toolbox:
             p = self._resolve(path)
             if not p.exists():
                 return f"error: file not found: {p}"
+            if p.is_dir():
+                return f"error: {p} is a directory (use list_files to see its contents)"
             try:
                 return _truncate(p.read_text(encoding="utf-8", errors="replace"))
             except Exception as exc:  # noqa: BLE001

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -146,3 +146,13 @@ def test_write_inside_workspace_stays_reversible(tmp_path):
     tb, wd, rev = _tb(tmp_path)
     tb.call("write_file", {"path": "new.txt", "content": "inside"})
     assert rev.history()[-1].reversible is True  # in-workspace = undoable
+
+
+def test_read_file_directory_returns_clear_error(tmp_path):
+    """read_file on a directory should suggest the right tool instead of a low-level
+    IsADirectoryError."""
+    tb, wd, _ = _tb(tmp_path)
+    out = tb.call("read_file", {"path": "src"})
+    assert "is a directory" in out
+    assert "list_files" in out
+    assert "IsADirectoryError" not in out


### PR DESCRIPTION
## Problem

`read_file` on a directory surfaced a low-level `IsADirectoryError` wrapped in a generic `error reading ...` message. For an agent that routes calls by name, that feedback is unhelpful — it does not say *why* the call failed or which tool should be used instead.

Issue: vedaant00/opendot#40

## Analysis

`Toolbox.read_file` resolved the path, checked `exists()`, and immediately tried `read_text()`. A directory path survives the existence check and only fails inside `read_text`, where the broad `except Exception` converted the exception into an opaque string.

`list_files` already handles the symmetric case gracefully: when given a file, it returns the file path instead of crashing. `read_file` should mirror that pattern.

## Solution

Added an explicit directory check before reading:

```python
if p.is_dir():
    return f"error: {p} is a directory (use list_files to see its contents)"
```

This is placed after the `not p.exists()` check so a missing path still reports "file not found", preserving existing behavior for files.

## Benchmarks / verification

- Added a regression test asserting that `read_file` on a directory returns a message containing "is a directory" and "list_files", and does not mention `IsADirectoryError`.
- Full test suite: `pytest tests/ -q` — **128 passed** (was 127).

## Notes

- No changes to mutating tools or the reversibility engine; this is a read-only error-message improvement.
- The message uses the resolved absolute path, matching the existing error style in `read_file` and `list_files`.
