### PR TITLE
feat(office): add append_rows and create_sheet for .xlsx (closes #108)

### DIFF
--- a/src/opendot/tools/office.py
+++ b/src/opendot/tools/office.py
@@ -132,9 +132,7 @@ def build_office_tools(box) -> list:
         wb.save(p)
         return f"{box._rel(p)} [{ws.title}] {cell}: {old!r} → {v!r}"
 
-    def append_rows(
-        path: str, rows: list, sheet: str | None = None, text: bool = False
-    ) -> str:
+    def append_rows(path: str, rows: list, sheet: str | None = None, text: bool = False) -> str:
         """Append whole rows after a sheet's last row, in one snapshot."""
         import openpyxl
 
@@ -142,7 +140,7 @@ def build_office_tools(box) -> list:
         if not p.exists():
             return f"error: file not found: {p}"
         if not isinstance(rows, list) or not rows:
-            return "error: rows must be a non-empty list of rows, e.g. [[\"a\", 1], [\"b\", 2]]"
+            return 'error: rows must be a non-empty list of rows, e.g. [["a", 1], ["b", 2]]'
         # A flat ["a", "b"] is the likely mistake, and openpyxl would silently
         # write it as one cell per row rather than one row. Reject it instead.
         for i, row in enumerate(rows):
@@ -151,9 +149,15 @@ def build_office_tools(box) -> list:
                     f"error: row {i} is {type(row).__name__}, not a list; "
                     'pass a list of rows, e.g. [["a", 1], ["b", 2]]'
                 )
+            if not row:
+                return f"error: row {i} is empty; each row must have at least one cell value"
 
         wb = openpyxl.load_workbook(p)
         names = wb.sheetnames
+        # An explicit empty sheet name is a caller mistake, not "use the default"
+        # (create_sheet rejects it too).
+        if sheet == "":
+            return "error: sheet name must not be empty"
         if sheet and sheet not in names:
             return f"error: no sheet {sheet!r}; sheets: {', '.join(names)}"
         ws = wb[sheet] if sheet else wb[names[0]]
@@ -169,11 +173,13 @@ def build_office_tools(box) -> list:
         first_new_row = 1 if empty else ws.max_row + 1
         for i, row in enumerate(rows):
             for j, v in enumerate(row):
-                ws.cell(
-                    row=first_new_row + i,
-                    column=j + 1,
-                    value=v if text or not isinstance(v, str) else _coerce_cell_value(v),
-                )
+                if text:
+                    cell_value = str(v)  # force text, incl. non-string values
+                elif isinstance(v, str):
+                    cell_value = _coerce_cell_value(v)
+                else:
+                    cell_value = v  # already a JSON number/bool — keep as-is
+                ws.cell(row=first_new_row + i, column=j + 1, value=cell_value)
         wb.save(p)
         last_new_row = first_new_row + len(rows) - 1
         return (
@@ -203,7 +209,7 @@ def build_office_tools(box) -> list:
 
         wb.create_sheet(title=name)
         wb.save(p)
-        return f"{box._rel(p)}: created sheet {name!r}  sheets: {', '.join(wb.sheetnames)}"
+        return f"{box._rel(p)}: created sheet {name!r} sheets: {', '.join(wb.sheetnames)}"
 
     # ---- pptx ----
     def read_pptx(path: str, max_slides: int = 50) -> str:
@@ -335,8 +341,7 @@ def build_office_tools(box) -> list:
                     "text": {
                         "type": "boolean",
                         "description": (
-                            "Write every value as text without numeric coercion. "
-                            "Default false."
+                            "Write every value as text without numeric coercion. Default false."
                         ),
                     },
                 },

--- a/src/opendot/tools/office.py
+++ b/src/opendot/tools/office.py
@@ -132,6 +132,79 @@ def build_office_tools(box) -> list:
         wb.save(p)
         return f"{box._rel(p)} [{ws.title}] {cell}: {old!r} → {v!r}"
 
