### PR TITLE
fix: prevent missing key warning with custom api base

### DIFF
--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -389,7 +389,10 @@ def _interactive(agent: Agent) -> None:
             if len(parts) > 1:
                 agent.config.model = parts[1].strip()
                 console.print(f"model → [cyan]{agent.config.model}[/cyan]")
-                _warn_if_missing_key(agent.config.model)
+                # A local api_base needs no provider key, so skip the hint here
+                # too (mirrors the startup guard in main()).
+                if not agent.config.api_base:
+                    _warn_if_missing_key(agent.config.model)
             else:
                 console.print(
                     f"model: [cyan]{agent.config.model}[/cyan]  ([dim]/model <id> to change[/dim])"

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -530,7 +530,8 @@ def main() -> None:
         return
 
     # Everything below this point calls a model — hint if the key looks missing.
-    _warn_if_missing_key(args.model)
+    if not args.api_base:
+        _warn_if_missing_key(args.model)
 
     # One-shot: -p flag, or piped stdin.
     oneshot = args.prompt

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -15,8 +15,10 @@ Completion calls are stubbed with a fake LiteLLM, so no real server is contacted
 Patterns mirror ``tests/test_usage.py`` (bare-agent + fake LiteLLM).
 """
 
+import sys
 import types
 
+from opendot import cli
 from opendot.agent.config import AgentConfig
 from opendot.agent.loop import Agent
 from opendot.agent.usage import Usage
@@ -145,3 +147,62 @@ def test_no_api_base_triggers_provider_autodetect(tmp_path, monkeypatch):
     agent = cli._build_agent("gpt-4o", str(tmp_path), api_base=None)
 
     assert agent.config.model == "claude-sonnet-4-5"  # switched via auto-detect
+
+
+def test_spurious_warning_for_local_api_base(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["opendot", "--api-base", API_BASE, "--model", "openai/local-model", "--repl"],
+    )
+
+    called = []
+
+    def fake_warn_if_missing_key(model):
+        called.append(model)
+
+    monkeypatch.setattr(cli, "_warn_if_missing_key", fake_warn_if_missing_key)
+
+    class FakeStdin:
+        def isatty(self):
+            return True
+
+    monkeypatch.setattr(sys, "stdin", FakeStdin())
+
+    dummy_object = "dummy"
+    monkeypatch.setattr(cli, "_build_agent", lambda model, workdir, confirm, api_base: dummy_object)
+
+    monkeypatch.setattr(cli, "_interactive", lambda agent: None)
+
+    cli.main()
+
+    assert called == []
+
+
+def test_warning_for_missing_key_with_no_api_base(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(sys, "argv", ["opendot", "--model", "gpt-4o", "--repl"])
+
+    called = []
+
+    def fake_warn_if_missing_key(model):
+        called.append(model)
+
+    monkeypatch.setattr(cli, "_warn_if_missing_key", fake_warn_if_missing_key)
+
+    class FakeStdin:
+        def isatty(self):
+            return True
+
+    monkeypatch.setattr(sys, "stdin", FakeStdin())
+
+    dummy_object = "dummy"
+    monkeypatch.setattr(cli, "_build_agent", lambda model, workdir, confirm, api_base: dummy_object)
+
+    monkeypatch.setattr(cli, "_interactive", lambda agent: None)
+
+    cli.main()
+
+    assert called == ["gpt-4o"]
+

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -182,6 +182,9 @@ def test_spurious_warning_for_local_api_base(monkeypatch):
 
 def test_warning_for_missing_key_with_no_api_base(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    # --api-base defaults to $OPENAI_API_BASE via argparse; clear it so the test
+    # is hermetic (otherwise a dev/CI machine with it set would skip the warning).
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
     monkeypatch.setattr(sys, "argv", ["opendot", "--model", "gpt-4o", "--repl"])
 
     called = []
@@ -205,4 +208,3 @@ def test_warning_for_missing_key_with_no_api_base(monkeypatch):
     cli.main()
 
     assert called == ["gpt-4o"]
-


### PR DESCRIPTION
<!-- Keep it short and in your own words. See CONTRIBUTING.md. -->

## What and Why
This addresses issue #76 by preventing the "no API Key" warning from appearing when using a local API base.

<!-- What does this change, and why? One or two sentences. -->
This changes lines 533 and 534 in cli.py to make it so that an unnecessary warning is not produced when a local API base is detected.

## How I verified it

<!-- What did you test, and how can a reviewer reproduce/confirm it? -->
I added tests for both cases- when there is an API base and when there is not. A reviewer can confirm it by running python -m pytest tests/test_api_base.py -v to confirm that it skips the missing key warning  when a API base is provided while the warning is still triggered when one is not provided. I also ran all the tests with python -m pytest. All 175 tests passed.

## Checklist

- [x] Small and focused (one change)
- [x] Added/updated tests; `pytest` passes locally
- [ ] If it touches `reversibility/` or a mutating tool: actions are snapshotted and undo still restores exactly (tests added)
- [ ] If it changes the UI: screenshot / short recording included below

<!-- UI screenshots (before / after) go here if applicable. -->
