### PR TITLE
feat(tools): make run_shell default timeout configurable via OPENDOT_SHELL_TIMEOUT

### DIFF
--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -31,6 +31,19 @@ def _max_output() -> int:
     return value if value > 0 else 30_000
 
 
+def _shell_timeout() -> int:
+    """Default shell timeout read from ``OPENDOT_SHELL_TIMEOUT``.
+
+    Falls back to 120s when the variable is unset or not a positive integer.
+    """
+    raw = os.environ.get("OPENDOT_SHELL_TIMEOUT", "120")
+    try:
+        value = int(raw)
+    except ValueError:
+        return 120
+    return value if value > 0 else 120
+
+
 def _unified_diff(old: str, new: str, path: str, max_lines: int = 200) -> str:
     """A unified diff of a file change, for the model and for colored rendering.
 
@@ -238,7 +251,9 @@ class Toolbox:
             verb = "created" if not old else "updated"
             return f"{verb} {rel}\n" + _unified_diff(old, content, rel)
 
-        def run_shell(command: str, timeout: int = 120) -> str:
+        def run_shell(command: str, timeout: int | None = None) -> str:
+            if timeout is None:
+                timeout = _shell_timeout()
             # Escape hatch: prefixing a command with OPENDOT_NO_SNAPSHOT=1 runs it
             # WITHOUT snapshotting first. Use it for things you *want* gone and
             # don't want a recoverable copy of (e.g. `shred secrets.txt`) or huge
@@ -443,7 +458,7 @@ class Toolbox:
                         "command": {"type": "string"},
                         "timeout": {
                             "type": "integer",
-                            "description": "Seconds before timeout (default 120).",
+                            "description": "Seconds before timeout (default 120, or OPENDOT_SHELL_TIMEOUT if set).",
                         },
                     },
                     "required": ["command"],

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -268,3 +268,46 @@ def test_truncate_respects_env_override(tmp_path, monkeypatch):
     out = _truncate("x" * 50)
     assert out.startswith("x" * 10)
     assert "truncated" in out
+
+
+def test_run_shell_uses_default_timeout_when_env_unset(tmp_path):
+    """Without OPENDOT_SHELL_TIMEOUT, a command that finishes quickly succeeds."""
+    tb, wd, _ = _tb(tmp_path)
+    out = tb.call("run_shell", {"command": "echo hello"})
+    assert "hello" in out
+    assert "[exit 0]" in out
+
+
+def test_run_shell_uses_opendot_shell_timeout_env_var(tmp_path, monkeypatch):
+    """OPENDOT_SHELL_TIMEOUT overrides the default timeout."""
+    monkeypatch.setenv("OPENDOT_SHELL_TIMEOUT", "1")
+    tb, wd, _ = _tb(tmp_path)
+    out = tb.call("run_shell", {"command": "sleep 2"})
+    assert "timed out after 1s" in out
+
+
+def test_run_shell_invalid_env_var_falls_back_to_default(tmp_path, monkeypatch):
+    """A non-numeric OPENDOT_SHELL_TIMEOUT is ignored, falling back to 120s."""
+    monkeypatch.setenv("OPENDOT_SHELL_TIMEOUT", "not-a-number")
+    tb, wd, _ = _tb(tmp_path)
+    out = tb.call("run_shell", {"command": "sleep 0.1"})
+    assert "[exit 0]" in out
+    assert "timed out" not in out
+
+
+def test_run_shell_per_call_timeout_overrides_env_var(tmp_path, monkeypatch):
+    """An explicit timeout argument still takes precedence over the env default."""
+    monkeypatch.setenv("OPENDOT_SHELL_TIMEOUT", "600")
+    tb, wd, _ = _tb(tmp_path)
+    out = tb.call("run_shell", {"command": "sleep 0.1", "timeout": 1})
+    assert "[exit 0]" in out
+    assert "timed out" not in out
+
+
+def test_run_shell_non_positive_env_var_falls_back(tmp_path, monkeypatch):
+    """Zero or negative OPENDOT_SHELL_TIMEOUT is treated as invalid."""
+    monkeypatch.setenv("OPENDOT_SHELL_TIMEOUT", "0")
+    tb, wd, _ = _tb(tmp_path)
+    out = tb.call("run_shell", {"command": "sleep 0.1"})
+    assert "[exit 0]" in out
+    assert "timed out" not in out


### PR DESCRIPTION
## Problem

`run_shell` defaults to a hard-coded 120s timeout with no user-level override. Users running slower commands (large test suites, builds, etc.) have to rely on the model remembering to pass a higher `timeout` on every single call, otherwise they hit `error: command timed out after 120s`.

Fixes #59.

## Analysis

The timeout is currently baked into the function signature:

```python
def run_shell(command: str, timeout: int = 120) -> str:
```

Per-call override works, but there is no way to change the global default without editing source. The repo already uses `os.environ.get(...)` for configurable defaults elsewhere, so a small helper is the natural place to add this.

## Solution

- Add `_shell_timeout()` that reads `OPENDOT_SHELL_TIMEOUT`, parses it as an integer, and falls back to `120` when the variable is unset, non-numeric, or non-positive.
- Change `run_shell` default to `timeout: int | None = None` and resolve it inside the function via `_shell_timeout()`.
- Update the JSON schema description to mention the env var.
- Preserve the existing per-call override behavior.

## Benchmarks / Verification

Full test suite passes:

```bash
pytest tests/ -q -W error::RuntimeWarning
# 149 passed in 14.29s
```

Added five regression tests covering:
- default behavior when env var is unset
- env var override
- invalid env var fallback
- non-positive env var fallback
- per-call `timeout` still takes precedence

## Notes

- The helper is evaluated at call time, so changing the env var during a long-running opendot session is reflected on the next shell invocation.
- No changes to the timeout error message or to the reversibility/snapshot flow.
