### PR TITLE
fix: retry transient API errors with backoff instead of aborting the turn

### DIFF
--- a/src/opendot/agent/config.py
+++ b/src/opendot/agent/config.py
@@ -29,6 +29,20 @@ def _max_steps() -> int:
     return value if value > 0 else 40
 
 
+def _max_retries() -> int:
+    """Default transient-error retry cap read from ``OPENDOT_MAX_RETRIES``.
+
+    Falls back to 3 when the variable is unset or not a non-negative integer.
+    0 is a valid value (retries disabled), unlike ``_max_steps``.
+    """
+    raw = os.environ.get("OPENDOT_MAX_RETRIES", "3")
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return 3
+    return value if value >= 0 else 3
+
+
 @dataclass
 class AgentConfig:
     """Everything the agent loop needs. Kept minimal for v1."""
@@ -38,6 +52,9 @@ class AgentConfig:
     # Hard bound on tool-calling turns per user message. Override via the
     # OPENDOT_MAX_STEPS env var or by passing a value at construction time.
     max_steps: int = field(default_factory=_max_steps)
+    # Bound on retries for a transient model-call error (rate-limit/5xx/timeout)
+    # before a turn gives up. Override via OPENDOT_MAX_RETRIES.
+    max_retries: int = field(default_factory=_max_retries)
     temperature: float | None = None
     system_prompt: str | None = None  # None => use the built-in default
     # Base URL for an OpenAI-compatible server (llama.cpp/llama-server, vLLM,

--- a/src/opendot/agent/loop.py
+++ b/src/opendot/agent/loop.py
@@ -48,6 +48,11 @@ class _StreamUnsupported(Exception):
     """Raised when a provider's stream can't yield structured tool calls."""
 
 
+# Cap on the exponential-backoff sleep between retries so a high max_retries
+# can't turn into multi-minute waits before a turn finally gives up.
+_MAX_BACKOFF_SECONDS = 30
+
+
 @dataclass
 class _Assembled:
     """Sentinel yielded at the end of a turn carrying the assembled result."""
@@ -268,7 +273,7 @@ class Agent:
                     yield Event("error", text=f"model call failed: {exc}")
                     return
 
-            await asyncio.sleep(2**attempt)
+            await asyncio.sleep(min(2**attempt, _MAX_BACKOFF_SECONDS))
             attempt += 1
 
     async def _stream_turn(self, litellm, tools):
@@ -288,16 +293,18 @@ class Agent:
         )
         content_parts: list[str] = []
         tool_calls: dict[int, dict[str, Any]] = {}
-        # Guard: with include_usage some providers report usage on both the last
-        # content chunk and a final usage-only chunk — count it once per turn.
-        usage_counted = False
+        # Usage may arrive on its own final chunk (no choices) or attached to a
+        # content chunk — capture whichever arrives first, but don't record it
+        # until the stream fully completes. Recording it as soon as it's seen
+        # would double-count on a retry: if a transient error drops the
+        # connection after the usage chunk but before the stream finishes, the
+        # aborted attempt must not have already billed usage that the retried,
+        # successful attempt will bill again.
+        usage_chunk = None
 
         async for chunk in stream:
-            # Usage may arrive on its own final chunk (no choices) or attached to
-            # a content chunk — capture it either way, but only once.
-            if not usage_counted and getattr(chunk, "usage", None):
-                self.usage.add_response(chunk, litellm, model=self.config.model)
-                usage_counted = True
+            if usage_chunk is None and getattr(chunk, "usage", None):
+                usage_chunk = chunk
             choices = getattr(chunk, "choices", None)
             if not choices:
                 continue
@@ -317,6 +324,9 @@ class Agent:
                     slot["name"] = tc.function.name
                 if tc.function and tc.function.arguments:
                     slot["args"] += tc.function.arguments
