### PR TITLE
feat(list_files): add recursive option reusing the ignore-aware walk (#85)

### DIFF
--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -192,26 +192,60 @@ class Toolbox:
                 return f"{num_bytes / (1024 * 1024):.1f} MB"
             return f"{num_bytes / (1024 * 1024 * 1024):.1f} GB"
 
-        def list_files(path: str = ".") -> str:
+        def _entry_line(e: Path, name: str) -> str:
+            """Format one listing line: dirs get a trailing '/', files get a size.
+            A broken symlink or unreadable file shouldn't crash the listing — just
+            show the name without a size."""
+            if e.is_dir():
+                return f"{name}/"
+            try:
+                return f"{name} ({_format_size(e.stat().st_size)})"
+            except OSError:
+                return name
+
+        # Cap a recursive listing so an enormous tree can't blow the context. The
+        # per-char _truncate still applies on top; this bounds the entry count.
+        _MAX_RECURSIVE_ENTRIES = 1000
+
+        def list_files(path: str = ".", recursive: bool = False) -> str:
             base = self._resolve(path)
             if not base.exists():
                 return f"error: path does not exist: {base}"
             if base.is_file():
                 return str(base)
+
+            if not recursive:
+                entries = [
+                    _entry_line(e, e.name)
+                    for e in sorted(base.iterdir())
+                    if e.name not in self._IGNORE
+                ]
+                return _truncate("\n".join(entries) or "(empty)")
+
+            # Recursive: os.walk with the same _IGNORE pruning as _walk_files, so it
+            # skips .git/node_modules/.venv/.opendot exactly like grep/glob. Paths are
+            # shown relative to `base` so the tree stays readable.
             entries = []
-            for e in sorted(base.iterdir()):
-                if e.name in self._IGNORE:
-                    continue
-                if e.is_dir():
-                    entries.append(f"{e.name}/")
-                else:
-                    # A broken symlink or unreadable file shouldn't crash the whole
-                    # listing — just show the name without a size.
-                    try:
-                        entries.append(f"{e.name} ({_format_size(e.stat().st_size)})")
-                    except OSError:
-                        entries.append(e.name)
-            return _truncate("\n".join(entries) or "(empty)")
+            truncated = False
+            for dirpath, dirnames, filenames in os.walk(base):
+                dirnames[:] = sorted(d for d in dirnames if d not in self._IGNORE)
+                here = Path(dirpath)
+                for name in dirnames:
+                    rel = str((here / name).relative_to(base))
+                    entries.append(f"{rel}/")
+                for fn in sorted(filenames):
+                    p = here / fn
+                    rel = str(p.relative_to(base))
+                    entries.append(_entry_line(p, rel))
+                    if len(entries) >= _MAX_RECURSIVE_ENTRIES:
+                        truncated = True
+                        break
+                if truncated:
+                    break
+            out = "\n".join(entries) or "(empty)"
+            if truncated:
+                out += f"\n... (listing capped at {_MAX_RECURSIVE_ENTRIES} entries)"
+            return _truncate(out)
 
         def read_file(
             path: str,
@@ -467,14 +501,22 @@ class Toolbox:
         return [
             Tool(
                 "list_files",
-                "List files and directories at a path (relative to the working dir).",
+                "List files and directories at a path (relative to the working dir). "
+                "Set recursive=true to walk subdirectories in one call.",
                 {
                     "type": "object",
                     "properties": {
                         "path": {
                             "type": "string",
                             "description": "Path to list; defaults to '.'.",
-                        }
+                        },
+                        "recursive": {
+                            "type": "boolean",
+                            "description": (
+                                "Walk subdirectories (skipping .git/node_modules/.venv/etc), "
+                                "showing paths relative to the listed dir. Default false."
+                            ),
+                        },
                     },
                 },
                 list_files,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -166,6 +166,47 @@ def test_list_files_ignores_same_dirs_as_grep_and_glob(tmp_path):
     assert "keep/" in out  # non-ignored dirs are still listed
 
 
+def test_list_files_recursive_lists_nested_entries(tmp_path):
+    # recursive=True walks subdirectories and shows paths relative to the base,
+    # so a nested file appears with its dir prefix (issue #85).
+    tb, wd, _ = _tb(tmp_path)
+    out = tb.call("list_files", {"path": ".", "recursive": True})
+    assert "src/" in out
+    assert "src/a.py" in out
+    assert "src/b.py" in out
+    assert "README.md" in out
+
+
+def test_list_files_default_is_top_level_only(tmp_path):
+    # Default (recursive=False) is unchanged: only the top level, so nested files
+    # are not listed with a dir prefix.
+    tb, wd, _ = _tb(tmp_path)
+    out = tb.call("list_files", {"path": "."})
+    assert "src/" in out
+    assert "src/a.py" not in out  # not descended into
+    assert "src/b.py" not in out
+
+
+def test_list_files_recursive_skips_ignored_dirs(tmp_path):
+    # The recursive walk skips the same _IGNORE dirs as grep/glob, in both modes.
+    tb, wd, _ = _tb(tmp_path)
+    for name in (".venv", ".opendot", "node_modules", "__pycache__"):
+        (wd / name).mkdir()
+        (wd / name / "junk.py").write_text("x = 1\n")
+
+    out = tb.call("list_files", {"path": ".", "recursive": True})
+
+    for name in (".venv", ".opendot", "node_modules", "__pycache__"):
+        assert name not in out  # neither the dir nor its nested junk.py
+    assert "src/a.py" in out  # non-ignored nested files still appear
+
+
+def test_list_files_schema_exposes_recursive(tmp_path):
+    tb, _, _ = _tb(tmp_path)
+    specs = {s["function"]["name"]: s["function"]["parameters"] for s in tb.specs()}
+    assert "recursive" in specs["list_files"]["properties"]
+
+
 def test_edit_replaces_and_reports(tmp_path):
     tb, wd, _ = _tb(tmp_path)
     out = tb.call("edit", {"path": "src/b.py", "find": "z = 3", "replace": "z = 99"})


### PR DESCRIPTION
list_files only listed one directory level, so mapping a repo meant calling it per-directory. Add recursive=False (default) / recursive=True: when set, walk subdirectories with the same _IGNORE pruning grep/glob use (.git, node_modules, .venv, .opendot, ...), printing paths relative to the listed dir. Directories keep the trailing /, files keep their size via _format_size, and the broken-symlink guard is preserved (factored into a shared _entry_line helper).

The default path is byte-identical to before. A recursive listing is bounded at 1000 entries (with _truncate still applying on top) so a huge tree can't blow the context. Schema gains the recursive param.

Tests: nested workspace lists nested entries when recursive and only the top level when not, ignored dirs are absent in both modes, and the schema exposes recursive.