+    def append_rows(
+        path: str, rows: list, sheet: str | None = None, text: bool = False
+    ) -> str:
+        """Append whole rows after a sheet's last row, in one snapshot."""
+        import openpyxl
+
+        p = box._resolve(path)
+        if not p.exists():
+            return f"error: file not found: {p}"
+        if not isinstance(rows, list) or not rows:
+            return "error: rows must be a non-empty list of rows, e.g. [[\"a\", 1], [\"b\", 2]]"
+        # A flat ["a", "b"] is the likely mistake, and openpyxl would silently
+        # write it as one cell per row rather than one row. Reject it instead.
+        for i, row in enumerate(rows):
+            if not isinstance(row, list):
+                return (
+                    f"error: row {i} is {type(row).__name__}, not a list; "
+                    'pass a list of rows, e.g. [["a", 1], ["b", 2]]'
+                )
+
+        wb = openpyxl.load_workbook(p)
+        names = wb.sheetnames
+        if sheet and sheet not in names:
+            return f"error: no sheet {sheet!r}; sheets: {', '.join(names)}"
+        ws = wb[sheet] if sheet else wb[names[0]]
+
+        if not _snapshot(p):
+            return "skipped: user declined an edit outside the workspace"
+
+        # An untouched sheet reports max_row == 1 while being empty, and
+        # ws.append() would write to row 2 there, leaving a blank first row.
+        # Compute the target row and write cells directly so the first appended
+        # row is exactly where we say it is.
+        empty = ws.max_row == 1 and all(c.value is None for c in ws[1])
+        first_new_row = 1 if empty else ws.max_row + 1
+        for i, row in enumerate(rows):
+            for j, v in enumerate(row):
+                ws.cell(
+                    row=first_new_row + i,
+                    column=j + 1,
+                    value=v if text or not isinstance(v, str) else _coerce_cell_value(v),
+                )
+        wb.save(p)
+        last_new_row = first_new_row + len(rows) - 1
+        return (
+            f"{box._rel(p)} [{ws.title}]: appended {len(rows)} row(s) "
+            f"at {first_new_row}-{last_new_row}"
+        )
+
+    def create_sheet(path: str, name: str) -> str:
+        """Add a new named sheet to an existing workbook."""
+        import openpyxl
+
+        p = box._resolve(path)
+        if not p.exists():
+            return f"error: file not found: {p}"
+        if not name or not name.strip():
+            return "error: sheet name must not be empty"
+
+        wb = openpyxl.load_workbook(p)
+        names = wb.sheetnames
+        # openpyxl silently uniquifies a clashing title ("Data" -> "Data1"), which
+        # would leave the agent writing to a sheet it didn't ask for. Say no.
+        if name in names:
+            return f"error: sheet {name!r} already exists; sheets: {', '.join(names)}"
+
+        if not _snapshot(p):
+            return "skipped: user declined an edit outside the workspace"
+
+        wb.create_sheet(title=name)
+        wb.save(p)
+        return f"{box._rel(p)}: created sheet {name!r}  sheets: {', '.join(wb.sheetnames)}"
+
     # ---- pptx ----
     def read_pptx(path: str, max_slides: int = 50) -> str:
         from pptx import Presentation
@@ -240,6 +313,50 @@ def build_office_tools(box) -> list:
                 "required": ["path", "cell", "value"],
             },
             edit_cell,