+
+        if usage_chunk is not None:
+            self.usage.add_response(usage_chunk, litellm, model=self.config.model)
 
         calls = [
             {"id": c["id"] or f"call_{i}", "name": c["name"], "args": c["args"]}

--- a/src/opendot/agent/loop.py
+++ b/src/opendot/agent/loop.py
@@ -8,6 +8,7 @@ to the model until it produces a final answer (no more tool calls).
 
 from __future__ import annotations
 
+import asyncio
 import json
 from dataclasses import dataclass
 from typing import Any, AsyncIterator
@@ -149,26 +150,16 @@ class Agent:
             # live, and tool-call deltas are reassembled. Streaming is what makes
             # the UX feel alive. If streaming fails for a provider, fall back to
             # a single non-streaming call (some local models emit tool calls as
-            # text in streaming mode).
-            try:
-                gen = None
-                async for ev in self._stream_turn(litellm, tools):
-                    if isinstance(ev, _Assembled):
-                        gen = ev
-                    else:
-                        yield ev
-            except _StreamUnsupported:
-                gen = None
-                async for ev in self._nonstream_turn(litellm, tools):
-                    if isinstance(ev, _Assembled):
-                        gen = ev
-                    else:
-                        yield ev
-            except Exception as exc:  # noqa: BLE001
-                yield Event("error", text=f"model call failed: {exc}")
-                return
+            # text in streaming mode). Transient provider errors (rate-limit/5xx/
+            # timeout) are retried with backoff before any output is produced.
+            gen = None
+            async for ev in self._dispatch_turn(litellm, tools):
+                if isinstance(ev, _Assembled):
+                    gen = ev
+                else:
+                    yield ev
 
-            if gen is None:  # an error event was already yielded
+            if gen is None:  # a terminal "error" event was already yielded
                 return
 
             self.messages.append(gen.assistant_msg)
@@ -210,13 +201,75 @@ class Agent:
                 # Run the (synchronous) tool off the event loop. This is what lets
                 # a confirm-callback safely block for a UI prompt (e.g. the TUI
                 # modal) without freezing the loop.
-                import asyncio
-
                 result = await asyncio.to_thread(self.toolbox.call, name, args)
                 yield Event("tool_end", tool=name, result=result)
                 self.messages.append({"role": "tool", "tool_call_id": call_id, "content": result})
 
         yield Event("error", text=f"stopped: hit max_steps ({self.config.max_steps})")
+
+    @staticmethod
+    def _transient_errors(litellm) -> tuple[type[BaseException], ...]:
+        """Provider errors worth retrying: rate-limit, 5xx, timeout, connection.
+
+        Deliberately excludes fatal errors (auth, bad request) — those should
+        fail fast rather than burn through the retry budget.
+        """
+        return (
+            litellm.RateLimitError,
+            litellm.APIConnectionError,
+            litellm.Timeout,
+            litellm.InternalServerError,
+            litellm.ServiceUnavailableError,
+        )
+
+    async def _dispatch_turn(self, litellm, tools):
+        """Run one model turn (streaming, falling back to non-streaming),
+        retrying transient provider errors with exponential backoff.
+
+        Yields Events, then a final _Assembled sentinel on success, or a
+        terminal "error" Event if the turn ultimately fails. A retry is only
+        attempted while no output has been produced yet for this attempt —
+        once content has streamed to the user, a blip is surfaced as-is
+        rather than silently redone.
+        """
+        transient = self._transient_errors(litellm)
+        attempt = 0
+        while True:
+            produced_output = False
+            try:
+                async for ev in self._stream_turn(litellm, tools):
+                    if not isinstance(ev, _Assembled):
+                        produced_output = True
+                    yield ev
+                return
+            except _StreamUnsupported:
+                try:
+                    async for ev in self._nonstream_turn(litellm, tools):
+                        if not isinstance(ev, _Assembled):
+                            produced_output = True
+                        yield ev
+                    return
+                except Exception as exc:  # noqa: BLE001
+                    should_retry = (
+                        not produced_output
+                        and attempt < self.config.max_retries
+                        and isinstance(exc, transient)
+                    )
+                    if not should_retry:
+                        yield Event("error", text=f"model call failed: {exc}")
+                        return
+            except Exception as exc:  # noqa: BLE001
+                should_retry = (
+                    not produced_output
+                    and attempt < self.config.max_retries
+                    and isinstance(exc, transient)
+                )
+                if not should_retry:
+                    yield Event("error", text=f"model call failed: {exc}")
+                    return
+
+            await asyncio.sleep(2**attempt)
+            attempt += 1
 
     async def _stream_turn(self, litellm, tools):
         """Stream one model turn. Yields Events, then a final _Assembled sentinel.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 """Tests for agent configuration defaults and env-var overrides."""
 
-from opendot.agent.config import AgentConfig, _max_steps
+from opendot.agent.config import AgentConfig, _max_retries, _max_steps
 
 
 def test_max_steps_default_when_unset(monkeypatch):
@@ -38,3 +38,45 @@ def test_agent_config_explicit_argument_overrides_env(monkeypatch):
     monkeypatch.setenv("OPENDOT_MAX_STEPS", "999")
     cfg = AgentConfig(max_steps=50)
     assert cfg.max_steps == 50
+
+
+def test_max_retries_default_when_unset(monkeypatch):
+    """Without OPENDOT_MAX_RETRIES, the cap stays at the default of 3."""
+    monkeypatch.delenv("OPENDOT_MAX_RETRIES", raising=False)
+    assert _max_retries() == 3
+
+
+def test_max_retries_honors_valid_env_override(monkeypatch):
+    monkeypatch.setenv("OPENDOT_MAX_RETRIES", "5")
+    assert _max_retries() == 5
+
+
+def test_max_retries_falls_back_on_invalid_or_negative(monkeypatch):
+    """Non-integer and negative values keep the default of 3."""
+    for bad in ("not-a-number", "-1"):
+        monkeypatch.setenv("OPENDOT_MAX_RETRIES", bad)
+        assert _max_retries() == 3, f"{bad!r} should fall back to the default"
+
+
+def test_max_retries_allows_zero(monkeypatch):
+    """Zero is a valid, meaningful value (no retries) unlike max_steps."""
+    monkeypatch.setenv("OPENDOT_MAX_RETRIES", "0")
+    assert _max_retries() == 0
+
+
+def test_agent_config_default_max_retries(monkeypatch):
+    monkeypatch.delenv("OPENDOT_MAX_RETRIES", raising=False)
+    cfg = AgentConfig()
+    assert cfg.max_retries == 3
+
+
+def test_agent_config_env_override_max_retries(monkeypatch):
+    monkeypatch.setenv("OPENDOT_MAX_RETRIES", "7")
+    cfg = AgentConfig()
+    assert cfg.max_retries == 7
+
+
+def test_agent_config_explicit_max_retries_overrides_env(monkeypatch):
+    monkeypatch.setenv("OPENDOT_MAX_RETRIES", "999")
+    cfg = AgentConfig(max_retries=1)
+    assert cfg.max_retries == 1

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -4,10 +4,15 @@ Covers the streaming path's choice-less chunk bug: some providers emit a final
 usage-only chunk that has no `choices` attribute at all. Direct attribute access
 would raise `AttributeError` and be swallowed by the broad `run()` exception
 handler as a "model call failed" failure.
+
+Also covers retrying transient provider errors (rate-limit/5xx/timeout) with
+backoff instead of aborting the whole turn on the first blip.
 """
 
 import asyncio
 import types
+
+import litellm as real_litellm
 
 from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
@@ -42,13 +47,57 @@ def _chunk_with_choices(content: str | None = None, with_usage: bool = False):
     return c
 
 
-def _bare_agent():
+def _bare_agent(max_retries: int = 3):
     a = Agent.__new__(Agent)
-    a.config = AgentConfig(model="gpt-4o", workdir="/tmp")
+    a.config = AgentConfig(model="gpt-4o", workdir="/tmp", max_retries=max_retries)
     a.usage = types.SimpleNamespace(add_response=lambda *a, **k: None, total_tokens=0, cost_usd=0.0)
-    a.messages = []
-    a.toolbox = types.SimpleNamespace(_confirm=None, specs=lambda: [])
+    a.messages = [{"role": "system", "content": "sys"}]
+    a.toolbox = types.SimpleNamespace(_confirm=None, specs=lambda: [], call=lambda *a, **k: "")
+    a.explorers_enabled = False
     return a
+
+
+class _FlakyLiteLLM(types.SimpleNamespace):
+    """Fake litellm module: `acompletion` raises for the first `fail_times`
+    calls, then succeeds. Reuses the real exception classes so isinstance
+    checks in the retry helper behave exactly as with the real litellm.
+    """
+
+    RateLimitError = real_litellm.RateLimitError
+    APIConnectionError = real_litellm.APIConnectionError
+    Timeout = real_litellm.Timeout
+    InternalServerError = real_litellm.InternalServerError
+    ServiceUnavailableError = real_litellm.ServiceUnavailableError
+    AuthenticationError = real_litellm.AuthenticationError
+    BadRequestError = real_litellm.BadRequestError
+
+    def __init__(self, fail_times, make_exc, **kw):
+        super().__init__(**kw)
+        self.fail_times = fail_times
+        self.make_exc = make_exc
+        self.calls = 0
+
+    async def acompletion(self, **kw):
+        self.calls += 1
+        if self.calls <= self.fail_times:
+            raise self.make_exc()
+
+        async def gen():
+            yield _chunk_with_choices("done", with_usage=True)
+
+        return gen()
+
+
+def _rate_limit_error():
+    return real_litellm.RateLimitError(
+        message="rate limited", llm_provider="openai", model="gpt-4o"
+    )
+
+
+def _auth_error():
+    return real_litellm.AuthenticationError(
+        message="bad key", llm_provider="openai", model="gpt-4o"
+    )
 
 
 def test_stream_turn_skips_choiceless_chunk():
@@ -98,3 +147,77 @@ def test_stream_turn_choiceless_chunk_not_fatal():
 
     events = asyncio.run(run())
     assert not any(isinstance(ev, Event) and ev.type == "error" for ev in events)
+
+
+def _run_agent(a, litellm, monkeypatch, user_message="hi"):
+    import sys
+
+    from opendot.agent import loop as loop_module
+
+    monkeypatch.setitem(sys.modules, "litellm", litellm)
+    # Don't actually wait through backoff sleeps in tests. `asyncio` is a
+    # single shared module object, so capture the real sleep before patching
+    # it — otherwise the replacement would call itself recursively.
+    real_sleep = loop_module.asyncio.sleep
+    monkeypatch.setattr(loop_module.asyncio, "sleep", lambda *a, **k: real_sleep(0))
+
+    async def go():
+        events = []
+        async for ev in a.run(user_message):
+            events.append(ev)
+        return events
+
+    return asyncio.run(go())
+
+
+def test_run_survives_transient_failures_then_succeeds(monkeypatch):
+    """Two rate-limit blips followed by a success: no error event, turn completes."""
+    a = _bare_agent(max_retries=3)
+    fake = _FlakyLiteLLM(fail_times=2, make_exc=_rate_limit_error)
+
+    events = _run_agent(a, fake, monkeypatch)
+
+    assert fake.calls == 3
+    assert not any(ev.type == "error" for ev in events)
+    assert any(ev.type == "final" for ev in events)
+    text_events = [ev for ev in events if ev.type == "text"]
+    assert text_events and text_events[-1].text == "done"
+
+
+def test_run_does_not_retry_fatal_errors(monkeypatch):
+    """An authentication error fails immediately, with no retry attempts."""
+    a = _bare_agent(max_retries=3)
+    fake = _FlakyLiteLLM(fail_times=99, make_exc=_auth_error)
+
+    events = _run_agent(a, fake, monkeypatch)
+
+    assert fake.calls == 1
+    assert len(events) == 1
+    assert events[0].type == "error"
+    assert "bad key" in events[0].text
+
+
+def test_run_exhausts_retries_then_yields_terminal_error(monkeypatch):
+    """More transient failures than max_retries allows: the turn ultimately fails."""
+    a = _bare_agent(max_retries=2)
+    fake = _FlakyLiteLLM(fail_times=99, make_exc=_rate_limit_error)
+
+    events = _run_agent(a, fake, monkeypatch)
+
+    # 1 initial attempt + 2 retries = 3 calls total.
+    assert fake.calls == 3
+    assert len(events) == 1
+    assert events[0].type == "error"
+    assert "rate limited" in events[0].text
+
+
+def test_run_zero_max_retries_fails_on_first_transient_error(monkeypatch):
+    """max_retries=0 means no retrying at all — the first blip is terminal."""
+    a = _bare_agent(max_retries=0)
+    fake = _FlakyLiteLLM(fail_times=99, make_exc=_rate_limit_error)
+
+    events = _run_agent(a, fake, monkeypatch)
+
+    assert fake.calls == 1
+    assert len(events) == 1
+    assert events[0].type == "error"

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -149,7 +149,7 @@ def test_stream_turn_choiceless_chunk_not_fatal():
     assert not any(isinstance(ev, Event) and ev.type == "error" for ev in events)
 
 
-def _run_agent(a, litellm, monkeypatch, user_message="hi"):
+def _run_agent(a, litellm, monkeypatch, user_message="hi", sleep_log=None):
     import sys
 
     from opendot.agent import loop as loop_module
@@ -159,7 +159,13 @@ def _run_agent(a, litellm, monkeypatch, user_message="hi"):
     # single shared module object, so capture the real sleep before patching
     # it — otherwise the replacement would call itself recursively.
     real_sleep = loop_module.asyncio.sleep
-    monkeypatch.setattr(loop_module.asyncio, "sleep", lambda *a, **k: real_sleep(0))
+
+    async def fake_sleep(seconds, *a, **k):
+        if sleep_log is not None:
+            sleep_log.append(seconds)
+        await real_sleep(0)
+
+    monkeypatch.setattr(loop_module.asyncio, "sleep", fake_sleep)
 
     async def go():
         events = []
@@ -221,3 +227,70 @@ def test_run_zero_max_retries_fails_on_first_transient_error(monkeypatch):
     assert fake.calls == 1
     assert len(events) == 1
     assert events[0].type == "error"
+
+
+class _DropsAfterUsageChunk(types.SimpleNamespace):
+    """Fake litellm: first call's stream yields a usage-only chunk then drops
+    with a transient error; second call succeeds. Models a provider that
+    reports usage before the connection is lost mid-turn.
+    """
+
+    RateLimitError = real_litellm.RateLimitError
+    APIConnectionError = real_litellm.APIConnectionError
+    Timeout = real_litellm.Timeout
+    InternalServerError = real_litellm.InternalServerError
+    ServiceUnavailableError = real_litellm.ServiceUnavailableError
+    AuthenticationError = real_litellm.AuthenticationError
+    BadRequestError = real_litellm.BadRequestError
+
+    def __init__(self, **kw):
+        super().__init__(**kw)
+        self.calls = 0
+
+    async def acompletion(self, **kw):
+        self.calls += 1
+        if self.calls == 1:
+
+            async def gen_fail():
+                yield _chunk_no_choices(with_usage=True)
+                raise real_litellm.Timeout(message="dropped", model="gpt-4o", llm_provider="openai")
+
+            return gen_fail()
+
+        async def gen_ok():
+            yield _chunk_with_choices("done", with_usage=True)
+
+        return gen_ok()
+
+
+def test_retry_does_not_double_count_usage(monkeypatch):
+    """A transient error after usage arrives but before the stream finishes
+    must not record that usage — the retried, successful attempt records it
+    once, not the aborted attempt too."""
+    a = _bare_agent(max_retries=1)
+    usage_calls = []
+    a.usage.add_response = lambda *a2, **k: usage_calls.append(1)
+    fake = _DropsAfterUsageChunk()
+
+    events = _run_agent(a, fake, monkeypatch)
+
+    assert fake.calls == 2
+    assert not any(ev.type == "error" for ev in events)
+    assert usage_calls == [1]
+
+
+def test_backoff_delay_is_capped(monkeypatch):
+    """Exponential backoff must not grow unbounded as retries increase."""
+    from opendot.agent import loop as loop_module
+
+    a = _bare_agent(max_retries=10)
+    fake = _FlakyLiteLLM(fail_times=99, make_exc=_rate_limit_error)
+    sleep_log: list[float] = []
+
+    _run_agent(a, fake, monkeypatch, sleep_log=sleep_log)
+
+    assert fake.calls == 11  # 1 initial attempt + 10 retries
+    assert len(sleep_log) == 10
+    assert max(sleep_log) <= loop_module._MAX_BACKOFF_SECONDS
+    # Naive 2**attempt would reach 512s by the 10th retry; confirm it's capped.
+    assert 512 not in sleep_log


### PR DESCRIPTION
Closes #102.

Retries transient API errors with bounded exponential backoff instead of aborting the agent turn. Completion dispatch now retries transient LiteLLM errors (429s, 5xxs, timeouts, and connection errors) while fatal errors still fail immediately.

Adds `AgentConfig.max_retries` (default 3), configurable via `OPENDOT_MAX_RETRIES`. Retries only occur when no output has streamed yet, preventing duplicated content after mid-stream failures.

Added config and loop tests covering retry behavior, fatal errors, retry limits, environment overrides, and `max_retries=0`. Full `pytest` suite passes except one pre-existing unrelated `test_mcp.py` failure. Also ran `ruff check` and `ruff format`.