### PR TITLE
fix(tools): report negative edit counts accurately

### DIFF
--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -380,7 +380,7 @@ class Toolbox:
                 )
             new = text.replace(find, replace, count if count > 0 else -1)
             p.write_text(new, encoding="utf-8")
-            replaced = n if count == 0 else min(n, count)
+            replaced = n if count <= 0 else min(n, count)
             rel = self._rel(p)
             return f"edited {rel} ({replaced} replacement(s))\n" + _unified_diff(text, new, rel)
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -89,6 +89,28 @@ def test_edit_replaces_and_reports(tmp_path):
     assert (wd / "src" / "b.py").read_text() == "z = 99\n"
 
 
+def test_edit_positive_count_limits_replacements(tmp_path):
+    tb, wd, _ = _tb(tmp_path)
+    target = wd / "src" / "b.py"
+    target.write_text("z = 3\nz = 3\nz = 3\n")
+
+    out = tb.call("edit", {"path": "src/b.py", "find": "z = 3", "replace": "z = 99", "count": 1})
+
+    assert "1 replacement" in out
+    assert target.read_text() == "z = 99\nz = 3\nz = 3\n"
+
+
+def test_edit_negative_count_replaces_all_and_reports_actual_count(tmp_path):
+    tb, wd, _ = _tb(tmp_path)
+    target = wd / "src" / "b.py"
+    target.write_text("z = 3\nz = 3\nz = 3\n")
+
+    out = tb.call("edit", {"path": "src/b.py", "find": "z = 3", "replace": "z = 99", "count": -1})
+
+    assert "3 replacement" in out
+    assert target.read_text() == "z = 99\nz = 99\nz = 99\n"
+
+
 def test_edit_missing_find_is_error_no_change(tmp_path):
     tb, wd, _ = _tb(tmp_path)
     before = (wd / "src" / "b.py").read_text()


### PR DESCRIPTION
## Summary
Fix the edit tool's replacement count reporting when a negative count is passed.

## Root cause
The edit tool already treats non-positive counts as "replace all" when calling str.replace, but the reported replacement count only handled count=0 as the all-replacements case. A negative count therefore replaced every match while reporting a negative number.

## Changes
- Report all matches as replaced for any non-positive count.
- Add regression coverage for negative count behavior.
- Add coverage that positive counts still limit replacements.

## Testing
- `.venv/bin/python -m pytest` (157 passed)
- `.venv/bin/python -m py_compile src/opendot/tools/local.py tests/test_tools.py` (passed)

Fixes #57