### PR TITLE
fix(agent): pass api_base and temperature to explorers

### DIFF
--- a/src/opendot/agent/explorers.py
+++ b/src/opendot/agent/explorers.py
@@ -33,7 +33,9 @@ anything; those tools are not available to you.
 """
 
 
-async def run_explorers(tasks: list[str], *, model: str, workdir: str) -> AsyncIterator[Event]:
+async def run_explorers(
+    tasks: list[str], *, model: str, workdir: str, api_base: str | None = None, temperature: float | None = None
+) -> AsyncIterator[Event]:
     """Run each task as a concurrent read-only subagent, yielding lane-tagged
     events, and finally a merged findings summary the caller can use."""
     from opendot.agent.config import AgentConfig
@@ -55,6 +57,8 @@ async def run_explorers(tasks: list[str], *, model: str, workdir: str) -> AsyncI
                 model=model,
                 workdir=workdir,
                 system_prompt=_EXPLORER_SYSTEM,
+                api_base=api_base,
+                temperature=temperature,
             )
         )
         # Force a read-only toolbox regardless of defaults.

--- a/src/opendot/agent/explorers.py
+++ b/src/opendot/agent/explorers.py
@@ -34,7 +34,12 @@ anything; those tools are not available to you.
 
 
 async def run_explorers(
-    tasks: list[str], *, model: str, workdir: str, api_base: str | None = None, temperature: float | None = None
+    tasks: list[str],
+    *,
+    model: str,
+    workdir: str,
+    api_base: str | None = None,
+    temperature: float | None = None,
 ) -> AsyncIterator[Event]:
     """Run each task as a concurrent read-only subagent, yielding lane-tagged
     events, and finally a merged findings summary the caller can use."""

--- a/src/opendot/agent/loop.py
+++ b/src/opendot/agent/loop.py
@@ -194,6 +194,8 @@ class Agent:
                         args.get("tasks", []),
                         model=self.config.model,
                         workdir=self.config.workdir,
+                        api_base=self.config.api_base,
+                        temperature=self.config.temperature,
                     ):
                         if ev.type == "tool_end" and ev.tool == "spawn_explorers":
                             result = ev.result  # merged findings


### PR DESCRIPTION
Fixes #95 by threading the parent config's api_base and temperature to the explorer subagents in spawn_explorers.