### PR TITLE
feat(mcp): browser-OAuth flow for authenticated MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,19 +116,26 @@ opendot mcp add <name> --env KEY=VALUE -- <command> [args...]
 # a remote server (http/sse)
 opendot mcp add <name> --url <https url>
 
-# a remote server that needs auth — pass an HTTP header
+# a remote server with a static token — pass an HTTP header
 opendot mcp add supabase \
   --url "https://mcp.supabase.com/mcp?project_ref=<id>&read_only=true" \
   --header "Authorization=Bearer <your-supabase-access-token>"
+
+# a remote server that uses OAuth — authorize in your browser
+opendot mcp add linear --url "https://mcp.linear.app/mcp" --oauth
 
 opendot mcp list           # show configured servers
 opendot mcp remove <name>  # remove one
 ```
 
 Servers are stored in `~/.opendot/mcp.json` and connect automatically on the
-next launch; connected servers appear in the sidebar. For authenticated remote
-servers, opendot supports the header/token method (e.g. Supabase's access
-token) — the interactive browser-OAuth flow is not implemented yet.
+next launch; connected servers appear in the sidebar. Authenticated remote
+servers work two ways: a **static token** via `--header` (e.g. Supabase's access
+token), or **browser OAuth** via `--oauth` (or by typing `oauth` in the `/mcp`
+add form) — opendot opens your browser to authorize, runs a one-shot local
+callback server to catch the redirect, and caches the issued tokens under
+`~/.opendot/mcp_oauth/` (owner-readable only), refreshing them automatically.
+Removing a server also forgets its cached OAuth tokens.
 
 Because opendot can't know what an external tool does, **every MCP tool call is
 treated as irreversible** — it's confirmed before running and marked ✗ in the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.1.9"
+version = "0.2.0"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 from opendot.agent.loop import Agent
 
-__version__ = "0.1.9"
+__version__ = "0.2.0"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -229,12 +229,14 @@ def _cmd_mcp(args) -> None:
                 env[k] = v
         if args.url:
             spec = {"url": args.url}
+            if getattr(args, "oauth", False):
+                spec["auth"] = "oauth"  # browser-OAuth; opendot obtains tokens itself
             headers = {}
             for pair in getattr(args, "header", []):
                 if "=" in pair:
                     k, v = pair.split("=", 1)
                     headers[k.strip()] = v.strip()
-            if headers:
+            if headers and "auth" not in spec:
                 spec["headers"] = headers  # e.g. Authorization=Bearer <token>
         else:
             cmd = list(getattr(args, "post_dashdash", []))
@@ -249,6 +251,22 @@ def _cmd_mcp(args) -> None:
         if env:
             spec["env"] = env
         add_mcp_server(args.name, spec)
+        if spec.get("auth") == "oauth":
+            from opendot.mcp import authorize_oauth_server
+
+            console.print(f"opening your browser to authorize [cyan]{args.name}[/cyan]…")
+            res = authorize_oauth_server(args.name, spec)
+            if res.ok:
+                console.print(
+                    f"[green]✓ authorized[/green] [cyan]{args.name}[/cyan] — "
+                    f"{res.tool_count} tools. They load next time you run opendot."
+                )
+            else:
+                console.print(
+                    f"[red]✗ authorization failed[/red] — {res.error}. "
+                    f"The server is saved; retry with `opendot mcp test {args.name}`."
+                )
+            return
         console.print(
             f"[green]added[/green] MCP server [cyan]{args.name}[/cyan]. It will connect next time you run opendot."
         )
@@ -478,6 +496,12 @@ def main() -> None:
         metavar="KEY=VAL",
         help="HTTP header for a remote (--url) server, e.g. "
         "'Authorization=Bearer <token>' (repeatable).",
+    )
+    p_add.add_argument(
+        "--oauth",
+        action="store_true",
+        help="Authorize a remote (--url) server via browser OAuth instead of a static "
+        "token. Opens your browser to authorize when you add it.",
     )
     # The launch command (after `--`) is captured from argv in main(), not here,
     # so its own flags (e.g. -y) aren't parsed by argparse.

--- a/src/opendot/mcp/__init__.py
+++ b/src/opendot/mcp/__init__.py
@@ -1,8 +1,10 @@
 """MCP client support — connect opendot to external MCP servers' tools."""
 
 from opendot.mcp.manager import (
+    AuthorizeResult,
     MCPManager,
     add_mcp_server,
+    authorize_oauth_server,
     load_mcp_config,
     remove_mcp_server,
     save_mcp_config,
@@ -10,8 +12,10 @@ from opendot.mcp.manager import (
 
 __all__ = [
     "MCPManager",
+    "AuthorizeResult",
     "load_mcp_config",
     "save_mcp_config",
     "add_mcp_server",
+    "authorize_oauth_server",
     "remove_mcp_server",
 ]

--- a/src/opendot/mcp/manager.py
+++ b/src/opendot/mcp/manager.py
@@ -78,7 +78,8 @@ def remove_mcp_server(name: str) -> bool:
         return False
     del servers[name]
     save_mcp_config(servers)
-    # If it was an OAuth server, forget its cached tokens too.
+    # Forget any cached OAuth tokens/registration for this name (a no-op for
+    # servers that never used OAuth).
     try:
         from opendot.mcp.oauth import clear_tokens
 
@@ -193,13 +194,19 @@ class MCPManager:
             except Exception as exc:  # noqa: BLE001 - a bad server must not kill the rest
                 self.errors[name] = f"{type(exc).__name__}: {exc}"
         # OAuth callback servers have done their job once every server is connected.
-        for cb in self._callbacks:
+        # shutdown() also sweeps any survivors, in case it races this coroutine
+        # (e.g. start() timed out and the app exits before we get here).
+        self._close_callbacks()
+        ready.set()
+
+    def _close_callbacks(self) -> None:
+        """Close and forget any open loopback OAuth callback servers (idempotent)."""
+        while self._callbacks:
+            cb = self._callbacks.pop()
             try:
                 cb.close()
             except Exception:  # noqa: BLE001
                 pass
-        self._callbacks.clear()
-        ready.set()
 
     async def _open_transport(self, spec: dict):
         """Return (read, write) streams for a stdio or http/sse server."""
@@ -272,6 +279,10 @@ class MCPManager:
             return f"error calling {server}.{name}: {exc}"
 
     def shutdown(self) -> None:
+        # Close any loopback OAuth callback servers first — they may still be open
+        # if start() timed out mid-authorization and we never reached _connect_all's
+        # own cleanup. Idempotent, so double-closing after a clean connect is fine.
+        self._close_callbacks()
         if self._loop and self._loop.is_running():
 
             async def _close():

--- a/src/opendot/mcp/manager.py
+++ b/src/opendot/mcp/manager.py
@@ -16,9 +16,13 @@ Config lives at ``~/.opendot/mcp.json`` (Claude-Desktop-style):
                        "env": {"GITHUB_TOKEN": "..."} },
         "remote":    { "url": "https://example.com/mcp" },         // http/sse
         "supabase":  { "url": "https://mcp.supabase.com/mcp?project_ref=abc",
-                       "headers": {"Authorization": "Bearer <PAT>"} }  // authenticated remote
+                       "headers": {"Authorization": "Bearer <PAT>"} },  // static token
+        "linear":    { "url": "https://mcp.linear.app/mcp", "auth": "oauth" }  // browser OAuth
       }
     }
+
+Tokens for ``"auth": "oauth"`` servers live outside this file (see
+``opendot.mcp.oauth``); the config only records that the server uses OAuth.
 
 MCP tools are OPAQUE — opendot can't know if a call is reversible. So callers
 treat every MCP tool as irreversible (confirm + mark ✗ in the ledger).
@@ -74,7 +78,43 @@ def remove_mcp_server(name: str) -> bool:
         return False
     del servers[name]
     save_mcp_config(servers)
+    # If it was an OAuth server, forget its cached tokens too.
+    try:
+        from opendot.mcp.oauth import clear_tokens
+
+        clear_tokens(name)
+    except Exception:  # noqa: BLE001
+        pass
     return True
+
+
+@dataclass
+class AuthorizeResult:
+    ok: bool
+    tool_count: int = 0
+    error: str | None = None
+
+
+def authorize_oauth_server(name: str, spec: dict) -> AuthorizeResult:
+    """Connect one OAuth server now, driving the browser flow, to prove it works.
+
+    Called at add-time (from the TUI) so the user authorizes in-browser immediately
+    and tokens get cached — no restart needed to reach a working state. Spins up a
+    throwaway single-server manager, connects (which opens the browser on first
+    auth), and reports the tool count or the failure. Blocking; run off the UI thread.
+    """
+    mgr = MCPManager({name: spec})
+    try:
+        # The OAuth browser dance waits on a human, so allow well past start's
+        # default settle window (matches the provider's 300s flow timeout).
+        mgr.start(settle_timeout=300.0)
+        if name in mgr.connected:
+            return AuthorizeResult(
+                ok=True, tool_count=sum(1 for t in mgr.tools if t.server == name)
+            )
+        return AuthorizeResult(ok=False, error=mgr.errors.get(name, "connection failed"))
+    finally:
+        mgr.shutdown()
 
 
 @dataclass
@@ -102,10 +142,17 @@ class MCPManager:
         self._thread: threading.Thread | None = None
         self._sessions: dict[str, Any] = {}
         self._stack = None  # AsyncExitStack holding all open connections
+        self._callbacks: list[Any] = []  # loopback OAuth callback servers to close
 
     # -- lifecycle --
-    def start(self) -> None:
-        """Spin up the background loop and connect all configured servers."""
+    def start(self, settle_timeout: float = 30.0) -> None:
+        """Spin up the background loop and connect all configured servers.
+
+        ``settle_timeout`` bounds how long ``start`` blocks waiting for connections
+        to settle. The default (30s) suits normal launch; the OAuth authorize flow
+        passes a larger value because it waits on a human clicking through a browser
+        consent screen.
+        """
         if not self.config or self._thread is not None:
             return
         ready = threading.Event()
@@ -118,7 +165,7 @@ class MCPManager:
 
         self._thread = threading.Thread(target=run, daemon=True, name="opendot-mcp")
         self._thread.start()
-        ready.wait(timeout=30)  # let connections settle (best-effort)
+        ready.wait(timeout=settle_timeout)  # let connections settle (best-effort)
 
     async def _connect_all(self, ready: threading.Event) -> None:
         from contextlib import AsyncExitStack
@@ -128,7 +175,7 @@ class MCPManager:
         self._stack = AsyncExitStack()
         for name, spec in self.config.items():
             try:
-                read, write = await self._open_transport(spec)
+                read, write = await self._open_transport({**spec, "_name": name})
                 session = await self._stack.enter_async_context(ClientSession(read, write))
                 await session.initialize()
                 self._sessions[name] = session
@@ -145,6 +192,13 @@ class MCPManager:
                     )
             except Exception as exc:  # noqa: BLE001 - a bad server must not kill the rest
                 self.errors[name] = f"{type(exc).__name__}: {exc}"
+        # OAuth callback servers have done their job once every server is connected.
+        for cb in self._callbacks:
+            try:
+                cb.close()
+            except Exception:  # noqa: BLE001
+                pass
+        self._callbacks.clear()
         ready.set()
 
     async def _open_transport(self, spec: dict):
@@ -152,14 +206,30 @@ class MCPManager:
         if spec.get("url"):
             url = spec["url"]
             headers = spec.get("headers") or None  # e.g. {"Authorization": "Bearer ..."}
+            auth = None
+            if spec.get("auth") == "oauth":
+                # Browser-OAuth server: attach an OAuthClientProvider (an httpx.Auth)
+                # that drives the authorize/refresh flow. Static headers are ignored
+                # for OAuth servers — the provider supplies Authorization itself.
+                from opendot.mcp.oauth import build_oauth_provider
+
+                auth, callback = build_oauth_provider(url, spec["_name"])
+                self._callbacks.append(callback)
+                headers = None
             if url.rstrip("/").endswith("/sse"):
                 from mcp.client.sse import sse_client
 
-                return (await self._stack.enter_async_context(sse_client(url, headers=headers)))[:2]
+                return (
+                    await self._stack.enter_async_context(
+                        sse_client(url, headers=headers, auth=auth)
+                    )
+                )[:2]
             from mcp.client.streamable_http import streamablehttp_client
 
             return (
-                await self._stack.enter_async_context(streamablehttp_client(url, headers=headers))
+                await self._stack.enter_async_context(
+                    streamablehttp_client(url, headers=headers, auth=auth)
+                )
             )[:2]
         # stdio
         from mcp import StdioServerParameters

--- a/src/opendot/mcp/oauth.py
+++ b/src/opendot/mcp/oauth.py
@@ -1,0 +1,225 @@
+"""Browser-OAuth support for authenticated remote MCP servers (issue #35).
+
+Many hosted MCP servers (Linear, Notion, GitHub's remote MCP, …) don't hand out a
+static token you can paste into an ``Authorization`` header — they use OAuth 2.0:
+you authorize in a browser, the server issues short-lived tokens, and the client
+refreshes them. This module wires the MCP SDK's ``OAuthClientProvider`` into
+opendot so a server marked ``"auth": "oauth"`` gets that flow.
+
+Three pieces, mirroring the desktop-OAuth pattern opendot already uses for Composio:
+
+* ``FileTokenStorage`` — persists the registered OAuth client + issued tokens to
+  ``~/.opendot/mcp_oauth/<server>.json`` (mode 0600; these are credentials), so a
+  server authorized once stays authorized across launches until the token is revoked.
+* ``_LoopbackCallbackServer`` — a one-shot ``127.0.0.1:<port>`` HTTP server that
+  catches the ``?code=…&state=…`` redirect and shows a "you can close this tab" page.
+  Its address is the OAuth ``redirect_uri``.
+* ``build_oauth_provider`` — assembles an ``OAuthClientProvider`` (an ``httpx.Auth``)
+  that the transport layer passes as ``auth=`` to the streamable-http / SSE client.
+
+Tokens live outside the tracked config (``mcp.json`` stays credential-free); the
+config only records ``"auth": "oauth"`` so opendot knows to attach the provider.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+from opendot.reversibility.snapshots import store_root
+
+# opendot registers itself as this OAuth client (dynamic registration fills in the
+# rest). client_name shows on the provider's consent screen.
+_CLIENT_NAME = "opendot"
+_DEFAULT_SCOPE = None  # let the server decide; some reject unknown scopes
+
+
+def _oauth_dir() -> Path:
+    d = store_root() / "mcp_oauth"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _token_file(server: str) -> Path:
+    # server names come from the user's own config; keep the filename filesystem-safe.
+    safe = "".join(c if (c.isalnum() or c in "-_.") else "_" for c in server)
+    return _oauth_dir() / f"{safe}.json"
+
+
+class FileTokenStorage:
+    """SDK ``TokenStorage`` backed by one JSON file per server.
+
+    Stores both the OAuth tokens and the dynamically-registered client info so we
+    don't re-register on every launch. Written with owner-only permissions.
+    """
+
+    def __init__(self, server: str) -> None:
+        self._path = _token_file(server)
+
+    def _read(self) -> dict:
+        if not self._path.exists():
+            return {}
+        try:
+            return json.loads(self._path.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001 - a corrupt file just means "re-auth"
+            return {}
+
+    def _write(self, data: dict) -> None:
+        self._path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        try:
+            self._path.chmod(0o600)  # tokens are secrets
+        except OSError:
+            pass
+
+    async def get_tokens(self):
+        from mcp.shared.auth import OAuthToken
+
+        raw = self._read().get("tokens")
+        return OAuthToken.model_validate(raw) if raw else None
+
+    async def set_tokens(self, tokens) -> None:
+        data = self._read()
+        data["tokens"] = tokens.model_dump(mode="json", exclude_none=True)
+        self._write(data)
+
+    async def get_client_info(self):
+        from mcp.shared.auth import OAuthClientInformationFull
+
+        raw = self._read().get("client_info")
+        return OAuthClientInformationFull.model_validate(raw) if raw else None
+
+    async def set_client_info(self, client_info) -> None:
+        data = self._read()
+        data["client_info"] = client_info.model_dump(mode="json", exclude_none=True)
+        self._write(data)
+
+
+def has_stored_tokens(server: str) -> bool:
+    """True if we already hold an OAuth token for this server (authorized before)."""
+    try:
+        return bool(json.loads(_token_file(server).read_text(encoding="utf-8")).get("tokens"))
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def clear_tokens(server: str) -> bool:
+    """Forget a server's OAuth tokens/registration (used when removing it). Returns
+    True if anything was deleted."""
+    path = _token_file(server)
+    if path.exists():
+        path.unlink()
+        return True
+    return False
+
+
+class _CallbackHandler(BaseHTTPRequestHandler):
+    """Captures the single OAuth redirect and answers with a close-me page."""
+
+    # set by the server instance
+    result: dict = {}
+    done: threading.Event
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib name
+        params = parse_qs(urlparse(self.path).query)
+        code = params.get("code", [None])[0]
+        state = params.get("state", [None])[0]
+        error = params.get("error", [None])[0]
+        self.server.result = {"code": code, "state": state, "error": error}  # type: ignore[attr-defined]
+
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.end_headers()
+        if error:
+            body = f"<h2>Authorization failed</h2><p>{error}</p><p>You can close this tab.</p>"
+        else:
+            body = "<h2>Authorized ✓</h2><p>You can close this tab and return to opendot.</p>"
+        self.wfile.write(f"<!doctype html><html><body>{body}</body></html>".encode())
+        self.server.done.set()  # type: ignore[attr-defined]
+
+    def log_message(self, *args) -> None:  # silence stdlib request logging
+        return
+
+
+class _LoopbackCallbackServer:
+    """One-shot loopback HTTP server that yields the OAuth redirect's code+state.
+
+    Bind to an ephemeral port on 127.0.0.1; ``redirect_uri`` is this address. The
+    server runs on its own thread so the async callback handler can block-wait on it.
+    """
+
+    def __init__(self) -> None:
+        self._httpd = HTTPServer(("127.0.0.1", 0), _CallbackHandler)
+        self._httpd.result = {}  # type: ignore[attr-defined]
+        self._httpd.done = threading.Event()  # type: ignore[attr-defined]
+        self._thread: threading.Thread | None = None
+
+    @property
+    def redirect_uri(self) -> str:
+        host, port = self._httpd.server_address[:2]
+        return f"http://127.0.0.1:{port}/callback"
+
+    def start(self) -> None:
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+
+    def wait(self, timeout: float) -> dict:
+        """Block until the redirect arrives (or timeout). Returns {code,state,error}."""
+        got = self._httpd.done.wait(timeout)  # type: ignore[attr-defined]
+        if not got:
+            return {"code": None, "state": None, "error": "timeout waiting for authorization"}
+        return dict(self._httpd.result)  # type: ignore[attr-defined]
+
+    def close(self) -> None:
+        self._httpd.shutdown()
+        self._httpd.server_close()
+
+
+def build_oauth_provider(server_url: str, server_name: str):
+    """Build an ``OAuthClientProvider`` for a server, plus its callback server.
+
+    Returns ``(provider, callback_server)``. The caller passes ``provider`` as
+    ``auth=`` to the transport and must ``callback_server.close()`` when the
+    connection attempt is done (win or lose). The provider drives the flow: on the
+    first (unauthenticated) request it opens the browser via ``redirect_handler``
+    and waits for ``callback_handler`` to return the code; thereafter it uses the
+    stored/refreshed tokens with no browser interaction.
+    """
+    import anyio
+    from mcp.client.auth import OAuthClientProvider
+    from mcp.shared.auth import OAuthClientMetadata
+
+    callback = _LoopbackCallbackServer()
+    callback.start()
+
+    metadata = OAuthClientMetadata(
+        client_name=_CLIENT_NAME,
+        redirect_uris=[callback.redirect_uri],
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        scope=_DEFAULT_SCOPE,
+        token_endpoint_auth_method="none",  # public client (PKCE), no client secret
+    )
+
+    async def redirect_handler(auth_url: str) -> None:
+        # Open the user's browser to the provider's consent screen.
+        webbrowser.open(auth_url)
+
+    async def callback_handler() -> tuple[str, str | None]:
+        # Wait (off the event loop) for the loopback server to catch the redirect.
+        result = await anyio.to_thread.run_sync(lambda: callback.wait(300))
+        if result.get("error") or not result.get("code"):
+            raise RuntimeError(result.get("error") or "no authorization code received")
+        return result["code"], result.get("state")
+
+    provider = OAuthClientProvider(
+        server_url=server_url,
+        client_metadata=metadata,
+        storage=FileTokenStorage(server_name),
+        redirect_handler=redirect_handler,
+        callback_handler=callback_handler,
+    )
+    return provider, callback

--- a/src/opendot/mcp/oauth.py
+++ b/src/opendot/mcp/oauth.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import json
 import threading
 import webbrowser
+from html import escape
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
@@ -134,7 +135,10 @@ class _CallbackHandler(BaseHTTPRequestHandler):
         self.send_header("Content-Type", "text/html; charset=utf-8")
         self.end_headers()
         if error:
-            body = f"<h2>Authorization failed</h2><p>{error}</p><p>You can close this tab.</p>"
+            # Escape: this value comes from the redirect URL, so a crafted link
+            # (e.g. ?error=<script>…) must not inject markup into the page we serve.
+            safe = escape(error)
+            body = f"<h2>Authorization failed</h2><p>{safe}</p><p>You can close this tab.</p>"
         else:
             body = "<h2>Authorized ✓</h2><p>You can close this tab and return to opendot.</p>"
         self.wfile.write(f"<!doctype html><html><body>{body}</body></html>".encode())

--- a/src/opendot/mcp/oauth.py
+++ b/src/opendot/mcp/oauth.py
@@ -24,6 +24,7 @@ config only records ``"auth": "oauth"`` so opendot knows to attach the provider.
 from __future__ import annotations
 
 import json
+import os
 import threading
 import webbrowser
 from html import escape
@@ -70,11 +71,21 @@ class FileTokenStorage:
             return {}
 
     def _write(self, data: dict) -> None:
-        self._path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        # Tokens are secrets, so the file must never exist group/world-readable —
+        # not even briefly. Create a temp file that is 0600 *from the first byte*
+        # (O_CREAT with mode 0o600, before any content lands), then atomically
+        # rename it into place. os.replace also means a crash mid-write can't leave
+        # a torn token file.
+        payload = json.dumps(data, indent=2).encode("utf-8")
+        tmp = self._path.with_name(f".{self._path.name}.{os.getpid()}.tmp")
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
         try:
-            self._path.chmod(0o600)  # tokens are secrets
-        except OSError:
-            pass
+            with os.fdopen(fd, "wb") as f:
+                f.write(payload)
+            os.replace(tmp, self._path)
+        finally:
+            if tmp.exists():
+                tmp.unlink()
 
     async def get_tokens(self):
         from mcp.shared.auth import OAuthToken

--- a/src/opendot/tui/app.py
+++ b/src/opendot/tui/app.py
@@ -520,7 +520,9 @@ class OpendotTUI(App):
         self._refresh_sidebar()
 
     async def _manage_mcp(self) -> None:
-        from opendot.mcp import add_mcp_server, load_mcp_config
+        import asyncio
+
+        from opendot.mcp import add_mcp_server, authorize_oauth_server, load_mcp_config
 
         servers = load_mcp_config()
         mgr = getattr(self.agent, "mcp", None)
@@ -547,10 +549,29 @@ class OpendotTUI(App):
         result = await self.push_screen_wait(McpAddModal())
         if not result:
             return
-        add_mcp_server(result["name"], result["spec"])
+        name, spec = result["name"], result["spec"]
+        add_mcp_server(name, spec)
+
+        if spec.get("auth") == "oauth":
+            # Authorize in the browser now so the server is usable without a restart.
+            self._write(f"→ opening your browser to authorize '{name}'…", "sys")
+            res = await asyncio.to_thread(authorize_oauth_server, name, spec)
+            if res.ok:
+                self._write(
+                    f"✓ '{name}' authorized — {res.tool_count} tools. "
+                    f"They load on next launch (restart opendot).",
+                    "sys",
+                )
+            else:
+                self._write(
+                    f"✗ couldn't authorize '{name}': {res.error}. "
+                    f"The server is saved; retry from /mcp.",
+                    "sys",
+                )
+            return
+
         self._write(
-            f"✓ added MCP server '{result['name']}' — it connects on next launch "
-            f"(restart opendot).",
+            f"✓ added MCP server '{name}' — it connects on next launch (restart opendot).",
             "sys",
         )
 

--- a/src/opendot/tui/modals.py
+++ b/src/opendot/tui/modals.py
@@ -190,6 +190,10 @@ class McpAddModal(ModalScreen[dict | None]):
     One field decides the transport: a value starting with http(s):// is a
     remote server (with an optional Authorization header); anything else is a
     stdio launch command (split on spaces).
+
+    For a remote server that uses OAuth (Linear, Notion, GitHub's remote MCP, …),
+    type ``oauth`` in the auth field instead of a header — opendot will open your
+    browser to authorize when you add it.
     """
 
     CSS = """
@@ -209,9 +213,13 @@ class McpAddModal(ModalScreen[dict | None]):
                 placeholder="https://…/mcp   OR   npx -y @scope/server args…",
                 id="target",
             )
-            yield Input(placeholder="Authorization header (remote only, optional)", id="header")
+            yield Input(
+                placeholder="auth (remote only): 'oauth' for browser login, or an "
+                "Authorization header",
+                id="header",
+            )
             yield Static(
-                "enter submit · a value starting with http(s):// is treated as a remote URL",
+                "enter submit · http(s):// = remote URL · type 'oauth' to authorize in a browser",
                 id="hint",
             )
 
@@ -226,7 +234,9 @@ class McpAddModal(ModalScreen[dict | None]):
             return  # name + target required; keep the form open
         if target.lower().startswith(("http://", "https://")):
             spec: dict = {"url": target}
-            if header:
+            if header.lower() == "oauth":
+                spec["auth"] = "oauth"  # browser-OAuth flow, no static token
+            elif header:
                 k, _, v = header.partition("=") if "=" in header else header.partition(":")
                 spec["headers"] = {k.strip(): v.strip()}
         else:

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -53,15 +53,20 @@ async def test_token_storage_roundtrip():
 async def test_token_file_is_owner_only():
     from mcp.shared.auth import OAuthToken
 
-    from opendot.mcp.oauth import FileTokenStorage, _token_file
+    from opendot.mcp.oauth import FileTokenStorage, _oauth_dir, _token_file
 
-    await FileTokenStorage("secretsrv").set_tokens(
-        OAuthToken(access_token="x", token_type="Bearer")
-    )
+    store = FileTokenStorage("secretsrv")
+    await store.set_tokens(OAuthToken(access_token="x", token_type="Bearer"))
     path = _token_file("secretsrv")
     assert path.exists()
     # tokens are secrets — file must not be group/world readable
     assert (path.stat().st_mode & 0o077) == 0, "token file must be mode 0600"
+
+    # An overwrite (second write, e.g. token refresh) must preserve 0600 and not
+    # leave a temp file behind (atomic write via os.replace).
+    await store.set_tokens(OAuthToken(access_token="y", token_type="Bearer"))
+    assert (path.stat().st_mode & 0o077) == 0
+    assert not any(p.name.endswith(".tmp") for p in _oauth_dir().iterdir())
 
 
 def test_clear_tokens():

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -118,6 +118,23 @@ def test_loopback_callback_reports_error_param():
         cb.close()
 
 
+def test_loopback_callback_escapes_error_html():
+    # A crafted error value must not inject markup into the page we serve back.
+    from opendot.mcp.oauth import _LoopbackCallbackServer
+
+    cb = _LoopbackCallbackServer()
+    cb.start()
+    try:
+        # ?error=<script>alert(1)</script> (URL-encoded)
+        payload = "%3Cscript%3Ealert(1)%3C%2Fscript%3E"
+        page = urllib.request.urlopen(cb.redirect_uri + f"?error={payload}", timeout=5).read()
+        page = page.decode()
+        assert "<script>alert(1)</script>" not in page  # raw markup must not appear
+        assert "&lt;script&gt;" in page  # it's escaped instead
+    finally:
+        cb.close()
+
+
 # -- provider factory --------------------------------------------------------
 
 
@@ -153,6 +170,24 @@ async def test_remove_oauth_server_clears_tokens():
 
     assert remove_mcp_server("linear") is True
     assert not has_stored_tokens("linear")  # tokens forgotten on removal
+
+
+def test_shutdown_closes_leftover_callback_servers():
+    # If start() times out mid-authorization, a callback server can still be open.
+    # shutdown() must close it rather than leak the loopback thread.
+    from opendot.mcp.manager import MCPManager
+    from opendot.mcp.oauth import _LoopbackCallbackServer
+
+    mgr = MCPManager({})  # empty config: start() is a no-op, no background loop
+    cb = _LoopbackCallbackServer()
+    cb.start()
+    mgr._callbacks.append(cb)
+
+    mgr.shutdown()  # should sweep the callback even with no loop running
+    assert mgr._callbacks == []
+    # the loopback port is closed: binding is released (a second bind would work),
+    # and a follow-up close is a harmless no-op (idempotent).
+    mgr.shutdown()
 
 
 def test_cli_add_oauth_flag_stores_auth_oauth(monkeypatch):

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -1,0 +1,211 @@
+"""Tests for browser-OAuth support for authenticated MCP servers (issue #35).
+
+Covers the storage layer (token roundtrip + permissions), the loopback callback
+server, the provider factory, config/spec handling (auth:oauth), and the CLI
+--oauth flag. The actual browser dance is not exercised (no real server), but the
+pieces that would drive it are.
+"""
+
+import json
+import sys
+import urllib.request
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolated_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENDOT_HOME", str(tmp_path / "store"))
+    yield
+
+
+# -- FileTokenStorage --------------------------------------------------------
+
+
+async def test_token_storage_roundtrip():
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+    from opendot.mcp.oauth import FileTokenStorage, has_stored_tokens
+
+    store = FileTokenStorage("linear")
+    assert await store.get_tokens() is None
+    assert not has_stored_tokens("linear")
+
+    tok = OAuthToken(access_token="abc123", token_type="Bearer", refresh_token="r1")
+    await store.set_tokens(tok)
+    got = await store.get_tokens()
+    assert got is not None
+    assert got.access_token == "abc123"
+    assert got.refresh_token == "r1"
+    assert has_stored_tokens("linear")
+
+    info = OAuthClientInformationFull(
+        client_id="cid", redirect_uris=["http://127.0.0.1:9/callback"]
+    )
+    await store.set_client_info(info)
+    got_info = await store.get_client_info()
+    assert got_info is not None
+    assert got_info.client_id == "cid"
+    # tokens survive a client_info write (same file, merged)
+    assert (await store.get_tokens()).access_token == "abc123"
+
+
+async def test_token_file_is_owner_only():
+    from mcp.shared.auth import OAuthToken
+
+    from opendot.mcp.oauth import FileTokenStorage, _token_file
+
+    await FileTokenStorage("secretsrv").set_tokens(
+        OAuthToken(access_token="x", token_type="Bearer")
+    )
+    path = _token_file("secretsrv")
+    assert path.exists()
+    # tokens are secrets — file must not be group/world readable
+    assert (path.stat().st_mode & 0o077) == 0, "token file must be mode 0600"
+
+
+def test_clear_tokens():
+    from opendot.mcp.oauth import _token_file, clear_tokens
+
+    p = _token_file("gone")
+    p.write_text(json.dumps({"tokens": {"access_token": "z", "token_type": "Bearer"}}))
+    assert clear_tokens("gone") is True
+    assert not p.exists()
+    assert clear_tokens("gone") is False  # already absent
+
+
+def test_token_filename_is_sanitized():
+    from opendot.mcp.oauth import _token_file
+
+    # a server name with path separators must not escape the oauth dir
+    p = _token_file("../../etc/passwd")
+    assert "oauth" in str(p.parent)
+    assert "/" not in p.name.replace(".json", "")
+
+
+# -- loopback callback server ------------------------------------------------
+
+
+def test_loopback_callback_captures_code_and_state():
+    from opendot.mcp.oauth import _LoopbackCallbackServer
+
+    cb = _LoopbackCallbackServer()
+    cb.start()
+    try:
+        uri = cb.redirect_uri
+        assert uri.startswith("http://127.0.0.1:")
+        # simulate the provider's browser redirect back to us
+        urllib.request.urlopen(uri + "?code=THECODE&state=xyz", timeout=5).read()
+        result = cb.wait(5)
+        assert result["code"] == "THECODE"
+        assert result["state"] == "xyz"
+        assert result["error"] is None
+    finally:
+        cb.close()
+
+
+def test_loopback_callback_reports_error_param():
+    from opendot.mcp.oauth import _LoopbackCallbackServer
+
+    cb = _LoopbackCallbackServer()
+    cb.start()
+    try:
+        urllib.request.urlopen(cb.redirect_uri + "?error=access_denied", timeout=5).read()
+        result = cb.wait(5)
+        assert result["error"] == "access_denied"
+        assert result["code"] is None
+    finally:
+        cb.close()
+
+
+# -- provider factory --------------------------------------------------------
+
+
+def test_build_oauth_provider_returns_auth_flow():
+    from opendot.mcp.oauth import build_oauth_provider
+
+    provider, cb = build_oauth_provider("https://mcp.linear.app/mcp", "linear")
+    try:
+        # The provider drives auth via the httpx auth_flow protocol (a generator of
+        # requests). That's the contract the transport's auth= param consumes — it
+        # subclasses the SDK's Auth, which mirrors httpx.Auth, so a plain
+        # isinstance(httpx.Auth) check doesn't hold; presence of auth_flow is the
+        # real requirement.
+        assert callable(getattr(provider, "auth_flow", None))
+        # its redirect_uri points at our loopback callback server
+        assert provider.context.client_metadata.redirect_uris[0].host == "127.0.0.1"
+    finally:
+        cb.close()
+
+
+# -- config / spec handling --------------------------------------------------
+
+
+async def test_remove_oauth_server_clears_tokens():
+    from mcp.shared.auth import OAuthToken
+
+    from opendot.mcp.manager import add_mcp_server, remove_mcp_server
+    from opendot.mcp.oauth import FileTokenStorage, has_stored_tokens
+
+    add_mcp_server("linear", {"url": "https://mcp.linear.app/mcp", "auth": "oauth"})
+    await FileTokenStorage("linear").set_tokens(OAuthToken(access_token="t", token_type="Bearer"))
+    assert has_stored_tokens("linear")
+
+    assert remove_mcp_server("linear") is True
+    assert not has_stored_tokens("linear")  # tokens forgotten on removal
+
+
+def test_cli_add_oauth_flag_stores_auth_oauth(monkeypatch):
+    # Don't actually run the browser flow: stub authorize_oauth_server.
+    import opendot.mcp as mcp_pkg
+    from opendot import cli
+    from opendot.mcp.manager import load_mcp_config
+
+    def _fake_authorize(name, spec):
+        from opendot.mcp.manager import AuthorizeResult
+
+        return AuthorizeResult(ok=True, tool_count=3)
+
+    monkeypatch.setattr(mcp_pkg, "authorize_oauth_server", _fake_authorize)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["opendot", "mcp", "add", "linear", "--url", "https://mcp.linear.app/mcp", "--oauth"],
+    )
+    cli.main()
+    cfg = load_mcp_config()
+    assert cfg["linear"] == {"url": "https://mcp.linear.app/mcp", "auth": "oauth"}
+
+
+def test_cli_add_oauth_ignores_static_header(monkeypatch):
+    # --oauth wins: a stray --header is not stored (the provider supplies auth).
+    import opendot.mcp as mcp_pkg
+    from opendot import cli
+    from opendot.mcp.manager import load_mcp_config
+
+    monkeypatch.setattr(
+        mcp_pkg,
+        "authorize_oauth_server",
+        lambda n, s: __import__(
+            "opendot.mcp.manager", fromlist=["AuthorizeResult"]
+        ).AuthorizeResult(ok=True, tool_count=0),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "opendot",
+            "mcp",
+            "add",
+            "srv",
+            "--url",
+            "https://x/mcp",
+            "--oauth",
+            "--header",
+            "Authorization=Bearer nope",
+        ],
+    )
+    cli.main()
+    spec = load_mcp_config()["srv"]
+    assert spec == {"url": "https://x/mcp", "auth": "oauth"}
+    assert "headers" not in spec


### PR DESCRIPTION
Closes #35.

## Summary
Adds the OAuth 2.0 browser-login flow for remote MCP servers, so opendot can
connect to hosted servers that issue tokens dynamically (Linear, Notion, GitHub's
remote MCP, …) instead of only servers where you can paste a static bearer token.

Mark a server `"auth": "oauth"` and opendot opens your browser to authorize when
you add it, caches the tokens locally, and refreshes them automatically thereafter.

## What's new
- **`opendot/mcp/oauth.py`**
  - `FileTokenStorage` — SDK `TokenStorage` persisting tokens + the registered
    OAuth client to `~/.opendot/mcp_oauth/<server>.json` (mode 0600). Tokens live
    outside `mcp.json`, which stays credential-free.
  - `_LoopbackCallbackServer` — ephemeral `127.0.0.1` server that catches the
    OAuth redirect (`code`/`state`) and is used as the `redirect_uri`.
  - `build_oauth_provider` — wires the SDK's `OAuthClientProvider` (public PKCE
    client) with browser-redirect + loopback-callback handlers.
- **Transport**: `MCPManager._open_transport` attaches the provider as `auth=` for
  OAuth servers.
- **Add-time authorization**: `authorize_oauth_server()` runs the browser flow when
  you add the server (no restart needed to reach a working state), driven from both
  the TUI (`/mcp` → type `oauth`) and the CLI (`opendot mcp add … --url … --oauth`).
- Removing an OAuth server also clears its cached tokens.

## Notes
- OAuth waits on a human at a consent screen, so `MCPManager.start()` gained a
  `settle_timeout` param (300s for the OAuth path) — the previous fixed 30s window
  would have falsely reported failure on a slow authorization.
- `--oauth` takes precedence over a static `--header` (the provider supplies auth).
- Static-header and stdio servers are unchanged.

## Testing
- 10 new tests (token roundtrip + 0600 perms, filename sanitization, loopback
  callback capture + error param, provider construction, remove-clears-tokens,
  CLI `--oauth`). Full suite: **129 passed, 2 skipped**. Lint + format clean.

## Version
0.1.9 → 0.2.0 (new feature).