### PR TITLE
fix(office): stop edit_cell over-coercing values; add text opt-out (#96)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.2.6"
+version = "0.2.7"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 from opendot.agent.loop import Agent
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/tools/office.py
+++ b/src/opendot/tools/office.py
@@ -13,8 +13,40 @@ aren't installed, the tools aren't registered (see build_office_tools).
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
+
+# A canonical, plain numeric literal: optional sign, ASCII digits, optional single
+# decimal part and/or exponent. Deliberately strict — it rejects underscores
+# ("1_000"), non-finite words ("inf"/"nan"), unicode digits, and thousands
+# separators, all of which Python's int()/float() would otherwise accept. A
+# leading-zero integer ("007") is handled separately so ZIP/ID/SKU values survive.
+_INT_RE = re.compile(r"[+-]?[0-9]+")
+_FLOAT_RE = re.compile(r"[+-]?(?:[0-9]+\.[0-9]*|\.[0-9]+|[0-9]+)(?:[eE][+-]?[0-9]+)?")
+
+
+def _coerce_cell_value(value: str) -> Any:
+    """Convert a cell string to int/float only when it's an unambiguous, canonical
+    number; otherwise keep it as text. Formulas (leading '=') pass through as-is.
+
+    Kept conservative on purpose: leading-zero integers, underscores, inf/nan, and
+    non-ASCII digits all stay text, so IDs like "007" or codes aren't mangled.
+    """
+    if value.startswith("="):
+        return value  # formula
+
+    if _INT_RE.fullmatch(value):
+        # Preserve leading zeros (ZIP/ID/SKU): "007" stays text, "0" is fine.
+        digits = value.lstrip("+-")
+        if len(digits) > 1 and digits[0] == "0":
+            return value
+        return int(value)
+
+    if _FLOAT_RE.fullmatch(value):
+        return float(value)  # regex already excludes inf/nan/underscores
+
+    return value
 
 
 def office_available() -> bool:
@@ -79,7 +111,9 @@ def build_office_tools(box) -> list:
             lines.append(f"{r}: {cells}")
         return _truncate("\n".join(lines))
 
-    def edit_cell(path: str, cell: str, value: str, sheet: str | None = None) -> str:
+    def edit_cell(
+        path: str, cell: str, value: str, sheet: str | None = None, text: bool = False
+    ) -> str:
         import openpyxl
 
         p = box._resolve(path)
@@ -93,16 +127,7 @@ def build_office_tools(box) -> list:
         old = ws[cell].value
         if not _snapshot(p):
             return "skipped: user declined an edit outside the workspace"
-        # numbers stay numbers; formulas (leading '=') pass through
-        v: Any = value
-        if not value.startswith("="):
-            try:
-                v = int(value)
-            except ValueError:
-                try:
-                    v = float(value)
-                except ValueError:
-                    v = value
+        v = value if text else _coerce_cell_value(value)
         ws[cell] = v
         wb.save(p)
         return f"{box._rel(p)} [{ws.title}] {cell}: {old!r} → {v!r}"
@@ -191,7 +216,8 @@ def build_office_tools(box) -> list:
         ),
         Tool(
             "edit_cell",
-            "Set one cell in an .xlsx (e.g. cell 'B4'). Numbers/formulas handled. Undoable.",
+            "Set one cell in an .xlsx (e.g. cell 'B4'). Canonical numbers and "
+            "formulas ('=...') are handled; pass text=true to force a string. Undoable.",
             {
                 "type": "object",
                 "properties": {
@@ -202,6 +228,14 @@ def build_office_tools(box) -> list:
                     },
                     "value": {"type": "string"},
                     "sheet": {"type": "string"},
+                    "text": {
+                        "type": "boolean",
+                        "description": (
+                            "Write the value as text without numeric coercion "
+                            "(e.g. keep '007' or a phone number as a string). "
+                            "Default false."
+                        ),
+                    },
                 },
                 "required": ["path", "cell", "value"],
             },

--- a/tests/test_office.py
+++ b/tests/test_office.py
@@ -113,6 +113,61 @@ def test_read_and_edit_xlsx(tmp_path):
 
 
 @pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("7", 7),
+        ("-5", -5),
+        ("+7", 7),
+        ("0", 0),
+        ("3.14", 3.14),
+        ("1e3", 1000.0),
+        (".5", 0.5),
+        # These must stay TEXT (the bug this fixes):
+        ("007", "007"),  # leading-zero ID/ZIP/SKU
+        ("1_000", "1_000"),  # underscore separators
+        ("inf", "inf"),  # non-finite
+        ("nan", "nan"),
+        ("-inf", "-inf"),
+        ("١٢٣", "١٢٣"),  # unicode digits
+        ("2,000", "2,000"),  # thousands separator
+        ("abc", "abc"),
+        ("007-88-1234", "007-88-1234"),
+        ("=A1+A2", "=A1+A2"),  # formula passes through
+    ],
+)
+def test_coerce_cell_value(value, expected):
+    from opendot.tools.office import _coerce_cell_value
+
+    result = _coerce_cell_value(value)
+    assert result == expected
+    assert type(result) is type(expected)  # int vs float vs str must match
+
+
+def test_edit_cell_preserves_leading_zeros_by_default(tmp_path):
+    tb, wd, _ = _tb(tmp_path)
+    _make_xlsx(wd / "data.xlsx")
+    tb.call("edit_cell", {"path": "data.xlsx", "cell": "A2", "value": "007"})
+
+    import openpyxl
+
+    # "007" is not a canonical number, so it stays the string "007", not 7.
+    assert openpyxl.load_workbook(wd / "data.xlsx").active["A2"].value == "007"
+
+
+def test_edit_cell_text_flag_forces_string(tmp_path):
+    tb, wd, _ = _tb(tmp_path)
+    _make_xlsx(wd / "data.xlsx")
+    # text=True keeps even a plain number as a string.
+    tb.call("edit_cell", {"path": "data.xlsx", "cell": "B2", "value": "120", "text": True})
+
+    import openpyxl
+
+    cell = openpyxl.load_workbook(wd / "data.xlsx").active["B2"]
+    assert cell.value == "120"
+    assert isinstance(cell.value, str)
+
+
+@pytest.mark.parametrize(
     ("tool_name", "arguments"),
     [
         ("read_xlsx", {}),


### PR DESCRIPTION
edit_cell coerced anything int()/float() could parse into a number, so '007' became 7, '1_000'/'inf'/'nan'/unicode digits silently turned numeric, and there was no way to force text. This corrupted ZIP codes, IDs, SKUs, and phone numbers.

Two changes:
- Tighten coercion (new _coerce_cell_value): only canonical ASCII numeric literals become int/float. Leading-zero integers, underscores, inf/nan, thousands separators, and non-ASCII digits stay text. Formulas ('=...') still pass through.
- Add a text: bool = False parameter (and schema entry) to force a string regardless, e.g. text=True to keep '120' as '120'.

Tests: parametrized _coerce_cell_value over every case in the issue, plus edit_cell integration tests for leading-zero preservation and the text flag. 214 passed.