### PR TITLE
fix(office): explain missing xlsx sheet names

### DIFF
--- a/src/opendot/tools/office.py
+++ b/src/opendot/tools/office.py
@@ -64,6 +64,8 @@ def build_office_tools(box) -> list:
             return f"error: file not found: {p}"
         wb = openpyxl.load_workbook(p, data_only=True)
         names = wb.sheetnames
+        if sheet and sheet not in names:
+            return f"error: no sheet {sheet!r}; sheets: {', '.join(names)}"
         ws = wb[sheet] if sheet else wb[names[0]]
         lines = [
             f"workbook {box._rel(p)}  sheets: {', '.join(names)}",
@@ -84,7 +86,10 @@ def build_office_tools(box) -> list:
         if not p.exists():
             return f"error: file not found: {p}"
         wb = openpyxl.load_workbook(p)
-        ws = wb[sheet] if sheet else wb[wb.sheetnames[0]]
+        names = wb.sheetnames
+        if sheet and sheet not in names:
+            return f"error: no sheet {sheet!r}; sheets: {', '.join(names)}"
+        ws = wb[sheet] if sheet else wb[names[0]]
         old = ws[cell].value
         if not _snapshot(p):
             return "skipped: user declined an edit outside the workspace"

--- a/tests/test_office.py
+++ b/tests/test_office.py
@@ -102,6 +102,27 @@ def test_read_and_edit_xlsx(tmp_path):
     assert wb.active["B2"].value == 120  # coerced to int
 
 
+def test_xlsx_missing_sheet_lists_available_sheets(tmp_path):
+    tb, wd, rev = _tb(tmp_path)
+    path = wd / "data.xlsx"
+    _make_xlsx(path)
+
+    read_result = tb.call("read_xlsx", {"path": "data.xlsx", "sheet": "Data"})
+    edit_result = tb.call(
+        "edit_cell",
+        {"path": "data.xlsx", "cell": "B2", "value": "120", "sheet": "Data"},
+    )
+
+    expected = "error: no sheet 'Data'; sheets: Sheet"
+    assert read_result == expected
+    assert edit_result == expected
+    assert rev.history() == []
+
+    import openpyxl
+
+    assert openpyxl.load_workbook(path).active["B2"].value == 100
+
+
 def test_xlsx_edit_is_undoable(tmp_path):
     tb, wd, rev = _tb(tmp_path)
     _make_xlsx(wd / "data.xlsx")


### PR DESCRIPTION
Fixes #69

Summary:
- Return the requested sheet name and available sheets when an XLSX sheet is missing.
- Validate before edit snapshots or writes.

Testing:
- `PYTHONPATH=src .venv/bin/pytest tests/test_office.py -q` (13 passed)
- `PYTHONPATH=src .venv/bin/pytest -q` (169 passed)
- Ruff check and format check passed.