### PR TITLE
feat: add move tool for renaming/moving files (snapshotted + undoable)

### DIFF
--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -495,8 +495,17 @@ class Toolbox:
             p_dst = self._resolve(dst)
             if not p_src.exists():
                 return f"error: file not found: {p_src}"
-            if p_dst.exists() and not overwrite:
-                return f"error: destination already exists: {p_dst} (pass overwrite=true to replace it)"
+            if p_dst.exists():
+                if not overwrite:
+                    return (
+                        f"error: destination already exists: {p_dst} "
+                        "(pass overwrite=true to replace it)"
+                    )
+                if p_dst.is_dir():
+                    # shutil.move()'s default behavior for a directory dst is to
+                    # move src INTO it, not replace it — that contradicts what
+                    # overwrite=true promises, so reject it explicitly.
+                    return f"error: cannot overwrite a directory: {p_dst}"
             # A move touching a path outside the working dir isn't covered by the
             # snapshot on that side, so it can't be fully undone. Confirm first and
             # record it honestly as irreversible, exactly like an escaping write/edit.
@@ -515,6 +524,14 @@ class Toolbox:
                     note="outside the workspace — not undoable" if outside else "",
                 )
             p_dst.parent.mkdir(parents=True, exist_ok=True)
+            # Remove an existing dst explicitly rather than relying on os.rename's
+            # implicit overwrite (shutil.move's fallback) — that isn't reliable
+            # across platforms (e.g. os.rename raises on Windows if dst exists).
+            if overwrite and p_dst.exists():
+                try:
+                    p_dst.unlink()
+                except OSError as exc:
+                    return f"error removing existing destination {p_dst}: {exc}"
             try:
                 shutil.move(str(p_src), str(p_dst))
             except Exception as exc:  # noqa: BLE001

--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import difflib
 import os
+import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -483,6 +484,43 @@ class Toolbox:
             rel = self._rel(p)
             return f"edited {rel} ({replaced} replacement(s))\n" + _unified_diff(text, new, rel)
 
