### PR TITLE
feat(ledger): record model + params for a fully auditable trail

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.2.0"
+version = "0.2.1"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 from opendot.agent.loop import Agent
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/agent/loop.py
+++ b/src/opendot/agent/loop.py
@@ -79,8 +79,22 @@ class Agent:
         from opendot.reversibility.engine import Reversibility
         from opendot.reversibility.rules import load_rules
 
+        # Record which model + sampling params drove each action, for a fully
+        # auditable ledger. Only include params that are actually set, so entries
+        # stay tidy and the default case adds nothing.
+        params = {
+            k: v
+            for k, v in (
+                ("temperature", self.config.temperature),
+                ("api_base", self.config.api_base),
+            )
+            if v is not None
+        }
         self.reversibility = Reversibility(
-            workdir=self.config.workdir, rules=load_rules(self.config.workdir)
+            workdir=self.config.workdir,
+            rules=load_rules(self.config.workdir),
+            model=self.config.model,
+            params=params,
         )
         self.toolbox = Toolbox(
             self.config.workdir,

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -144,6 +144,9 @@ def _cmd_log(workdir: str, clear: bool = False) -> None:
         console.print(f"  {e.id}  {mark}  [cyan]{e.kind}[/cyan]  {detail}")
         if e.note:
             console.print(f"        [dim]{e.note}[/dim]")
+        if e.model:
+            params = "".join(f" {k}={v}" for k, v in e.params.items())
+            console.print(f"        [dim]model: {e.model}{params}[/dim]")
     console.print("\n[dim]opendot undo           revert the last action[/dim]")
     console.print("[dim]opendot undo <id>      restore the workspace to before that action[/dim]")
 

--- a/src/opendot/reversibility/engine.py
+++ b/src/opendot/reversibility/engine.py
@@ -25,6 +25,11 @@ class Reversibility:
     workdir: str
     rules: IgnoreRules
     enabled: bool = True
+    # The model + sampling params driving the session, stamped into every ledger
+    # entry for a fully auditable trail. Set by the agent loop; empty for direct
+    # CLI actions with no model behind them.
+    model: str = ""
+    params: dict = field(default_factory=dict)
     # Lockfiles changed by the most recent undo (see undo_last). Lets the UI warn
     # that the environment isn't restored until the package manager is re-run.
     last_changed_lockfiles: list[str] = field(default_factory=list)
@@ -70,6 +75,8 @@ class Reversibility:
                     reversible=False,
                     note=note,
                     timestamp=timestamp,
+                    model=self.model,
+                    params=dict(self.params),
                 ),
             )
             return entry_id
@@ -90,6 +97,8 @@ class Reversibility:
                 reversible=reversible,
                 note=note,
                 timestamp=timestamp,
+                model=self.model,
+                params=dict(self.params),
             ),
         )
         return snap.id

--- a/src/opendot/reversibility/ledger.py
+++ b/src/opendot/reversibility/ledger.py
@@ -13,7 +13,7 @@ deterministic/testable); callers pass a timestamp string or leave it blank.
 from __future__ import annotations
 
 import json
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field, fields
 from pathlib import Path
 from typing import Literal
 
@@ -31,6 +31,12 @@ class LedgerEntry:
     reversible: bool = True
     note: str = ""  # e.g. "escapes workspace: git push"
     timestamp: str = ""
+    # Which model + sampling params drove this action, for a fully auditable trail
+    # ("what did it do" now includes "which model, with what settings"). Both
+    # optional and default-empty so ledgers written before this field still load,
+    # and non-agent callers (CLI direct actions) can omit them.
+    model: str = ""
+    params: dict = field(default_factory=dict)
 
 
 def _ledger_path(project_id: str) -> Path:
@@ -48,12 +54,17 @@ def read_all(project_id: str) -> list[LedgerEntry]:
     path = _ledger_path(project_id)
     if not path.exists():
         return []
+    known = {f.name for f in fields(LedgerEntry)}
     entries: list[LedgerEntry] = []
     for line in path.read_text(encoding="utf-8").splitlines():
         line = line.strip()
         if not line:
             continue
-        entries.append(LedgerEntry(**json.loads(line)))
+        # Keep only fields this version knows about, so ledgers written by an
+        # older opendot (missing model/params) or a newer one (extra keys) both
+        # load. Missing fields fall back to the dataclass defaults.
+        raw = {k: v for k, v in json.loads(line).items() if k in known}
+        entries.append(LedgerEntry(**raw))
     return entries
 
 

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -313,6 +313,92 @@ def test_ledger_clear_wipes_history(tmp_path):
     assert rev.clear_history() == 0
 
 
