### PR TITLE
fix(tools): make max tool output configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,10 @@ run in your own shell outside opendot is never snapshotted or logged either way.
 To exclude paths from snapshotting permanently, use the `skip:` rule in
 `OPENDOT.md`.
 
+**Tool output size.** Each tool result is capped so a huge file can't blow the
+model context. Override the default (30000 characters) with
+`OPENDOT_MAX_TOOL_OUTPUT` (non-integer values are ignored and the default is kept).
+
 ## Contributing
 
 Issues and PRs welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for setup and

--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -16,7 +16,19 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
-_MAX_OUTPUT = 30_000  # cap tool output so one huge file can't blow the context
+_DEFAULT_MAX_OUTPUT = 30_000
+
+
+def _resolve_max_output() -> int:
+    """Read ``OPENDOT_MAX_TOOL_OUTPUT``, falling back to 30000 on unset/invalid."""
+    raw = os.environ.get("OPENDOT_MAX_TOOL_OUTPUT", str(_DEFAULT_MAX_OUTPUT))
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_OUTPUT
+
+
+_MAX_OUTPUT = _resolve_max_output()  # cap tool output so one huge file can't blow the context
 
 
 def _unified_diff(old: str, new: str, path: str, max_lines: int = 200) -> str:
@@ -42,8 +54,9 @@ def _unified_diff(old: str, new: str, path: str, max_lines: int = 200) -> str:
 
 
 def _truncate(text: str) -> str:
-    if len(text) > _MAX_OUTPUT:
-        return text[:_MAX_OUTPUT] + f"\n... [truncated, {len(text)} chars total]"
+    limit = _resolve_max_output()
+    if len(text) > limit:
+        return text[:limit] + f"\n... [truncated, {len(text)} chars total]"
     return text
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -156,3 +156,29 @@ def test_read_file_directory_returns_clear_error(tmp_path):
     assert "is a directory" in out
     assert "list_files" in out
     assert "IsADirectoryError" not in out
+
+
+def test_max_tool_output_default(monkeypatch):
+    monkeypatch.delenv("OPENDOT_MAX_TOOL_OUTPUT", raising=False)
+    from opendot.tools.local import _DEFAULT_MAX_OUTPUT, _resolve_max_output
+
+    assert _resolve_max_output() == _DEFAULT_MAX_OUTPUT == 30_000
+
+
+def test_max_tool_output_env_override(monkeypatch):
+    monkeypatch.setenv("OPENDOT_MAX_TOOL_OUTPUT", "100")
+    from opendot.tools.local import _resolve_max_output, _truncate
+
+    assert _resolve_max_output() == 100
+    out = _truncate("x" * 150)
+    assert out.startswith("x" * 100)
+    assert "truncated" in out
+    assert "150 chars total" in out
+
+
+def test_max_tool_output_invalid_env_falls_back(monkeypatch):
+    monkeypatch.setenv("OPENDOT_MAX_TOOL_OUTPUT", "not-an-int")
+    from opendot.tools.local import _DEFAULT_MAX_OUTPUT, _resolve_max_output
+
+    assert _resolve_max_output() == _DEFAULT_MAX_OUTPUT
+


### PR DESCRIPTION
Closes #49.

`_MAX_OUTPUT` is now driven by `OPENDOT_MAX_TOOL_OUTPUT`, defaulting to 30000 (same env-var style as `DEFAULT_MODEL`). Non-integer values fall back to the default. Documented in the README near the other `OPENDOT_*` knobs.

Made with [Cursor](https://cursor.com)