### PR TITLE
fix(tools): handle invalid xlsx sheet names

### DIFF
--- a/src/opendot/tools/office.py
+++ b/src/opendot/tools/office.py
@@ -64,6 +64,8 @@ def build_office_tools(box) -> list:
             return f"error: file not found: {p}"
         wb = openpyxl.load_workbook(p, data_only=True)
         names = wb.sheetnames
+        if sheet and sheet not in names:
+            return f"error: no sheet {sheet!r}; sheets: {', '.join(names)}"
         ws = wb[sheet] if sheet else wb[names[0]]
         lines = [
             f"workbook {box._rel(p)}  sheets: {', '.join(names)}",
@@ -84,7 +86,10 @@ def build_office_tools(box) -> list:
         if not p.exists():
             return f"error: file not found: {p}"
         wb = openpyxl.load_workbook(p)
-        ws = wb[sheet] if sheet else wb[wb.sheetnames[0]]
+        names = wb.sheetnames
+        if sheet and sheet not in names:
+            return f"error: no sheet {sheet!r}; sheets: {', '.join(names)}"
+        ws = wb[sheet] if sheet else wb[names[0]]
         old = ws[cell].value
         if not _snapshot(p):
             return "skipped: user declined an edit outside the workspace"

--- a/tests/test_office.py
+++ b/tests/test_office.py
@@ -37,6 +37,16 @@ def _make_xlsx(path):
     wb.save(path)
 
 
+def _add_xlsx_sheet(path):
+    import openpyxl
+
+    wb = openpyxl.load_workbook(path)
+    ws = wb.create_sheet("Summary")
+    ws["A1"] = "total"
+    ws["B1"] = 100
+    wb.save(path)
+
+
 def _make_pptx(path):
     from pptx import Presentation
     from pptx.util import Inches
@@ -100,6 +110,41 @@ def test_read_and_edit_xlsx(tmp_path):
 
     wb = openpyxl.load_workbook(wd / "data.xlsx")
     assert wb.active["B2"].value == 120  # coerced to int
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "arguments"),
+    [
+        ("read_xlsx", {}),
+        ("edit_cell", {"cell": "A1", "value": "changed"}),
+    ],
+)
+def test_invalid_xlsx_sheet_lists_available_sheets(tmp_path, tool_name, arguments):
+    tb, wd, _ = _tb(tmp_path)
+    _make_xlsx(wd / "data.xlsx")
+    _add_xlsx_sheet(wd / "data.xlsx")
+
+    out = tb.call(tool_name, {"path": "data.xlsx", "sheet": "Nope", **arguments})
+    assert out == "error: no sheet 'Nope'; sheets: Sheet, Summary"
+
+
+def test_read_and_edit_xlsx_explicit_sheet(tmp_path):
+    tb, wd, _ = _tb(tmp_path)
+    _make_xlsx(wd / "data.xlsx")
+    _add_xlsx_sheet(wd / "data.xlsx")
+
+    out = tb.call("read_xlsx", {"path": "data.xlsx", "sheet": "Summary"})
+    assert "total" in out
+
+    res = tb.call(
+        "edit_cell",
+        {"path": "data.xlsx", "sheet": "Summary", "cell": "B1", "value": "120"},
+    )
+    assert "100" in res and "120" in res
+
+    import openpyxl
+
+    assert openpyxl.load_workbook(wd / "data.xlsx")["Summary"]["B1"].value == 120
 
 
 def test_xlsx_edit_is_undoable(tmp_path):


### PR DESCRIPTION
## What & why

Fixes #69.

`read_xlsx` and `edit_cell` now return a clear error listing the available worksheets when the requested sheet does not exist, instead of exposing openpyxl's `KeyError`.

Valid named sheets and omitted sheet names continue to use the existing behavior.

## How I verified it

- Added regression coverage for invalid sheet names in both tools.
- Added coverage for reading and editing an explicit valid sheet.
- Confirmed the existing default-sheet and XLSX undo tests still pass.
- `pytest tests/test_office.py -q` — 15 passed
- `pytest -q` — 171 passed
- `ruff check src/ tests/` — passed
- `ruff format --check src/ tests/` — passed

## Checklist

- [x] Small and focused (one change)
- [x] Added/updated tests; `pytest` passes locally
- [x] Existing XLSX snapshot and undo coverage still passes; invalid edits return before any mutation
- [x] No UI changes
