### PR TITLE
fix(tools): treat explicit run_shell timeout <= 0 as invalid and fall back to default

### DIFF
--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -257,7 +257,7 @@ class Toolbox:
             return f"{verb} {rel}\n" + _unified_diff(old, content, rel)
 
         def run_shell(command: str, timeout: int | None = None) -> str:
-            if timeout is None:
+            if timeout is None or timeout <= 0:
                 timeout = _shell_timeout()
             # Escape hatch: prefixing a command with OPENDOT_NO_SNAPSHOT=1 runs it
             # WITHOUT snapshotting first. Use it for things you *want* gone and
@@ -463,7 +463,7 @@ class Toolbox:
                         "command": {"type": "string"},
                         "timeout": {
                             "type": "integer",
-                            "description": "Seconds before timeout (default 120, or OPENDOT_SHELL_TIMEOUT if set).",
+                            "description": "Seconds before timeout. Must be a positive integer; values <= 0 fall back to the default (120s, or OPENDOT_SHELL_TIMEOUT if set).",
                         },
                     },
                     "required": ["command"],

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -311,3 +311,27 @@ def test_run_shell_non_positive_env_var_falls_back(tmp_path, monkeypatch):
     out = tb.call("run_shell", {"command": "sleep 0.1"})
     assert "[exit 0]" in out
     assert "timed out" not in out
+
+
+def test_run_shell_zero_timeout_argument_uses_default(tmp_path):
+    """An explicit timeout=0 should not time out instantly; it should fall back to
+    the default so the model gets a useful command result."""
+    tb, wd, _ = _tb(tmp_path)
+    out = tb.call("run_shell", {"command": "sleep 0.1", "timeout": 0})
+    assert "[exit 0]" in out
+    assert "timed out" not in out
+
+
+def test_run_shell_negative_timeout_argument_uses_default(tmp_path):
+    """An explicit negative timeout should also fall back to the default."""
+    tb, wd, _ = _tb(tmp_path)
+    out = tb.call("run_shell", {"command": "sleep 0.1", "timeout": -1})
+    assert "[exit 0]" in out
+    assert "timed out" not in out
+
+
+def test_run_shell_positive_timeout_argument_still_enforced(tmp_path):
+    """A positive per-call timeout still works normally."""
+    tb, wd, _ = _tb(tmp_path)
+    out = tb.call("run_shell", {"command": "sleep 2", "timeout": 1})
+    assert "timed out after 1s" in out


### PR DESCRIPTION
## Problem
`run_shell(timeout=0)` timed out instantly instead of running the command. A model can pass `0` either by mistake or because it interprets "no timeout" as zero, but `subprocess.run(timeout=0)` expires immediately.

This is #68.

## Analysis
`run_shell` only replaced `timeout` with the default when the argument was omitted (`timeout is None`). Any explicit non-positive integer was forwarded straight to `subprocess.run`, which treats `timeout <= 0` as "already expired". The JSON schema also described `timeout` as a plain integer with no hint about valid values.

## Solution
- Treat explicit `timeout <= 0` the same as an omitted timeout: fall back to `_shell_timeout()` (default 120s, or `OPENDOT_SHELL_TIMEOUT` if set).
- Update the JSON schema description to state that the value must be a positive integer and that non-positive values fall back to the default.

## Benchmarks / Tests
- Added regression tests:
  - `test_run_shell_zero_timeout_argument_uses_default`
  - `test_run_shell_negative_timeout_argument_uses_default`
  - `test_run_shell_positive_timeout_argument_still_enforced`
- Full suite: 168 passed under `pytest tests/ -q -W error::RuntimeWarning` (was 165).

## Notes
Per-call positive timeouts still take precedence over the env default. Only zero and negative values are reinterpreted as "use the default".
