### PR TITLE
Add ignore_case option to grep tool

### DIFF
--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -448,6 +448,10 @@ class Toolbox:
                             "description": "Dir or file to search (default '.').",
                         },
                         "max_matches": {"type": "integer"},
+                        "ignore_case": {
+                            "type": "boolean",
+                            "description": "Case-insensitive search (default false).",
+                        },
                     },
                     "required": ["pattern"],
                 },

--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -287,13 +287,21 @@ class Toolbox:
             except Exception as exc:  # noqa: BLE001
                 return f"error running command: {exc}"
 
-        def grep(pattern: str, path: str = ".", max_matches: int = 100) -> str:
+        def grep(
+            pattern: str,
+            path: str = ".",
+            max_matches: int = 100,
+            ignore_case: bool = False,
+        ) -> str:
             """Search file contents for a regex, returning path:line:text matches."""
             import re
 
             base = self._resolve(path)
             try:
-                rx = re.compile(pattern)
+                rx = re.compile(
+                    pattern,
+                    re.IGNORECASE if ignore_case else 0,
+                )
             except re.error as exc:
                 return f"error: bad pattern: {exc}"
             hits: list[str] = []

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -34,6 +34,19 @@ def test_grep_no_match(tmp_path):
     tb, wd, _ = _tb(tmp_path)
     assert tb.call("grep", {"pattern": "nonexistent_xyz"}) == "no matches"
 
+def test_grep_ignore_case(tmp_path):
+    tb, wd, _ = _tb(tmp_path)
+
+    out = tb.call(
+        "grep",
+        {
+            "pattern": "todo",
+            "ignore_case": True,
+        },
+    )
+
+    assert "TODO" in out
+
 
 def test_glob(tmp_path):
     tb, wd, _ = _tb(tmp_path)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -34,18 +34,22 @@ def test_grep_no_match(tmp_path):
     tb, wd, _ = _tb(tmp_path)
     assert tb.call("grep", {"pattern": "nonexistent_xyz"}) == "no matches"
 
+
 def test_grep_ignore_case(tmp_path):
     tb, wd, _ = _tb(tmp_path)
 
-    out = tb.call(
-        "grep",
-        {
-            "pattern": "todo",
-            "ignore_case": True,
-        },
-    )
-
+    # ignore_case=True matches the lowercase pattern against the file's "TODO"
+    out = tb.call("grep", {"pattern": "todo", "ignore_case": True})
     assert "TODO" in out
+
+    # default is case-sensitive: "todo" must NOT match "TODO"
+    assert tb.call("grep", {"pattern": "todo"}) == "no matches"
+
+
+def test_grep_schema_exposes_ignore_case(tmp_path):
+    tb, _, _ = _tb(tmp_path)
+    specs = {s["function"]["name"]: s["function"]["parameters"] for s in tb.specs()}
+    assert "ignore_case" in specs["grep"]["properties"]
 
 
 def test_glob(tmp_path):


### PR DESCRIPTION
## What & why

Added an `ignore_case` option to the `grep` tool so searches can be performed case-insensitively when requested.

## How I verified it

- Added a test that only matches when `ignore_case=True`.
- Verified with:

```bash
py -m pytest tests/test_tools.py -k ignore_case
```

The new test passes successfully.

## Checklist

- [x] Small and focused (one change)
- [x] Added/updated tests; `pytest` passes locally
- [ ] If it touches `reversibility/` or a mutating tool: actions are snapshotted and undo still restores exactly (tests added)
- [ ] If it changes the UI: screenshot / short recording included below