### PR TITLE
fix(tools): grep no longer crashes on paths outside the workspace

### DIFF
--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -346,7 +346,7 @@ class Toolbox:
                         f.read_text(encoding="utf-8", errors="ignore").splitlines(), 1
                     ):
                         if rx.search(line):
-                            rel = f.relative_to(self.workdir)
+                            rel = self._rel(f)
                             hits.append(f"{rel}:{i}:{line.strip()[:200]}")
                             if len(hits) >= max_matches:
                                 return _truncate(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -35,6 +35,19 @@ def test_grep_no_match(tmp_path):
     assert tb.call("grep", {"pattern": "nonexistent_xyz"}) == "no matches"
 
 
+def test_grep_outside_workspace_returns_matches(tmp_path):
+    # Regression: an absolute path outside workdir used to raise ValueError from
+    # Path.relative_to; it must now return matches (shown with the absolute path).
+    tb, wd, _ = _tb(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    target = outside / "c.py"
+    target.write_text("marker_outside = 1\n")
+    out = tb.call("grep", {"pattern": "marker_outside", "path": str(outside)})
+    assert "marker_outside" in out
+    assert str(target) in out
+
+
 def test_grep_ignore_case(tmp_path):
     tb, wd, _ = _tb(tmp_path)
 


### PR DESCRIPTION
Fixes #66.

`grep` crashed with `ValueError` on any path outside the workspace. It built the display path with `f.relative_to(self.workdir)`, which raises for files not under `workdir`, and the loop only caught `OSError` — so the error escaped:

```python
grep("root", path="/etc")   # -> ValueError: '/etc/hosts' is not in the subtree of ...
```

**Fix (one line):** use the existing `_rel` helper (local.py:157-162), which already falls back to the absolute path on `ValueError`:

```python
rel = self._rel(f)   # was: f.relative_to(self.workdir)
```

**Test:** added `test_grep_outside_workspace_returns_matches` — greps an absolute path outside `workdir` and asserts it returns the match with the absolute path (previously raised).

**Verification** (`py -3.12 -m pytest tests/test_tools.py`): the new test passes; in-workspace grep tests unchanged. The only failing tests (`test_glob`, `test_list_files_shows_sizes`, `test_list_files_survives_unreadable_entry`) fail identically on a clean checkout on Windows for environment reasons (`\` path separator and `os.symlink` privilege) — unrelated to this change (confirmed via `git stash`).

Acceptance criteria met: out-of-workspace grep returns matches (absolute paths), in-workspace behaviour unchanged, regression test added.

---
🤖 Assisted by Claude (disclosed).
