### PR TITLE
fix(tui): allow local api bases without provider keys

### DIFF
--- a/src/opendot/tui/app.py
+++ b/src/opendot/tui/app.py
@@ -412,6 +412,9 @@ class OpendotTUI(App):
         hint to the transcript and return True (so the caller skips the turn)."""
         import os
 
+        if getattr(self.agent.config, "api_base", None):
+            return False
+
         from opendot.providers import env_var_for
 
         var = env_var_for(self.agent.config.model)

--- a/tests/test_tui_api_base.py
+++ b/tests/test_tui_api_base.py
@@ -1,0 +1,31 @@
+"""Regression tests for the TUI's local API-base key hint behavior."""
+
+from types import SimpleNamespace
+
+from opendot.tui.app import OpendotTUI
+
+
+def _hint_app(api_base, *, include_api_base=True):
+    config = {"model": "gpt-4o"}
+    if include_api_base:
+        config["api_base"] = api_base
+    app = OpendotTUI.__new__(OpendotTUI)
+    app.agent = SimpleNamespace(config=SimpleNamespace(**config))
+    app.writes = []
+    app._write = lambda *args: app.writes.append(args)
+    return app
+
+
+def test_missing_key_hint_skips_provider_hint_for_local_api_base(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    configured = _hint_app("http://localhost:8080/v1")
+    absent = _hint_app(None, include_api_base=False)
+    falsey = _hint_app("")
+
+    assert configured._missing_key_hint() is False
+    assert configured.writes == []
+    assert absent._missing_key_hint() is True
+    assert len(absent.writes) == 1
+    assert falsey._missing_key_hint() is True
+    assert len(falsey.writes) == 1


### PR DESCRIPTION
Fixes #67

Summary:
- Skip the provider-key hint when a non-empty local `api_base` is configured.
- Preserve the existing hint behavior when `api_base` is absent or empty.
- Add regression coverage for configured, absent, and empty values.

Tests:
- `PYTHONPATH=src .venv/bin/pytest -q` (169 passed)
- `ruff check src/opendot/tui/app.py tests/test_tui_api_base.py`
- `ruff format --check src/opendot/tui/app.py tests/test_tui_api_base.py`
