### PR TITLE
fix: remove unused rich parameter from _run_turn

### DIFF
--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -304,7 +304,7 @@ def _cmd_mcp(args) -> None:
         return
 
 
-async def _run_turn(agent: Agent, message: str, *, rich: bool = True) -> None:
+async def _run_turn(agent: Agent, message: str) -> None:
     """Run one turn, streaming events to the console live.
 
     Reasoning ("thinking") streams dimmed; the answer streams in normal weight;
@@ -540,7 +540,7 @@ def main() -> None:
     if oneshot:
         # Non-interactive: can't prompt, so decline irreversible commands by default.
         agent = _build_agent(args.model, workdir, confirm=lambda _p: False, api_base=args.api_base)
-        asyncio.run(_run_turn(agent, oneshot, rich=False))
+        asyncio.run(_run_turn(agent, oneshot))
     elif args.repl:
         agent = _build_agent(args.model, workdir, confirm=_confirm, api_base=args.api_base)
         _interactive(agent)


### PR DESCRIPTION
## What & why

Removes the unused `rich` parameter from `_run_turn` function definition and its call site.

Closes #78

## How I verified it

Code inspection and verified call site references in `src/opendot/cli.py`.

## Checklist

- [x] Small and focused (one change)
- [ ] Added/updated tests; `pytest` passes locally
- [ ] If it touches `reversibility/` or a mutating tool: actions are snapshotted and undo still restores exactly (tests added)
- [ ] If it changes the UI: screenshot / short recording included below
