### PR TITLE
feat(tools): add output bounds to read_pptx and read_docx

### DIFF
--- a/src/opendot/tools/office.py
+++ b/src/opendot/tools/office.py
@@ -102,15 +102,19 @@ def build_office_tools(box) -> list:
         return f"{box._rel(p)} [{ws.title}] {cell}: {old!r} → {v!r}"
 
     # ---- pptx ----
-    def read_pptx(path: str) -> str:
+    def read_pptx(path: str, max_slides: int = 50) -> str:
         from pptx import Presentation
 
         p = box._resolve(path)
         if not p.exists():
             return f"error: file not found: {p}"
         prs = Presentation(str(p))
-        lines = [f"presentation {box._rel(p)}  ({len(prs.slides)} slides)"]
+        total = len(prs.slides)
+        lines = [f"presentation {box._rel(p)}  ({total} slides)"]
         for i, slide in enumerate(prs.slides, 1):
+            if i > max_slides:
+                lines.append(f"... ({total - max_slides} more slides)")
+                break
             texts = [
                 sh.text.strip() for sh in slide.shapes if sh.has_text_frame and sh.text.strip()
             ]
@@ -143,18 +147,24 @@ def build_office_tools(box) -> list:
         return f"{box._rel(p)}: replaced {find!r} → {replace!r} in {hits} run(s)"
 
     # ---- docx ----
-    def read_docx(path: str) -> str:
+    def read_docx(path: str, max_paragraphs: int = 200) -> str:
         from docx import Document
 
         p = box._resolve(path)
         if not p.exists():
             return f"error: file not found: {p}"
         doc = Document(str(p))
-        lines = [f"document {box._rel(p)}  ({len(doc.paragraphs)} paragraphs)"]
+        total = len(doc.paragraphs)
+        lines = [f"document {box._rel(p)}  ({total} paragraphs)"]
+        shown = 0
         for para in doc.paragraphs:
+            if shown >= max_paragraphs:
+                lines.append(f"... ({total - max_paragraphs} more paragraphs)")
+                break
             text = para.text.strip()
             if text:
                 lines.append(text)
+                shown += 1
         return _truncate("\n".join(lines))
 
     tools = [
@@ -198,7 +208,13 @@ def build_office_tools(box) -> list:
             "Read a .pptx presentation: outputs each slide's text outline.",
             {
                 "type": "object",
-                "properties": {"path": {"type": "string"}},
+                "properties": {
+                    "path": {"type": "string"},
+                    "max_slides": {
+                        "type": "integer",
+                        "description": "Maximum number of slides to output (default 50).",
+                    },
+                },
                 "required": ["path"],
             },
             read_pptx,
@@ -231,7 +247,13 @@ def build_office_tools(box) -> list:
                 "Read a .docx Word document: outputs its paragraph text.",
                 {
                     "type": "object",
-                    "properties": {"path": {"type": "string"}},
+                    "properties": {
+                        "path": {"type": "string"},
+                        "max_paragraphs": {
+                            "type": "integer",
+                            "description": "Maximum number of non-empty paragraphs to output (default 200).",
+                        },
+                    },
                     "required": ["path"],
                 },
                 read_docx,

--- a/tests/test_office.py
+++ b/tests/test_office.py
@@ -146,6 +146,66 @@ def test_edit_pptx_missing_text_is_error(tmp_path):
     assert "not found" in res
 
 
+def test_read_pptx_bounds_max_slides(tmp_path):
+    from pptx import Presentation
+    from pptx.util import Inches
+
+    tb, wd, _ = _tb(tmp_path)
+    prs = Presentation()
+    for i in range(5):
+        slide = prs.slides.add_slide(prs.slide_layouts[5])
+        box = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(4), Inches(1))
+        box.text_frame.text = f"Slide {i + 1}"
+    prs.save(wd / "deck.pptx")
+
+    out = tb.call("read_pptx", {"path": "deck.pptx", "max_slides": 2})
+    assert "Slide 1" in out
+    assert "Slide 2" in out
+    assert "Slide 3" not in out
+    assert "... (3 more slides)" in out
+
+
+def test_read_docx_bounds_max_paragraphs(tmp_path):
+    pytest.importorskip("docx")
+    from docx import Document
+
+    tb, wd, _ = _tb(tmp_path)
+    doc = Document()
+    for i in range(5):
+        doc.add_paragraph(f"Paragraph {i + 1}")
+    doc.save(wd / "report.docx")
+
+    out = tb.call("read_docx", {"path": "report.docx", "max_paragraphs": 2})
+    assert "Paragraph 1" in out
+    assert "Paragraph 2" in out
+    assert "Paragraph 3" not in out
+    assert "... (3 more paragraphs)" in out
+
+
+def test_read_pptx_and_docx_default_bounds_preserve_small_files(tmp_path):
+    pytest.importorskip("docx")
+    tb, wd, _ = _tb(tmp_path)
+
+    _make_pptx(wd / "deck.pptx")
+    _make_docx(wd / "report.docx")
+
+    pptx_out = tb.call("read_pptx", {"path": "deck.pptx"})
+    assert "Old Title" in pptx_out
+    assert "more slides" not in pptx_out
+
+    docx_out = tb.call("read_docx", {"path": "report.docx"})
+    assert "Project Report" in docx_out
+    assert "more paragraphs" not in docx_out
+
+
+def test_pptx_and_docx_schema_includes_bound_params(tmp_path):
+    tb, _, _ = _tb(tmp_path)
+    specs = {s["function"]["name"]: s["function"]["parameters"] for s in tb.specs()}
+
+    assert "max_slides" in specs["read_pptx"]["properties"]
+    assert "max_paragraphs" in specs["read_docx"]["properties"]
+
+
 def test_office_edit_outside_workspace_is_irreversible(tmp_path):
     """An office edit to a file outside the working dir isn't covered by the
     snapshot, so it's recorded as not-undoable (undo that doesn't lie)."""


### PR DESCRIPTION
**Problem**
`read_xlsx` accepts a `max_rows` parameter to bound its output, but `read_pptx` and `read_docx` iterate their entire contents and only rely on the global `_truncate`. For large decks or documents this means the tool either returns nothing useful or consumes a lot of context with no per-tool control.

**Analysis**
The inconsistency is small but matters for an agent that chooses how much to read:
- `office.py:58` shows `read_xlsx` already has the pattern to mirror.
- `read_pptx` (`office.py:105`) loops over `prs.slides` unconditionally.
- `read_docx` (`office.py:146`) loops over `doc.paragraphs` unconditionally.
- Neither tool schema exposes a bound parameter, so the model cannot request one.

**Solution**
Add the same bound pattern to both tools:
- `read_pptx(path, max_slides: int = 50)` — stops after `max_slides` and appends `... (N more slides)`.
- `read_docx(path, max_paragraphs: int = 200)` — stops after `max_paragraphs` non-empty paragraphs and appends `... (N more paragraphs)`.
- Updated the JSON schemas for both tools so the parameter is visible to the model.

Defaults were chosen to preserve current behavior for normal-sized files while giving the agent a knob for oversized ones.

**Verification**
- Full test suite: `pytest tests/ -q -W error::RuntimeWarning` — 148 passed.
- Added regression tests covering truncation, default pass-through for small files, and schema exposure.
