### PR TITLE
Add description for read_xlsx max_rows parameter

### DIFF
--- a/src/opendot/tools/office.py
+++ b/src/opendot/tools/office.py
@@ -166,7 +166,10 @@ def build_office_tools(box) -> list:
                 "properties": {
                     "path": {"type": "string"},
                     "sheet": {"type": "string"},
-                    "max_rows": {"type": "integer"},
+                    "max_rows": {
+                        "type": "integer",
+                        "description": "Max rows to print per sheet (default 100).",
+                    },
                 },
                 "required": ["path"],
             },


### PR DESCRIPTION
## What & why

Added a description to the `max_rows` schema entry for the `read_xlsx` tool so its purpose and default value are documented.

## How I verified it

Verified that the `max_rows` schema now includes the requested description and confirmed that no functional code or behavior was changed.

## Checklist

- [x] Small and focused (one change)
- [ ] Added/updated tests; `pytest` passes locally
- [ ] If it touches `reversibility/` or a mutating tool: actions are snapshotted and undo still restores exactly (tests added)
- [ ] If it changes the UI: screenshot / short recording included below