+def test_ledger_records_model_and_params(tmp_path):
+    """Each action records the model + sampling params that drove it (issue #31)."""
+    from opendot.reversibility.engine import Reversibility
+    from opendot.reversibility.rules import load_rules
+
+    wd = _workspace(tmp_path)
+    rev = Reversibility(
+        workdir=str(wd),
+        rules=load_rules(str(wd)),
+        model="claude-sonnet-4-5",
+        params={"temperature": 0.2},
+    )
+    rev.before_action("write", "a.txt", reversible=True)  # snapshot path
+    rev.before_action("shell", "shred x", snapshot=False)  # no-snapshot path
+
+    entries = rev.history()
+    assert len(entries) == 2
+    for e in entries:  # both paths stamp model + params
+        assert e.model == "claude-sonnet-4-5"
+        assert e.params == {"temperature": 0.2}
+
+
+def test_ledger_model_defaults_empty_when_unset(tmp_path):
+    """A Reversibility with no model (direct CLI action) records empty model/params
+    — behavior unchanged from before the field existed."""
+    from opendot.reversibility.engine import Reversibility
+    from opendot.reversibility.rules import load_rules
+
+    wd = _workspace(tmp_path)
+    rev = Reversibility(workdir=str(wd), rules=load_rules(str(wd)))
+    rev.before_action("write", "a.txt", reversible=True)
+
+    e = rev.history()[-1]
+    assert e.model == ""
+    assert e.params == {}
+
+
+def test_ledger_reads_legacy_entries_without_model(tmp_path):
+    """Ledger lines written before model/params existed must still load, with the
+    new fields falling back to their defaults."""
+    import json
+
+    from opendot.reversibility import ledger
+    from opendot.reversibility.snapshots import project_id_for
+
+    wd = _workspace(tmp_path)
+    pid = project_id_for(str(wd))
+    path = ledger._ledger_path(pid)
+    # an old-format line (no model/params) and a newer line that also carries an
+    # unknown future key — both must load without error
+    path.write_text(
+        json.dumps({"id": "1", "kind": "write", "detail": "old.txt", "snapshot_before": "1"})
+        + "\n"
+        + json.dumps(
+            {
+                "id": "2",
+                "kind": "shell",
+                "detail": "cmd",
+                "snapshot_before": "",
+                "model": "m",
+                "params": {},
+                "future_field": "ignored",
+            }
+        )
+        + "\n"
+    )
+    entries = ledger.read_all(pid)
+    assert len(entries) == 2
+    assert entries[0].model == "" and entries[0].params == {}  # legacy defaults
+    assert entries[1].model == "m"  # newer line still loads (unknown key dropped)
+
+
+def test_agent_wires_model_into_reversibility(tmp_path, monkeypatch):
+    """The agent loop stamps its configured model + set params onto the ledger."""
+    monkeypatch.setenv("OPENDOT_HOME", str(tmp_path / "store"))
+    from opendot.agent.config import AgentConfig
+    from opendot.agent.loop import Agent
+
+    wd = _workspace(tmp_path)
+    agent = Agent(AgentConfig(model="gpt-5.1", workdir=str(wd), temperature=0.5))
+    assert agent.reversibility.model == "gpt-5.1"
+    assert agent.reversibility.params == {"temperature": 0.5}
+    # api_base unset → not included (params stay tidy)
+    assert "api_base" not in agent.reversibility.params
+
+
 def test_undo_reports_changed_lockfile(tmp_path):
     """Undoing across a lockfile change must report it, so the caller can warn
     that the environment isn't restored (only the declared versions)."""


### PR DESCRIPTION
Every ledger entry now records which model and sampling params drove the
action, so `opendot log` shows not just what was done but which model did
it and with what settings (closes #31).

- LedgerEntry gains optional model/params fields; read_all filters to
  known fields so ledgers from older/newer opendot versions both load
  (backward + forward compatible, no migration).
- Reversibility carries model/params and stamps them on both the snapshot
  and no-snapshot (OPENDOT_NO_SNAPSHOT) paths.
- The agent loop wires in config.model and only the params that are set
  (temperature, api_base), keeping entries tidy.
- `opendot log` prints a model/params line under each action when present.

Tests cover both action paths, the unset default, and loading legacy
entries. 135 passed; lint + format clean.