### PR TITLE
feat: persist and resume project sessions

### DIFF
--- a/src/opendot/agent/loop.py
+++ b/src/opendot/agent/loop.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, AsyncIterator
@@ -140,9 +141,13 @@ class Agent:
             "model": self.config.model,
             "messages": self.messages,
         }
+        # Create the temp file 0600 from the start (not write-then-chmod), so the
+        # conversation content is never briefly readable at the umask default.
         temp = path.with_suffix(".tmp")
-        temp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
-        temp.chmod(0o600)
+        data = json.dumps(payload, ensure_ascii=False, indent=2)
+        fd = os.open(temp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(data)
         temp.replace(path)
         return path
 

--- a/src/opendot/agent/loop.py
+++ b/src/opendot/agent/loop.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import json
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, AsyncIterator
 
 from opendot.agent.config import AgentConfig
@@ -122,6 +123,58 @@ class Agent:
     def reset(self) -> None:
         """Clear the conversation (the /clear context-reset barrier), keeping system."""
         self.messages = self.messages[:1]
+
+    def _session_path(self) -> Path:
+        from opendot.reversibility.snapshots import project_id_for, store_root
+
+        project_id = project_id_for(self.config.workdir)
+        return store_root() / "sessions" / f"{project_id}.json"
+
+    def save_session(self) -> Path:
+        """Persist this project's conversation and return the session path."""
+        path = self._session_path()
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        payload = {
+            "version": 1,
+            "workdir": str(Path(self.config.workdir).resolve()),
+            "model": self.config.model,
+            "messages": self.messages,
+        }
+        temp = path.with_suffix(".tmp")
+        temp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        temp.chmod(0o600)
+        temp.replace(path)
+        return path
+
+    def load_session(self) -> bool:
+        """Resume this project's saved conversation, or leave this agent fresh."""
+        try:
+            payload = json.loads(self._session_path().read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            return False
+
+        messages = payload.get("messages") if isinstance(payload, dict) else None
+        model = payload.get("model") if isinstance(payload, dict) else None
+        saved_workdir = payload.get("workdir") if isinstance(payload, dict) else None
+        version = payload.get("version") if isinstance(payload, dict) else None
+        if (
+            version != 1
+            or not isinstance(messages, list)
+            or not messages
+            or not all(isinstance(message, dict) for message in messages)
+            or messages[0].get("role") != "system"
+            or not isinstance(model, str)
+            or not model
+            or not isinstance(saved_workdir, str)
+            or Path(saved_workdir).resolve() != Path(self.config.workdir).resolve()
+        ):
+            return False
+
+        # Keep today's system/project prompt rather than reviving a stale copy.
+        self.messages = self.messages[:1] + messages[1:]
+        self.config.model = model
+        self.reversibility.model = model
+        return True
 
     def compact(self, keep_recent: int = 6) -> int:
         """Trim old turns to fight context bloat, keeping the system prompt and

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -643,6 +643,10 @@ def main() -> None:
         agent = _build_agent(args.model, workdir, confirm=lambda _p: False, api_base=args.api_base)
         if args.command == "resume":
             agent.load_session()
+            # load_session may have changed the model; warn early like the other
+            # paths so a missing key surfaces now, not mid-turn.
+            if not args.api_base:
+                _warn_if_missing_key(agent.config.model)
         run_tui(agent)
 
 

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -33,6 +33,8 @@ SLASH_HELP = """\
   /diff     preview what /undo <id> would change, without touching disk
   /undo     revert the last action ( /undo <id> to restore to a point )
   /clear    reset the conversation
+  /save     save this project's conversation
+  /resume   reload this project's saved conversation
   /compact  trim old conversation turns to free up context
   /model    show the current model ( /model <id> to switch )
   /provider connect a provider ( /provider <ENV_VAR> <api-key> )
@@ -419,6 +421,22 @@ def _interactive(agent: Agent) -> None:
             agent.reset()
             console.print("[dim]context cleared[/dim]")
             continue
+        if low == "/save":
+            try:
+                agent.save_session()
+                console.print("[dim]session saved[/dim]")
+            except OSError as exc:
+                console.print(f"[red]could not save session:[/red] {exc}")
+            continue
+        if low == "/resume":
+            if agent.load_session():
+                console.print(
+                    f"[dim]session resumed: {len(agent.messages) - 1} message(s), "
+                    f"model {agent.config.model}[/dim]"
+                )
+            else:
+                console.print("[dim]no valid saved session for this project[/dim]")
+            continue
         if low == "/compact":
             dropped = agent.compact()
             console.print(f"[dim]compacted: dropped {dropped} old message(s)[/dim]")
@@ -526,6 +544,7 @@ def main() -> None:
         "diff", help="Show what `opendot undo <id>` would change, without touching disk."
     )
     p_diff.add_argument("id", help="Action id from `opendot log`.")
+    sub.add_parser("resume", help="Resume this project's saved conversation.")
 
     # opendot mcp add/list/remove
     p_mcp = sub.add_parser("mcp", help="Manage MCP servers opendot connects to.")
@@ -586,7 +605,7 @@ def main() -> None:
         return
 
     # Everything below this point calls a model — hint if the key looks missing.
-    if not args.api_base:
+    if args.command != "resume" and not args.api_base:
         _warn_if_missing_key(args.model)
 
     # One-shot: -p flag, or piped stdin.
@@ -597,9 +616,23 @@ def main() -> None:
     if oneshot:
         # Non-interactive: can't prompt, so decline irreversible commands by default.
         agent = _build_agent(args.model, workdir, confirm=lambda _p: False, api_base=args.api_base)
+        if args.command == "resume":
+            agent.load_session()
+            if not args.api_base:
+                _warn_if_missing_key(agent.config.model)
         asyncio.run(_run_turn(agent, oneshot))
     elif args.repl:
         agent = _build_agent(args.model, workdir, confirm=_confirm, api_base=args.api_base)
+        if args.command == "resume":
+            if agent.load_session():
+                console.print(
+                    f"[dim]session resumed: {len(agent.messages) - 1} message(s), "
+                    f"model {agent.config.model}[/dim]"
+                )
+            else:
+                console.print("[dim]no valid saved session for this project; starting fresh[/dim]")
+            if not args.api_base:
+                _warn_if_missing_key(agent.config.model)
         _interactive(agent)
     else:
         # Default: the full-screen TUI. It installs its own confirm callback
@@ -608,6 +641,8 @@ def main() -> None:
         from opendot.tui import run_tui
 
         agent = _build_agent(args.model, workdir, confirm=lambda _p: False, api_base=args.api_base)
+        if args.command == "resume":
+            agent.load_session()
         run_tui(agent)
 
 

--- a/src/opendot/tui/app.py
+++ b/src/opendot/tui/app.py
@@ -227,6 +227,13 @@ class OpendotTUI(App):
         # Start on the welcome screen (logo only); first message reveals the rest.
         self.screen.add_class("-welcome")
         self.query_one("#input", Input).focus()
+        if len(getattr(self.agent, "messages", [])) > 1:
+            self._dismiss_welcome()
+            self._write(
+                f"session resumed: {len(self.agent.messages) - 1} message(s), "
+                f"model {self.agent.config.model}",
+                "sys",
+            )
 
     # -- transcript helpers --
     def _write(self, renderable, cls: str = "") -> None:
@@ -439,7 +446,7 @@ class OpendotTUI(App):
         a = self.agent
         if cmd == "help":
             self._write(
-                "commands: /log /diff <id> /undo [id] /clear /compact /model "
+                "commands: /log /diff <id> /undo [id] /clear /save /resume /compact /model "
                 "/provider /mcp /composio /help",
                 "sys",
             )
@@ -447,6 +454,21 @@ class OpendotTUI(App):
             a.reset()
             self._clear_transcript()
             self._write("cleared — screen and conversation reset", "sys")
+        elif cmd == "save":
+            try:
+                a.save_session()
+                self._write("session saved", "sys")
+            except OSError as exc:
+                self._write(f"could not save session: {exc}", "err")
+        elif cmd == "resume":
+            if a.load_session():
+                self._write(
+                    f"session resumed: {len(a.messages) - 1} message(s), model {a.config.model}",
+                    "sys",
+                )
+                self._refresh_sidebar()
+            else:
+                self._write("no valid saved session for this project", "sys")
         elif cmd == "compact":
             n = a.compact()
             self._write(f"compacted: dropped {n} old message(s)", "sys")

--- a/src/opendot/tui/commands.py
+++ b/src/opendot/tui/commands.py
@@ -12,6 +12,8 @@ SLASH_COMMANDS: list[tuple[str, str]] = [
     ("/diff", "preview what /undo <id> would change ( /diff <id> )"),
     ("/undo", "revert the last action ( /undo <id> )"),
     ("/clear", "reset the conversation"),
+    ("/save", "save this project's conversation"),
+    ("/resume", "reload this project's saved conversation"),
     ("/compact", "trim old turns to free context"),
     ("/help", "list commands"),
 ]

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,98 @@
+import sys
+
+from opendot import cli
+from opendot.agent.config import AgentConfig
+from opendot.agent.loop import Agent
+
+
+def _agent(workdir, *, model="gpt-5.1", system="current system"):
+    return Agent(AgentConfig(model=model, workdir=str(workdir), system_prompt=system))
+
+
+def test_save_load_round_trip_keeps_current_system_prompt(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENDOT_HOME", str(tmp_path / "store"))
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    source = _agent(workdir, model="ollama/qwen3", system="old system")
+    source.messages.extend(
+        [
+            {"role": "user", "content": "remember this"},
+            {"role": "assistant", "content": "remembered"},
+        ]
+    )
+
+    path = source.save_session()
+    resumed = _agent(workdir, model="gpt-5.1", system="new system")
+
+    assert resumed.load_session() is True
+    assert path == resumed._session_path()
+    assert resumed.messages == [
+        {"role": "system", "content": "new system"},
+        {"role": "user", "content": "remember this"},
+        {"role": "assistant", "content": "remembered"},
+    ]
+    assert resumed.config.model == "ollama/qwen3"
+    assert resumed.reversibility.model == "ollama/qwen3"
+
+
+def test_sessions_are_keyed_per_project(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENDOT_HOME", str(tmp_path / "store"))
+    first_dir = tmp_path / "first"
+    second_dir = tmp_path / "second"
+    first_dir.mkdir()
+    second_dir.mkdir()
+    first = _agent(first_dir)
+    second = _agent(second_dir)
+
+    first.messages.append({"role": "user", "content": "first project"})
+    first.save_session()
+
+    assert first._session_path() != second._session_path()
+    assert second.load_session() is False
+    assert second.messages == [{"role": "system", "content": "current system"}]
+
+
+def test_missing_session_starts_fresh(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENDOT_HOME", str(tmp_path / "store"))
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    agent = _agent(workdir)
+
+    assert agent.load_session() is False
+    assert agent.messages == [{"role": "system", "content": "current system"}]
+
+
+def test_corrupt_session_starts_fresh(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENDOT_HOME", str(tmp_path / "store"))
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    agent = _agent(workdir)
+    agent._session_path().parent.mkdir(parents=True)
+    agent._session_path().write_text("not json", encoding="utf-8")
+
+    assert agent.load_session() is False
+    assert agent.messages == [{"role": "system", "content": "current system"}]
+
+
+def test_resume_command_loads_before_starting_ui(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENDOT_HOME", str(tmp_path / "store"))
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    source = _agent(workdir, model="ollama/qwen3")
+    source.messages.append({"role": "user", "content": "saved context"})
+    source.save_session()
+
+    class TtyStdin:
+        def isatty(self):
+            return True
+
+    started = []
+    monkeypatch.setattr(sys, "stdin", TtyStdin())
+    monkeypatch.setattr(sys, "argv", ["opendot", "-C", str(workdir), "resume"])
+    monkeypatch.setattr("opendot.tui.run_tui", started.append)
+
+    cli.main()
+
+    assert len(started) == 1
+    assert started[0].messages[-1] == {"role": "user", "content": "saved context"}
+    assert started[0].config.model == "ollama/qwen3"


### PR DESCRIPTION
## What & why

Persist each project's message history and model under the existing opendot store so a later process can continue the same conversation. Sessions can be saved and restored with `/save` and `/resume`, or loaded at startup with `opendot resume`.

Missing, malformed, or mismatched session files leave the agent fresh. A resumed session keeps the current system/project prompt while restoring the prior conversation and model.

Fixes #109

## How I verified it

- `uv run pytest -q` — 256 passed
- `uvx ruff@0.12.12 check src tests`
- `uvx ruff@0.12.12 format --check src tests`
- `uv run opendot --help` and `uv run opendot resume --help`

The regression tests cover round-trip persistence, per-project isolation, missing and corrupt files, preserving the current system prompt, restoring the ledger model, and loading before the UI starts.

## Checklist

- [x] Small and focused (one change)
- [x] Added/updated tests; `pytest` passes locally
- [x] Does not change the reversibility engine or add a mutating agent tool
- [x] No layout or styling change; the UI surface is limited to the two new slash commands and a resume status line