+        def move(src: str, dst: str, overwrite: bool = False) -> str:
+            """Move/rename a file or directory (surgical, undoable).
+
+            Errors on a missing src or an existing dst unless overwrite=True —
+            mirrors the confirm-first-then-record pattern edit/write_file use for
+            paths outside the workspace.
+            """
+            p_src = self._resolve(src)
+            p_dst = self._resolve(dst)
+            if not p_src.exists():
+                return f"error: file not found: {p_src}"
+            if p_dst.exists() and not overwrite:
+                return f"error: destination already exists: {p_dst} (pass overwrite=true to replace it)"
+            # A move touching a path outside the working dir isn't covered by the
+            # snapshot on that side, so it can't be fully undone. Confirm first and
+            # record it honestly as irreversible, exactly like an escaping write/edit.
+            outside = self._is_outside_workspace(p_src) or self._is_outside_workspace(p_dst)
+            rel_src, rel_dst = self._rel(p_src), self._rel(p_dst)
+            if outside and not self._confirm(
+                f"This moves a file outside the workspace and can't be undone:\n"
+                f"  {rel_src} -> {rel_dst}\nMove it?"
+            ):
+                return "skipped: user declined a move outside the workspace"
+            if self.rev is not None:
+                self.rev.before_action(
+                    "write",
+                    f"{rel_src} -> {rel_dst}",
+                    reversible=not outside,
+                    note="outside the workspace — not undoable" if outside else "",
+                )
+            p_dst.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                shutil.move(str(p_src), str(p_dst))
+            except Exception as exc:  # noqa: BLE001
+                return f"error moving {p_src} to {p_dst}: {exc}"
+            return f"{rel_src} -> {rel_dst}"
+
         def web_fetch(url: str) -> str:
             """Fetch an http(s) URL and return its content as LLM-ready markdown
             (structured text, headings, links, tables) via PyScrappy. Read-only:
@@ -625,6 +663,24 @@ class Toolbox:
                     "required": ["path", "find", "replace"],
                 },
                 edit,
+            ),
+            Tool(
+                "move",
+                "Move or rename a file or directory (surgical, undoable). Errors if "
+                "dst already exists unless overwrite=true.",
+                {
+                    "type": "object",
+                    "properties": {
+                        "src": {"type": "string"},
+                        "dst": {"type": "string"},
+                        "overwrite": {
+                            "type": "boolean",
+                            "description": "Replace dst if it already exists (default false).",
+                        },
+                    },
+                    "required": ["src", "dst"],
+                },
+                move,
             ),
             Tool(
                 "web_fetch",

--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -495,7 +495,10 @@ class Toolbox:
             p_dst = self._resolve(dst)
             if not p_src.exists():
                 return f"error: file not found: {p_src}"
-            if p_src.resolve() == p_dst.resolve():
+            # Lexical comparison only (os.path.normpath), NOT Path.resolve() —
+            # resolve() dereferences symlinks, which would wrongly treat two
+            # distinct symlinks pointing at the same target as "the same path".
+            if os.path.normpath(str(p_src)) == os.path.normpath(str(p_dst)):
                 # Same path either way — nothing to do, and critically must NOT
                 # fall into the overwrite=True unlink-then-move path below, which
                 # would delete src (since dst IS src) before the move can run.

--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -495,6 +495,11 @@ class Toolbox:
             p_dst = self._resolve(dst)
             if not p_src.exists():
                 return f"error: file not found: {p_src}"
+            if p_src.resolve() == p_dst.resolve():
+                # Same path either way — nothing to do, and critically must NOT
+                # fall into the overwrite=True unlink-then-move path below, which
+                # would delete src (since dst IS src) before the move can run.
+                return f"no change: {src} and {dst} are the same path\n"
             if p_dst.exists():
                 if not overwrite:
                     return (
@@ -523,16 +528,14 @@ class Toolbox:
                     reversible=not outside,
                     note="outside the workspace — not undoable" if outside else "",
                 )
-            p_dst.parent.mkdir(parents=True, exist_ok=True)
-            # Remove an existing dst explicitly rather than relying on os.rename's
-            # implicit overwrite (shutil.move's fallback) — that isn't reliable
-            # across platforms (e.g. os.rename raises on Windows if dst exists).
-            if overwrite and p_dst.exists():
-                try:
-                    p_dst.unlink()
-                except OSError as exc:
-                    return f"error removing existing destination {p_dst}: {exc}"
             try:
+                p_dst.parent.mkdir(parents=True, exist_ok=True)
+                # Remove an existing dst explicitly rather than relying on
+                # os.rename's implicit overwrite (shutil.move's fallback) — that
+                # isn't reliable across platforms (os.rename raises on Windows if
+                # dst exists).
+                if overwrite and p_dst.exists():
+                    p_dst.unlink()
                 shutil.move(str(p_src), str(p_dst))
             except Exception as exc:  # noqa: BLE001
                 return f"error moving {p_src} to {p_dst}: {exc}"

--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -67,6 +67,20 @@ def _unified_diff(old: str, new: str, path: str, max_lines: int = 200) -> str:
     return "\n".join(diff)
 
 
+def _same_path(a: Path, b: Path) -> bool:
+    """True if `a` and `b` denote the same filesystem path, compared lexically
+    (normpath + normcase) — NOT via Path.resolve(), which would dereference
+    symlinks and wrongly conflate two distinct paths pointing at the same
+    target. normcase folds case on case-insensitive filesystems (Windows,
+    default macOS) and is a no-op elsewhere.
+    """
+
+    def _norm(p: Path) -> str:
+        return os.path.normcase(os.path.normpath(str(p)))
+
+    return _norm(a) == _norm(b)
+
+
 def _truncate(text: str) -> str:
     max_output = _max_output()
     if len(text) > max_output:
@@ -161,6 +175,17 @@ class Toolbox:
             return str(p.resolve().relative_to(self.workdir))
         except ValueError:
             return str(p)
+
+    def _rel_no_resolve(self, p: Path) -> str:
+        """Like _rel, but purely lexical (normpath, no Path.resolve()). Used
+        where the path itself — e.g. a symlink — is what the user asked to
+        act on, not whatever it points at; resolving would misreport it."""
+        norm = Path(os.path.normpath(str(p)))
+        wd = Path(os.path.normpath(str(self.workdir)))
+        try:
+            return str(norm.relative_to(wd))
+        except ValueError:
+            return str(norm)
 
     def _is_outside_workspace(self, p: Path) -> bool:
         """True if ``p`` is not under the working directory. Writes/edits to such
