### PR TITLE
Add remove action for MCP servers

### DIFF
--- a/src/opendot/mcp/manager.py
+++ b/src/opendot/mcp/manager.py
@@ -256,6 +256,20 @@ class MCPManager:
         fut: Future = asyncio.run_coroutine_threadsafe(coro, self._loop)
         return fut.result(timeout=timeout)
 
+    def forget_server(self, name: str) -> None:
+        """Drop a server from the in-memory view (connected list, errors, tools)
+        so it stops appearing and its tools stop being offered this session.
+
+        The underlying session/subprocess is left for the normal shutdown path;
+        this just makes an in-session removal immediately consistent instead of
+        lingering until the next launch.
+        """
+        if name in self.connected:
+            self.connected.remove(name)
+        self.errors.pop(name, None)
+        self._sessions.pop(name, None)
+        self.tools = [t for t in self.tools if t.server != name]
+
     def call_tool(self, server: str, name: str, args: dict[str, Any]) -> str:
         """Call an MCP tool synchronously; return a text result."""
         session = self._sessions.get(server)

--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -126,6 +126,11 @@ class Toolbox:
         if self.mcp is not None and not read_only:
             self._mcp_tools = {t.qualified: t for t in self.mcp.tools}
 
+    def forget_mcp_server(self, server: str) -> None:
+        """Drop a removed MCP server's cached tools so the agent stops offering
+        (and can't call) them for the rest of this session."""
+        self._mcp_tools = {q: t for q, t in self._mcp_tools.items() if t.server != server}
+
     _IGNORE = {".git", "node_modules", "__pycache__", ".venv", "venv", ".opendot"}
 
     # -- resolution / safety helpers --

--- a/src/opendot/tui/app.py
+++ b/src/opendot/tui/app.py
@@ -565,6 +565,12 @@ class OpendotTUI(App):
 
             if action == "remove":
                 if remove_mcp_server(name):
+                    # Drop it from the live session too, so it disappears from the
+                    # sidebar and its tools stop being callable without a restart.
+                    if mgr is not None:
+                        mgr.forget_server(name)
+                    if self.agent.toolbox is not None:
+                        self.agent.toolbox.forget_mcp_server(name)
                     self._write(f"✓ removed MCP server '{name}'.", "sys")
                     self._refresh_sidebar()
                     await self._manage_mcp()

--- a/src/opendot/tui/app.py
+++ b/src/opendot/tui/app.py
@@ -522,7 +522,12 @@ class OpendotTUI(App):
     async def _manage_mcp(self) -> None:
         import asyncio
 
-        from opendot.mcp import add_mcp_server, authorize_oauth_server, load_mcp_config
+        from opendot.mcp import (
+            add_mcp_server,
+            authorize_oauth_server,
+            load_mcp_config,
+            remove_mcp_server,
+        )
 
         servers = load_mcp_config()
         mgr = getattr(self.agent, "mcp", None)
@@ -544,11 +549,34 @@ class OpendotTUI(App):
         items.append(("__add__", "➕ Add a server…", ""))
 
         chosen = await self.push_screen_wait(SearchListModal("MCP servers", items))
+
+        if not chosen:
+            return
+
         if chosen != "__add__":
-            return  # selecting a server is view-only for now
+            name = chosen.removeprefix("server:")
+
+            actions = [
+                ("remove", "🗑 Remove server", "Actions"),
+                ("keep", "Keep", "Actions"),
+            ]
+
+            action = await self.push_screen_wait(SearchListModal(f"MCP server: {name}", actions))
+
+            if action == "remove":
+                if remove_mcp_server(name):
+                    self._write(f"✓ removed MCP server '{name}'.", "sys")
+                    self._refresh_sidebar()
+                    await self._manage_mcp()
+                else:
+                    self._write(Text(f"No MCP server named '{name}'."), "err")
+
+            return
+
         result = await self.push_screen_wait(McpAddModal())
         if not result:
             return
+
         name, spec = result["name"], result["spec"]
         add_mcp_server(name, spec)
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -67,6 +67,36 @@ def test_mcp_tool_appears_in_specs(tmp_path):
     assert "mcp__stub__greet" in names
 
 
+def test_toolbox_forget_mcp_server_drops_tools(tmp_path):
+    """After a server is removed, its tools stop appearing in specs and can't be
+    called this session (in-session removal, not just config)."""
+    tb, _ = _tb(tmp_path, lambda p: True)
+    assert "mcp__stub__greet" in {s["function"]["name"] for s in tb.specs()}
+
+    tb.forget_mcp_server("stub")
+    assert "mcp__stub__greet" not in {s["function"]["name"] for s in tb.specs()}
+    assert "unknown tool" in tb.call("mcp__stub__greet", {"name": "x"}).lower()
+
+
+def test_manager_forget_server_purges_in_memory_state():
+    """forget_server drops the server from connected/errors/tools/_sessions so it
+    stops showing and its tools stop being offered until next launch."""
+    from opendot.mcp.manager import MCPManager, MCPTool
+
+    mgr = MCPManager({})
+    mgr.connected = ["stub", "other"]
+    mgr.errors = {"stub": "boom"}
+    mgr._sessions = {"stub": object()}
+    mgr.tools = [MCPTool("stub", "greet", "", {}), MCPTool("other", "ping", "", {})]
+
+    mgr.forget_server("stub")
+
+    assert mgr.connected == ["other"]
+    assert "stub" not in mgr.errors
+    assert "stub" not in mgr._sessions
+    assert [t.server for t in mgr.tools] == ["other"]
+
+
 def test_mcp_call_declined_by_confirm(tmp_path):
     tb, rev = _tb(tmp_path, lambda p: False)
     out = tb.call("mcp__stub__greet", {"name": "x"})


### PR DESCRIPTION
## Summary

Adds an action menu for existing MCP servers in the `/mcp` TUI.

### Changes

- Added an action menu when selecting an existing MCP server.
- Added **Remove server** and **Keep** actions.
- Removing a server updates `~/.opendot/mcp.json` using the existing `remove_mcp_server()` helper.
- Refreshes the sidebar after removal.
- Reopens the MCP server list so the updated state is immediately visible.

### Tested

- Added a `filesystem` MCP server.
- Removed it from the action menu.
- Verified it disappeared immediately.
- Restarted OpenDot and confirmed it remained removed.