### PR TITLE
feat: make tool output cap configurable via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ those, rather than pretending otherwise.
 **Skipping the snapshot on purpose.** When opendot runs a shell command it
 snapshots first — but for something you *want* gone (securely wiping a secret) or
 a huge throwaway file, that snapshot would keep a recoverable copy in the store.
+Set `OPENDOT_MAX_TOOL_OUTPUT` to change the per-tool output character cap (default `30000`). Non-integer or non-positive values keep the default.
+
 Prefixing the command opendot runs with `OPENDOT_NO_SNAPSHOT=1` skips the
 snapshot for that one command:
 

--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
+
 def _max_output() -> int:
     """Cap tool output so one huge file can't blow the context.
 

--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -16,7 +16,18 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
-_MAX_OUTPUT = 30_000  # cap tool output so one huge file can't blow the context
+def _max_output() -> int:
+    """Cap tool output so one huge file can't blow the context.
+
+    Override with OPENDOT_MAX_TOOL_OUTPUT (characters). Invalid values keep the
+    default of 30_000.
+    """
+    raw = os.environ.get("OPENDOT_MAX_TOOL_OUTPUT", "30000")
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return 30_000
+    return value if value > 0 else 30_000
 
 
 def _unified_diff(old: str, new: str, path: str, max_lines: int = 200) -> str:
@@ -42,8 +53,9 @@ def _unified_diff(old: str, new: str, path: str, max_lines: int = 200) -> str:
 
 
 def _truncate(text: str) -> str:
-    if len(text) > _MAX_OUTPUT:
-        return text[:_MAX_OUTPUT] + f"\n... [truncated, {len(text)} chars total]"
+    max_output = _max_output()
+    if len(text) > max_output:
+        return text[:max_output] + f"\n... [truncated, {len(text)} chars total]"
     return text
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -156,3 +156,37 @@ def test_read_file_directory_returns_clear_error(tmp_path):
     assert "is a directory" in out
     assert "list_files" in out
     assert "IsADirectoryError" not in out
+
+
+def test_max_output_default_when_unset(monkeypatch):
+    """The tool-output cap defaults to 30000 when OPENDOT_MAX_TOOL_OUTPUT is unset."""
+    from opendot.tools.local import _max_output
+
+    monkeypatch.delenv("OPENDOT_MAX_TOOL_OUTPUT", raising=False)
+    assert _max_output() == 30_000
+
+
+def test_max_output_honors_valid_override(monkeypatch):
+    from opendot.tools.local import _max_output
+
+    monkeypatch.setenv("OPENDOT_MAX_TOOL_OUTPUT", "500")
+    assert _max_output() == 500
+
+
+def test_max_output_falls_back_on_invalid_or_nonpositive(monkeypatch):
+    """Non-integer and non-positive values keep the 30000 default."""
+    from opendot.tools.local import _max_output
+
+    for bad in ("not-a-number", "0", "-5"):
+        monkeypatch.setenv("OPENDOT_MAX_TOOL_OUTPUT", bad)
+        assert _max_output() == 30_000, f"{bad!r} should fall back to the default"
+
+
+def test_truncate_respects_env_override(tmp_path, monkeypatch):
+    """_truncate uses the configured cap, so a lower override truncates sooner."""
+    from opendot.tools.local import _truncate
+
+    monkeypatch.setenv("OPENDOT_MAX_TOOL_OUTPUT", "10")
+    out = _truncate("x" * 50)
+    assert out.startswith("x" * 10)
+    assert "truncated" in out


### PR DESCRIPTION
## Summary
- Add `OPENDOT_MAX_TOOL_OUTPUT` to override the per-tool output character cap.
- Invalid or non-positive values fall back to `30000`.
- Document the variable in the README.

Closes #49