@@ -495,10 +520,7 @@ class Toolbox:
             p_dst = self._resolve(dst)
             if not p_src.exists():
                 return f"error: file not found: {p_src}"
-            # Lexical comparison only (os.path.normpath), NOT Path.resolve() —
-            # resolve() dereferences symlinks, which would wrongly treat two
-            # distinct symlinks pointing at the same target as "the same path".
-            if os.path.normpath(str(p_src)) == os.path.normpath(str(p_dst)):
+            if _same_path(p_src, p_dst):
                 # Same path either way — nothing to do, and critically must NOT
                 # fall into the overwrite=True unlink-then-move path below, which
                 # would delete src (since dst IS src) before the move can run.
@@ -518,7 +540,10 @@ class Toolbox:
             # snapshot on that side, so it can't be fully undone. Confirm first and
             # record it honestly as irreversible, exactly like an escaping write/edit.
             outside = self._is_outside_workspace(p_src) or self._is_outside_workspace(p_dst)
-            rel_src, rel_dst = self._rel(p_src), self._rel(p_dst)
+            # _rel_no_resolve, not _rel: a symlink's own path is what was asked
+            # to move, not whatever it points at — resolving would misreport
+            # the confirm prompt, ledger entry, and return value alike.
+            rel_src, rel_dst = self._rel_no_resolve(p_src), self._rel_no_resolve(p_dst)
             if outside and not self._confirm(
                 f"This moves a file outside the workspace and can't be undone:\n"
                 f"  {rel_src} -> {rel_dst}\nMove it?"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,10 +1,13 @@
 """Tests for the coding tools (grep, glob, edit) and that edit is undoable."""
 
+import os
+from pathlib import Path
+
 import pytest
 
 from opendot.reversibility.engine import Reversibility
 from opendot.reversibility.snapshots import IgnoreRules
-from opendot.tools.local import Toolbox
+from opendot.tools.local import Toolbox, _same_path
 
 
 @pytest.fixture(autouse=True)
@@ -361,6 +364,35 @@ def test_move_symlink_aliasing_is_not_treated_as_same_path(tmp_path):
 
     assert "no change" not in out
     assert "already exists" in out
+
+
+def test_same_path_distinguishes_different_paths():
+    assert _same_path(Path("/ws/src/a.py"), Path("/ws/src/b.py")) is False
+
+
+def test_same_path_is_case_insensitive_via_normcase(monkeypatch):
+    """The same-path comparison must fold case via os.path.normcase, so paths
+    differing only by case are recognized as aliases on case-insensitive
+    filesystems (Windows, default macOS). normcase is a no-op on this
+    (case-sensitive) test host, so monkeypatch it to simulate that platform's
+    behavior — this keeps the test deterministic and portable."""
+    monkeypatch.setattr(os.path, "normcase", str.lower)
+    assert _same_path(Path("/ws/src/B.py"), Path("/ws/src/b.py")) is True
+
+
+def test_move_symlink_reports_its_own_path_not_target(tmp_path):
+    """The returned 'src -> dst' summary (and the confirm/ledger text) must
+    show the symlink's own path, not the path it resolves to — self._rel()
+    dereferences symlinks, which would misreport a symlink move as if the
+    real target file moved."""
+    tb, wd, _ = _tb(tmp_path)
+    link = wd / "link.py"
+    link.symlink_to(wd / "src" / "b.py")
+
+    out = tb.call("move", {"src": "link.py", "dst": "renamed_link.py"})
+
+    assert "link.py -> renamed_link.py" in out
+    assert "src/b.py" not in out
 
 
 def test_move_dst_parent_is_a_file_returns_clean_error(tmp_path):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -346,6 +346,23 @@ def test_move_same_src_and_dst_with_overwrite_is_a_no_op(tmp_path):
     assert (wd / "src" / "b.py").read_text() == "z = 3\n"
 
 
+def test_move_symlink_aliasing_is_not_treated_as_same_path(tmp_path):
+    """Two distinct symlinks that happen to resolve to the same target must not
+    be treated as a same-path no-op — Path.resolve() dereferences symlinks,
+    which would wrongly conflate two different paths as identical."""
+    tb, wd, _ = _tb(tmp_path)
+    target = wd / "src" / "b.py"
+    link_a = wd / "link_a.py"
+    link_b = wd / "link_b.py"
+    link_a.symlink_to(target)
+    link_b.symlink_to(target)
+
+    out = tb.call("move", {"src": "link_a.py", "dst": "link_b.py"})
+
+    assert "no change" not in out
+    assert "already exists" in out
+
+
 def test_move_dst_parent_is_a_file_returns_clean_error(tmp_path):
     """If dst's parent path component is actually an existing file (not a
     directory), mkdir(parents=True) raises — this must surface as the same

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -321,6 +321,21 @@ def test_move_existing_dst_with_overwrite_replaces_it(tmp_path):
     assert (wd / "src" / "a.py").read_text() == "z = 3\n"
 
 
+def test_move_overwrite_rejects_directory_destination(tmp_path):
+    """overwrite=true must not silently move src INTO an existing directory dst
+    (shutil.move's default behavior) — that contradicts the documented
+    'replace it' semantics of overwrite."""
+    tb, wd, _ = _tb(tmp_path)
+    (wd / "otherdir").mkdir()
+
+    out = tb.call("move", {"src": "src/b.py", "dst": "otherdir", "overwrite": True})
+
+    assert "error" in out
+    assert "directory" in out
+    assert (wd / "src" / "b.py").exists()  # unmoved
+    assert not (wd / "otherdir" / "b.py").exists()  # not moved into the dir either
+
+
 def test_move_outside_workspace_is_irreversible_and_confirmed(tmp_path):
     """A move whose destination escapes the workspace isn't covered by the
     snapshot, so it must be confirmed first and recorded as NOT reversible."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -266,7 +266,88 @@ def test_new_tools_are_in_specs(tmp_path):
         "write_file",
         "list_files",
         "web_fetch",
+        "move",
     } <= names
+
+
+def test_move_renames_file_and_reports_summary(tmp_path):
+    tb, wd, _ = _tb(tmp_path)
+    out = tb.call("move", {"src": "src/b.py", "dst": "src/renamed.py"})
+    assert "src/b.py -> src/renamed.py" in out
+    assert not (wd / "src" / "b.py").exists()
+    assert (wd / "src" / "renamed.py").read_text() == "z = 3\n"
+
+
+def test_move_creates_parent_dirs_of_dst(tmp_path):
+    tb, wd, _ = _tb(tmp_path)
+    tb.call("move", {"src": "src/b.py", "dst": "new_dir/nested/b.py"})
+    assert (wd / "new_dir" / "nested" / "b.py").read_text() == "z = 3\n"
+
+
+def test_move_is_undoable(tmp_path):
+    tb, wd, rev = _tb(tmp_path)
+    tb.call("move", {"src": "src/b.py", "dst": "src/renamed.py"})
+    assert (wd / "src" / "renamed.py").exists()
+
+    rev.undo_last()
+
+    assert not (wd / "src" / "renamed.py").exists()
+    assert (wd / "src" / "b.py").read_text() == "z = 3\n"
+
+
+def test_move_missing_src_is_clear_error(tmp_path):
+    tb, wd, _ = _tb(tmp_path)
+    out = tb.call("move", {"src": "src/does_not_exist.py", "dst": "src/renamed.py"})
+    assert "error" in out
+    assert "not found" in out
+    assert not (wd / "src" / "renamed.py").exists()
+
+
+def test_move_existing_dst_is_clear_error_without_overwrite(tmp_path):
+    tb, wd, _ = _tb(tmp_path)
+    out = tb.call("move", {"src": "src/b.py", "dst": "src/a.py"})
+    assert "error" in out
+    assert "already exists" in out
+    # nothing changed
+    assert (wd / "src" / "b.py").exists()
+    assert (wd / "src" / "a.py").read_text() == "x = 1  # TODO fix\ny = 2\n"
+
+
+def test_move_existing_dst_with_overwrite_replaces_it(tmp_path):
+    tb, wd, _ = _tb(tmp_path)
+    out = tb.call("move", {"src": "src/b.py", "dst": "src/a.py", "overwrite": True})
+    assert "src/b.py -> src/a.py" in out
+    assert not (wd / "src" / "b.py").exists()
+    assert (wd / "src" / "a.py").read_text() == "z = 3\n"
+
+
+def test_move_outside_workspace_is_irreversible_and_confirmed(tmp_path):
+    """A move whose destination escapes the workspace isn't covered by the
+    snapshot, so it must be confirmed first and recorded as NOT reversible."""
+    tb, wd, rev = _tb(tmp_path)
+    outside = tmp_path / "outside.py"
+
+    out = tb.call("move", {"src": "src/b.py", "dst": str(outside)})
+    assert "src/b.py ->" in out
+    assert outside.read_text() == "z = 3\n"
+
+    last = rev.history()[-1]
+    assert last.reversible is False
+    assert "not undoable" in last.note
+
+
+def test_declining_outside_move_skips_it(tmp_path):
+    wd = tmp_path / "ws"
+    (wd / "src").mkdir(parents=True)
+    (wd / "src" / "b.py").write_text("z = 3\n")
+    rev = Reversibility(workdir=str(wd), rules=IgnoreRules())
+    tb = Toolbox(str(wd), reversibility=rev, confirm=lambda p: False)  # decline
+
+    outside = tmp_path / "outside.py"
+    out = tb.call("move", {"src": "src/b.py", "dst": str(outside)})
+    assert out.startswith("skipped")
+    assert not outside.exists()
+    assert (wd / "src" / "b.py").exists()  # unchanged
 
 
 def test_web_fetch_returns_markdown(tmp_path, monkeypatch):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -336,6 +336,31 @@ def test_move_overwrite_rejects_directory_destination(tmp_path):
     assert not (wd / "otherdir" / "b.py").exists()  # not moved into the dir either
 
 
+def test_move_same_src_and_dst_with_overwrite_is_a_no_op(tmp_path):
+    """A no-op move (src == dst) with overwrite=true must not delete the
+    source: unlinking dst before the move would otherwise wipe it out since
+    src and dst are the same file."""
+    tb, wd, _ = _tb(tmp_path)
+    out = tb.call("move", {"src": "src/b.py", "dst": "src/b.py", "overwrite": True})
+    assert "error" not in out
+    assert (wd / "src" / "b.py").read_text() == "z = 3\n"
+
+
+def test_move_dst_parent_is_a_file_returns_clean_error(tmp_path):
+    """If dst's parent path component is actually an existing file (not a
+    directory), mkdir(parents=True) raises — this must surface as the same
+    kind of clean error string the rest of move() returns, matching how
+    write_file/edit wrap their mkdir+mutate in one try/except."""
+    tb, wd, _ = _tb(tmp_path)
+    blocker = wd / "blocker.txt"
+    blocker.write_text("im a file, not a dir\n")
+
+    out = tb.call("move", {"src": "src/b.py", "dst": "blocker.txt/nested/b.py"})
+
+    assert out.startswith("error moving")
+    assert (wd / "src" / "b.py").exists()  # unmoved
+
+
 def test_move_outside_workspace_is_irreversible_and_confirmed(tmp_path):
     """A move whose destination escapes the workspace isn't covered by the
     snapshot, so it must be confirmed first and recorded as NOT reversible."""


### PR DESCRIPTION
Closes #101

Adds a `move(src, dst, overwrite=false)` tool to `local.py`, following the existing `edit`/`write_file` patterns.

* Resolves both paths and errors clearly if `src` is missing.
* Errors if `dst` exists unless `overwrite=true` is passed.
* Creates missing parent directories for `dst`.
* Snapshots before moving so the operation is undoable.
* Confirms and records the operation as irreversible if either path is outside the workspace.
* Returns a clear `src -> dst` summary.

## Testing

Added coverage for:

* Successful rename/move
* Parent-directory creation
* Undo
* Missing `src`
* Existing `dst`, with and without overwrite
* Outside-workspace confirm, decline, and irreversible paths

`ruff check` and `ruff format --check` pass on the changed files.

`pytest` passes except for one pre-existing unrelated failure in `test_mcp.py` (ANSI color-code assertion mismatch), also present on `main`.