+        ),
+        Tool(
+            "append_rows",
+            "Append rows to the end of an .xlsx sheet — use this instead of looping "
+            "edit_cell when writing a table. Values are coerced like edit_cell; pass "
+            "text=true to keep them all as strings. Undoable.",
+            {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "rows": {
+                        "type": "array",
+                        "description": (
+                            "Rows to append, each a list of cell values, e.g. "
+                            '[["Ada", 1815], ["Alan", 1912]].'
+                        ),
+                        "items": {"type": "array", "items": {}},
+                    },
+                    "sheet": {"type": "string"},
+                    "text": {
+                        "type": "boolean",
+                        "description": (
+                            "Write every value as text without numeric coercion. "
+                            "Default false."
+                        ),
+                    },
+                },
+                "required": ["path", "rows"],
+            },
+            append_rows,
+        ),
+        Tool(
+            "create_sheet",
+            "Add a new named sheet to an existing .xlsx. Errors if the name is "
+            "already taken. Undoable.",
+            {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "name": {"type": "string", "description": "New sheet name."},
+                },
+                "required": ["path", "name"],
+            },
+            create_sheet,
         ),
         Tool(
             "read_pptx",

--- a/tests/test_office.py
+++ b/tests/test_office.py
@@ -555,3 +555,35 @@ def test_append_rows_handles_ragged_rows(tmp_path):
     ws = openpyxl.load_workbook(wd / "data.xlsx").active
     assert [ws["A3"].value, ws["B3"].value] == ["bob", None]
     assert [ws["A4"].value, ws["B4"].value, ws["C4"].value] == ["carol", 95, "extra"]
+
+
+def test_append_rows_rejects_empty_sheet_name(tmp_path):
+    # An explicit empty sheet name is a caller mistake, not "use the default".
+    tb, wd, _ = _tb(tmp_path)
+    _make_xlsx(wd / "data.xlsx")
+    out = tb.call("append_rows", {"path": "data.xlsx", "rows": [["x"]], "sheet": ""})
+    assert "must not be empty" in out
+
+
+def test_append_rows_rejects_empty_row(tmp_path):
+    # An empty inner row would write no cells; reject it rather than report a
+    # phantom appended row.
+    tb, wd, _ = _tb(tmp_path)
+    _make_xlsx(wd / "data.xlsx")
+    before = (wd / "data.xlsx").read_bytes()
+    out = tb.call("append_rows", {"path": "data.xlsx", "rows": [["ok"], []]})
+    assert "empty" in out
+    assert (wd / "data.xlsx").read_bytes() == before  # nothing written
+
+
+def test_append_rows_text_flag_forces_non_string_to_text(tmp_path):
+    # text=True forces every value to a string, including a JSON number.
+    tb, wd, _ = _tb(tmp_path)
+    _make_xlsx(wd / "data.xlsx")
+    tb.call("append_rows", {"path": "data.xlsx", "rows": [[80, "007"]], "text": True})
+
+    import openpyxl
+
+    ws = openpyxl.load_workbook(wd / "data.xlsx").active
+    assert ws["A3"].value == "80" and isinstance(ws["A3"].value, str)
+    assert ws["B3"].value == "007"

--- a/tests/test_office.py
+++ b/tests/test_office.py
@@ -340,3 +340,218 @@ def test_read_docx_respects_max_paragraphs(tmp_path):
     full = tb.call("read_docx", {"path": "big.docx"})  # default cap is 200
     assert "Paragraph 10" in full
     assert "more paragraphs" not in full
+
+
+# ---- append_rows / create_sheet ----
+
+
+def test_append_rows_adds_after_the_last_row(tmp_path):
+    tb, wd, _ = _tb(tmp_path)
+    _make_xlsx(wd / "data.xlsx")  # header + one data row (alice)
+
+    res = tb.call(
+        "append_rows",
+        {"path": "data.xlsx", "rows": [["bob", "80"], ["carol", "95"]]},
+    )
+    assert "appended 2 row(s) at 3-4" in res
+
+    import openpyxl
+
+    ws = openpyxl.load_workbook(wd / "data.xlsx").active
+    assert ws.max_row == 4
+    assert [ws["A3"].value, ws["B3"].value] == ["bob", 80]
+    assert [ws["A4"].value, ws["B4"].value] == ["carol", 95]
+    assert ws["A2"].value == "alice"  # existing rows untouched
+
+
+def test_append_rows_coerces_like_edit_cell(tmp_path):
+    tb, wd, _ = _tb(tmp_path)
+    _make_xlsx(wd / "data.xlsx")
+    tb.call(
+        "append_rows",
+        {"path": "data.xlsx", "rows": [["007", "1.5", "=B2*2", "hello"]]},
+    )
+
+    import openpyxl
+
+    ws = openpyxl.load_workbook(wd / "data.xlsx").active
+    assert ws["A3"].value == "007"  # leading zero preserved, as in edit_cell
+    assert ws["B3"].value == 1.5
+    assert ws["C3"].value == "=B2*2"  # formula passes through
+    assert ws["D3"].value == "hello"
+
+
+def test_append_rows_text_flag_keeps_everything_a_string(tmp_path):
+    tb, wd, _ = _tb(tmp_path)
+    _make_xlsx(wd / "data.xlsx")
+    tb.call("append_rows", {"path": "data.xlsx", "rows": [["bob", "80"]], "text": True})
+
+    import openpyxl
+
+    cell = openpyxl.load_workbook(wd / "data.xlsx").active["B3"]
+    assert cell.value == "80"
+    assert isinstance(cell.value, str)
+
+
+def test_append_rows_targets_a_named_sheet(tmp_path):
+    tb, wd, _ = _tb(tmp_path)
+    _make_xlsx(wd / "data.xlsx")
+    _add_xlsx_sheet(wd / "data.xlsx")  # adds "Summary" with one row
+
+    tb.call("append_rows", {"path": "data.xlsx", "rows": [["net", "42"]], "sheet": "Summary"})
+
+    import openpyxl
+
+    wb = openpyxl.load_workbook(wd / "data.xlsx")
+    assert [wb["Summary"]["A2"].value, wb["Summary"]["B2"].value] == ["net", 42]
+    assert wb.active.max_row == 2  # first sheet untouched
+
+
+def test_append_rows_is_undoable(tmp_path):
+    tb, wd, rev = _tb(tmp_path)
+    _make_xlsx(wd / "data.xlsx")
+    before = (wd / "data.xlsx").read_bytes()
+
+    tb.call("append_rows", {"path": "data.xlsx", "rows": [["bob", "80"]]})
+
+    import openpyxl
+
+    assert openpyxl.load_workbook(wd / "data.xlsx").active.max_row == 3
+    rev.undo_last()  # restore the binary file exactly
+    assert (wd / "data.xlsx").read_bytes() == before
+
+
+def test_append_rows_rejects_a_flat_list(tmp_path):
+    """["a", "b"] is the likely mistake; openpyxl would write it as two rows."""
+    tb, wd, _ = _tb(tmp_path)
+    _make_xlsx(wd / "data.xlsx")
+    before = (wd / "data.xlsx").read_bytes()
+
+    res = tb.call("append_rows", {"path": "data.xlsx", "rows": ["bob", "80"]})
+    assert "not a list" in res
+    assert (wd / "data.xlsx").read_bytes() == before  # nothing written
+
+
+def test_append_rows_empty_is_an_error(tmp_path):
+    tb, wd, _ = _tb(tmp_path)
+    _make_xlsx(wd / "data.xlsx")
+    assert "non-empty list" in tb.call("append_rows", {"path": "data.xlsx", "rows": []})
+
+
+def test_create_sheet_adds_a_named_sheet(tmp_path):
+    tb, wd, _ = _tb(tmp_path)
+    _make_xlsx(wd / "data.xlsx")
+
+    res = tb.call("create_sheet", {"path": "data.xlsx", "name": "Summary"})
+    assert "Summary" in res
+
+    import openpyxl
+
+    assert "Summary" in openpyxl.load_workbook(wd / "data.xlsx").sheetnames
+
+
+def test_create_sheet_rejects_an_existing_name(tmp_path):
+    """openpyxl would silently make 'Summary1'; the agent must be told instead."""
+    tb, wd, _ = _tb(tmp_path)
+    _make_xlsx(wd / "data.xlsx")
+    _add_xlsx_sheet(wd / "data.xlsx")
+
+    res = tb.call("create_sheet", {"path": "data.xlsx", "name": "Summary"})
+    assert "already exists" in res
+
+    import openpyxl
+
+    assert openpyxl.load_workbook(wd / "data.xlsx").sheetnames.count("Summary") == 1
+    assert "Summary1" not in openpyxl.load_workbook(wd / "data.xlsx").sheetnames
+
+
+def test_create_sheet_is_undoable(tmp_path):
+    tb, wd, rev = _tb(tmp_path)
+    _make_xlsx(wd / "data.xlsx")
+    before = (wd / "data.xlsx").read_bytes()
+
+    tb.call("create_sheet", {"path": "data.xlsx", "name": "Summary"})
+
+    import openpyxl
+
+    assert "Summary" in openpyxl.load_workbook(wd / "data.xlsx").sheetnames
+    rev.undo_last()
+    assert (wd / "data.xlsx").read_bytes() == before
+
+
+def test_append_rows_outside_workspace_is_irreversible(tmp_path):
+    wd = tmp_path / "ws"
+    wd.mkdir()
+    rev = Reversibility(workdir=str(wd), rules=IgnoreRules())
+    tb = Toolbox(str(wd), reversibility=rev, confirm=lambda p: True)
+
+    outside = tmp_path / "outside.xlsx"
+    _make_xlsx(outside)
+
+    res = tb.call("append_rows", {"path": str(outside), "rows": [["bob", "80"]]})
+    assert "appended 1 row(s)" in res
+    last = rev.history()[-1]
+    assert last.reversible is False
+    assert "not undoable" in last.note
+
+
+def test_append_rows_outside_declined_writes_nothing(tmp_path):
+    wd = tmp_path / "ws"
+    wd.mkdir()
+    rev = Reversibility(workdir=str(wd), rules=IgnoreRules())
+    tb = Toolbox(str(wd), reversibility=rev, confirm=lambda p: False)
+
+    outside = tmp_path / "outside.xlsx"
+    _make_xlsx(outside)
+    before = outside.read_bytes()
+
+    res = tb.call("append_rows", {"path": str(outside), "rows": [["bob", "80"]]})
+    assert "skipped" in res
+    assert outside.read_bytes() == before
+
+
+def test_append_rows_to_a_fresh_sheet_starts_at_row_1(tmp_path):
+    """openpyxl's ws.append() writes to row 2 on an empty sheet; we must not."""
+    tb, wd, _ = _tb(tmp_path)
+    _make_xlsx(wd / "data.xlsx")
+    tb.call("create_sheet", {"path": "data.xlsx", "name": "Blank"})
+
+    res = tb.call(
+        "append_rows",
+        {"path": "data.xlsx", "rows": [["first", "1"]], "sheet": "Blank"},
+    )
+    assert "at 1-1" in res
+
+    import openpyxl
+
+    ws = openpyxl.load_workbook(wd / "data.xlsx")["Blank"]
+    assert [ws["A1"].value, ws["B1"].value] == ["first", 1]
+    assert ws.max_row == 1  # no stray blank row above it
+
+
+def test_append_rows_twice_keeps_stacking(tmp_path):
+    tb, wd, _ = _tb(tmp_path)
+    _make_xlsx(wd / "data.xlsx")
+    tb.call("append_rows", {"path": "data.xlsx", "rows": [["bob", "80"]]})
+    res = tb.call("append_rows", {"path": "data.xlsx", "rows": [["carol", "95"]]})
+    assert "at 4-4" in res
+
+    import openpyxl
+
+    ws = openpyxl.load_workbook(wd / "data.xlsx").active
+    assert [ws["A3"].value, ws["A4"].value] == ["bob", "carol"]
+
+
+def test_append_rows_handles_ragged_rows(tmp_path):
+    tb, wd, _ = _tb(tmp_path)
+    _make_xlsx(wd / "data.xlsx")
+    tb.call(
+        "append_rows",
+        {"path": "data.xlsx", "rows": [["bob"], ["carol", "95", "extra"]]},
+    )
+
+    import openpyxl
+
+    ws = openpyxl.load_workbook(wd / "data.xlsx").active
+    assert [ws["A3"].value, ws["B3"].value] == ["bob", None]
+    assert [ws["A4"].value, ws["B4"].value, ws["C4"].value] == ["carol", 95, "extra"]


### PR DESCRIPTION
Closes #108.

`edit_cell` was the only xlsx write, so a table of N rows × M columns cost N×M tool calls. Adds:

- **`append_rows(path, rows, sheet=None, text=False)`** — append a list of rows after a sheet's last row.
- **`create_sheet(path, name)`** — add a new named sheet.

Both follow the `edit_cell` pattern end to end: validate → `_snapshot(p)` → mutate → `wb.save(p)`. So a following `undo` restores the workbook byte-for-byte, and an out-of-workspace write is confirmed and recorded irreversible, same as the other office tools. Values go through `_coerce_cell_value`, so `"007"` stays text and `"=B2*2"` stays a formula; `text=true` opts out wholesale.

## Two openpyxl behaviours I had to work around

**1. `ws.append()` writes to row 2 on an empty sheet.** An untouched sheet reports `max_row == 1` while being empty, and `append` starts after that:

```
empty sheet max_row = 1  A1 = None
after append, A1 = None  max_row = 2
```

So `create_sheet` followed by `append_rows` would have left a blank row 1 *and* mis-reported the range. `append_rows` computes the first target row itself and writes via `ws.cell(...)`, which also makes the `at 3-4` in the return string exact by construction rather than by inference. `test_append_rows_to_a_fresh_sheet_starts_at_row_1` pins it.

**2. `create_sheet` silently uniquifies a clashing title** (`"Data"` → `"Data1"`), which would leave the agent writing to a sheet it didn't ask for. Rejected with the existing sheet list instead, matching how `edit_cell` reports a bad `sheet`.

A flat `["a", "b"]` for `rows` is also rejected — it's the likely mistake, and openpyxl would happily write it as one cell per row. Nothing is written in that case (asserted on the file bytes).

## Tests

15 added to `tests/test_office.py`, reusing its `_tb` / `_make_xlsx` / `_add_xlsx_sheet` helpers: append position, coercion parity with `edit_cell`, `text` flag, named-sheet targeting, undo of both tools (byte-for-byte), empty-sheet start row, restacking across two calls, ragged rows, flat-list and empty-list rejection, duplicate sheet name, out-of-workspace irreversibility, and declined-confirmation writing nothing.

## Suite status

`pytest` on Windows / Python 3.12 — **253 passed**, 3 skipped, 15 failed.

Those 15 fail identically on pristine `main` at `6547dc3` (I checked before starting): they're in `test_tools.py`, `test_snapshots.py` and `test_mcp_oauth.py` and come from Windows symlink support, POSIX file-permission bits, and path-separator assumptions. None are in the office area and none change on this branch. `pytest tests/test_office.py` is fully green: 49 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)