### PR TITLE
Add max_slides/max_paragraphs output limits to read_pptx and read_docx

### DIFF
--- a/src/opendot/tools/office.py
+++ b/src/opendot/tools/office.py
@@ -102,7 +102,7 @@ def build_office_tools(box) -> list:
         return f"{box._rel(p)} [{ws.title}] {cell}: {old!r} → {v!r}"
 
     # ---- pptx ----
-    def read_pptx(path: str) -> str:
+    def read_pptx(path: str, max_slides: int = 50) -> str:
         from pptx import Presentation
 
         p = box._resolve(path)
@@ -111,6 +111,9 @@ def build_office_tools(box) -> list:
         prs = Presentation(str(p))
         lines = [f"presentation {box._rel(p)}  ({len(prs.slides)} slides)"]
         for i, slide in enumerate(prs.slides, 1):
+            if i > max_slides:
+                lines.append(f"... ({len(prs.slides) - max_slides} more slides)")
+                break
             texts = [
                 sh.text.strip() for sh in slide.shapes if sh.has_text_frame and sh.text.strip()
             ]
@@ -143,7 +146,7 @@ def build_office_tools(box) -> list:
         return f"{box._rel(p)}: replaced {find!r} → {replace!r} in {hits} run(s)"
 
     # ---- docx ----
-    def read_docx(path: str) -> str:
+    def read_docx(path: str, max_paragraphs: int = 200) -> str:
         from docx import Document
 
         p = box._resolve(path)
@@ -151,7 +154,10 @@ def build_office_tools(box) -> list:
             return f"error: file not found: {p}"
         doc = Document(str(p))
         lines = [f"document {box._rel(p)}  ({len(doc.paragraphs)} paragraphs)"]
-        for para in doc.paragraphs:
+        for i, para in enumerate(doc.paragraphs, 1):
+            if i > max_paragraphs:
+                lines.append(f"... ({len(doc.paragraphs) - max_paragraphs} more paragraphs)")
+                break
             text = para.text.strip()
             if text:
                 lines.append(text)
@@ -195,7 +201,10 @@ def build_office_tools(box) -> list:
             "Read a .pptx presentation: outputs each slide's text outline.",
             {
                 "type": "object",
-                "properties": {"path": {"type": "string"}},
+                "properties": {
+                    "path": {"type": "string"},
+                    "max_slides": {"type": "integer"},
+                },
                 "required": ["path"],
             },
             read_pptx,
@@ -228,7 +237,10 @@ def build_office_tools(box) -> list:
                 "Read a .docx Word document: outputs its paragraph text.",
                 {
                     "type": "object",
-                    "properties": {"path": {"type": "string"}},
+                    "properties": {
+                        "path": {"type": "string"},
+                        "max_paragraphs": {"type": "integer"},
+                    },
                     "required": ["path"],
                 },
                 read_docx,

--- a/src/opendot/tools/office.py
+++ b/src/opendot/tools/office.py
@@ -203,7 +203,10 @@ def build_office_tools(box) -> list:
                 "type": "object",
                 "properties": {
                     "path": {"type": "string"},
-                    "max_slides": {"type": "integer"},
+                    "max_slides": {
+                        "type": "integer",
+                        "description": "Max slides to output (default 50).",
+                    },
                 },
                 "required": ["path"],
             },
@@ -239,7 +242,10 @@ def build_office_tools(box) -> list:
                     "type": "object",
                     "properties": {
                         "path": {"type": "string"},
-                        "max_paragraphs": {"type": "integer"},
+                        "max_paragraphs": {
+                            "type": "integer",
+                            "description": "Max paragraphs to output (default 200).",
+                        },
                     },
                     "required": ["path"],
                 },

--- a/tests/test_office.py
+++ b/tests/test_office.py
@@ -179,3 +179,45 @@ def test_office_edit_outside_declined_is_skipped(tmp_path):
     assert res.startswith("skipped")
     after = openpyxl.load_workbook(outside).active["B2"].value
     assert after == before  # file on disk unchanged
+
+
+def test_read_pptx_respects_max_slides(tmp_path):
+    from pptx import Presentation
+    from pptx.util import Inches
+
+    tb, wd, _ = _tb(tmp_path)
+    prs = Presentation()
+    for n in range(1, 6):  # 5 slides
+        slide = prs.slides.add_slide(prs.slide_layouts[5])
+        shape = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(4), Inches(1))
+        shape.text_frame.text = f"Slide {n} body"
+    prs.save(wd / "big.pptx")
+
+    out = tb.call("read_pptx", {"path": "big.pptx", "max_slides": 3})
+    assert "Slide 3 body" in out
+    assert "Slide 4 body" not in out
+    assert "... (2 more slides)" in out
+
+    full = tb.call("read_pptx", {"path": "big.pptx"})  # default cap is 50
+    assert "Slide 5 body" in full
+    assert "more slides" not in full
+
+
+def test_read_docx_respects_max_paragraphs(tmp_path):
+    pytest.importorskip("docx")
+    from docx import Document
+
+    tb, wd, _ = _tb(tmp_path)
+    doc = Document()
+    for n in range(1, 11):  # 10 paragraphs
+        doc.add_paragraph(f"Paragraph {n}")
+    doc.save(wd / "big.docx")
+
+    out = tb.call("read_docx", {"path": "big.docx", "max_paragraphs": 4})
+    assert "Paragraph 4" in out
+    assert "Paragraph 5" not in out
+    assert "... (6 more paragraphs)" in out
+
+    full = tb.call("read_docx", {"path": "big.docx"})  # default cap is 200
+    assert "Paragraph 10" in full
+    assert "more paragraphs" not in full


### PR DESCRIPTION
Fixes #50

`read_xlsx` bounds its output with `max_rows`, but `read_pptx` and `read_docx` had no equivalent, so a large deck or document could flood the context window. This adds matching bounds, following the existing `read_xlsx` pattern.

- `read_pptx(path, max_slides=50)`
- `read_docx(path, max_paragraphs=200)`
- Both append a `... (N more slides/paragraphs)` notice when the cap is reached.
- Both tool schemas now declare the new parameter so the model can pass it. `required` stays `["path"]`, so the change is backward compatible.

One design note: in `read_docx` the counter advances over every paragraph, including the blank ones that get filtered out of the output. That keeps the notice consistent with the `(N paragraphs)` header, which also counts blanks — the same way `read_xlsx` counts rows rather than non-empty rows. Happy to switch to counting only emitted paragraphs if you'd prefer.

Reversibility is unaffected — both tools are read-only and take no snapshots.

**Tests:** added `test_read_pptx_respects_max_slides` and `test_read_docx_respects_max_paragraphs` to `tests/test_office.py`, covering the cap, the "N more" arithmetic, and that the defaults leave small files untouched. `pytest tests/test_office.py` → 11 passed. Full suite locally: 139 passed, plus 4 pre-existing failures unrelated to this change (Unix file-mode and path-separator assumptions that don't hold on Windows).