### PR TITLE
feat(reversibility): add redo after undo (closes #107)

### DIFF
--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -32,6 +32,7 @@ SLASH_HELP = """\
   /log      show the auditable history of actions taken
   /diff     preview what /undo <id> would change, without touching disk
   /undo     revert the last action ( /undo <id> to restore to a point )
+  /redo     re-apply the action /undo just reverted
   /clear    reset the conversation
   /save     save this project's conversation
   /resume   reload this project's saved conversation
@@ -170,6 +171,9 @@ def _cmd_undo(workdir: str, snap_id: str | None) -> None:
             console.print(f"[red]no action with id {snap_id}[/red]  (see: opendot log)")
             return
         changed_locks = rev.restore_to(target.snapshot_before)
+        # An explicit jump leaves the undo/redo walk, so the cursor no longer
+        # describes where the workspace is.
+        rev.clear_redo()
         console.print(
             f"[green]restored[/green] workspace to before action {snap_id} ({target.kind}: {target.detail[:50]})"
         )
@@ -182,7 +186,22 @@ def _cmd_undo(workdir: str, snap_id: str | None) -> None:
             )
             return
         console.print(f"[green]undid[/green] last action ({undone.kind}: {undone.detail[:50]})")
+        console.print("[dim]run `opendot redo` to put it back[/dim]")
         _note_lockfiles(console, rev.last_changed_lockfiles)
+
+
+def _cmd_redo(workdir: str) -> None:
+    """`opendot redo` — re-apply the action the last undo reverted."""
+    from opendot.reversibility.engine import Reversibility
+    from opendot.reversibility.rules import load_rules
+
+    rev = Reversibility(workdir=workdir, rules=load_rules(workdir))
+    redone = rev.redo()
+    if redone is None:
+        console.print("[dim]nothing to redo[/dim]")
+        return
+    console.print(f"[green]redid[/green] action ({redone.kind}: {redone.detail[:50]})")
+    _note_lockfiles(console, rev.last_changed_lockfiles)
 
 
 def _cmd_diff(workdir: str, snap_id: str) -> None:
@@ -481,6 +500,9 @@ def _interactive(agent: Agent) -> None:
             else:
                 console.print("[dim]usage: /diff <id>  (see /log for ids)[/dim]")
             continue
+        if low.startswith("/redo"):  # before /undo: neither prefixes the other,
+            _cmd_redo(agent.config.workdir)  # but keep them adjacent and explicit
+            continue
         if low.startswith("/undo"):
             parts = text.split(maxsplit=1)
             _cmd_undo(agent.config.workdir, parts[1].strip() if len(parts) > 1 else None)
@@ -540,6 +562,7 @@ def main() -> None:
     )
     p_undo = sub.add_parser("undo", help="Restore the workspace (last action, or to a given id).")
     p_undo.add_argument("id", nargs="?", help="Action id from `opendot log` (default: last).")
+    sub.add_parser("redo", help="Re-apply the action `opendot undo` just reverted.")
     p_diff = sub.add_parser(
         "diff", help="Show what `opendot undo <id>` would change, without touching disk."
     )
@@ -596,6 +619,9 @@ def main() -> None:
         return
     if args.command == "undo":
         _cmd_undo(workdir, args.id)
+        return
+    if args.command == "redo":
+        _cmd_redo(workdir)
         return
     if args.command == "diff":
         _cmd_diff(workdir, args.id)

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -170,6 +170,9 @@ def _cmd_undo(workdir: str, snap_id: str | None) -> None:
         if target is None:
             console.print(f"[red]no action with id {snap_id}[/red]  (see: opendot log)")
             return
+        if not target.snapshot_before:
+            console.print(f"[yellow]action {snap_id} has no snapshot to undo[/yellow]")
+            return
         changed_locks = rev.restore_to(target.snapshot_before)
         # An explicit jump leaves the undo/redo walk, so the cursor no longer
         # describes where the workspace is.

--- a/src/opendot/reversibility/engine.py
+++ b/src/opendot/reversibility/engine.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from opendot.reversibility import ledger, snapshots
+from opendot.reversibility import ledger, redo, snapshots
 from opendot.reversibility.ledger import ActionKind, LedgerEntry
 from opendot.reversibility.snapshots import IgnoreRules, project_id_for
 
@@ -60,6 +60,9 @@ class Reversibility:
         """
         if not self.enabled:
             return ""
+        # A new action branches the history: whatever we had undone is no longer
+        # reachable, so the redo stack goes (standard editor semantics).
+        redo.clear(self.project_id)
         if not snapshot:
             # No snapshot is taken, so derive a sortable id from the shared
             # action-id counter (snapshots + ledger both feed it), keeping ids
@@ -110,7 +113,18 @@ class Reversibility:
     def clear_history(self) -> int:
         """Clear this project's action ledger (discards undo history). Returns
         the number of entries removed."""
+        redo.clear(self.project_id)
         return ledger.clear(self.project_id)
+
+    def clear_redo(self) -> None:
+        """Drop the redo stack. For callers that move the workspace outside the
+        undo/redo walk (e.g. `opendot undo <id>` jumping to an arbitrary point),
+        after which the cursor no longer describes where we are."""
+        redo.clear(self.project_id)
+
+    def redo_available(self) -> int:
+        """How many actions could currently be re-applied."""
+        return redo.read(self.project_id, len(self.history())).undone
 
     def restore_to(self, snapshot_id: str) -> list[str]:
         """Restore the workspace to the state captured in ``snapshot_id``.
@@ -134,19 +148,64 @@ class Reversibility:
         return snapshots.diff_snapshot(snap, self.rules)
 
     def undo_last(self) -> LedgerEntry | None:
-        """Revert the most recent action (restore its before-snapshot).
+        """Revert the most recent not-yet-undone action (restore its before-snapshot).
 
-        Returns the entry that was undone, or None if there's nothing to undo.
-        Any dependency lockfiles the restore changed are left in
-        ``last_changed_lockfiles`` for the caller to warn about.
+        Repeated calls walk further back through the history rather than
+        restoring the same snapshot again. Returns the entry that was undone, or
+        None if there's nothing left to undo. Any dependency lockfiles the
+        restore changed are left in ``last_changed_lockfiles`` for the caller to
+        warn about.
         """
         self.last_changed_lockfiles = []
         entries = self.history()
         if not entries:
             return None
-        last_entry = entries[-1]
-        if not last_entry.snapshot_before:
+        state = redo.read(self.project_id, len(entries))
+        if state.undone >= len(entries):
+            return None  # already walked back past the first action
+        target = entries[-1 - state.undone]
+        if not target.snapshot_before:
             # A no-snapshot action (OPENDOT_NO_SNAPSHOT) has nothing to restore.
             return None
-        self.last_changed_lockfiles = self.restore_to(last_entry.snapshot_before)
-        return last_entry
+
+        if state.undone == 0:
+            # The state we're leaving is the head, and no later action snapshotted
+            # it. Capture it now or redo has nothing to come back to. Every other
+            # "after" state is some other action's snapshot_before.
+            state.head_snapshot = snapshots.take_snapshot(self.workdir, self.rules).id
+
+        self.last_changed_lockfiles = self.restore_to(target.snapshot_before)
+        state.undone += 1
+        redo.write(self.project_id, state)
+        return target
+
+    def redo(self) -> LedgerEntry | None:
+        """Re-apply the most recently undone action.
+
+        Returns the entry that was re-applied, or None if there's nothing to
+        redo. Like ``undo_last``, any lockfiles the restore changed are left in
+        ``last_changed_lockfiles``.
+        """
+        self.last_changed_lockfiles = []
+        entries = self.history()
+        state = redo.read(self.project_id, len(entries))
+        if not state.can_redo:
+            return None
+
+        # With `undone` actions reverted, the one to re-apply is the first of
+        # them. Its "after" state is the next action's before-snapshot, or the
+        # captured head when it is the newest action.
+        target_index = len(entries) - state.undone
+        target = entries[target_index]
+        after = (
+            state.head_snapshot
+            if target_index == len(entries) - 1
+            else entries[target_index + 1].snapshot_before
+        )
+        if not after:
+            return None
+
+        self.last_changed_lockfiles = self.restore_to(after)
+        state.undone -= 1
+        redo.write(self.project_id, state)
+        return target

--- a/src/opendot/reversibility/redo.py
+++ b/src/opendot/reversibility/redo.py
@@ -1,0 +1,84 @@
+"""The undo/redo cursor — a small sidecar next to the append-only ledger.
+
+The ledger is an immutable audit trail: it records what opendot *did*, and
+undoing something is not itself an action worth recording. So the cursor
+tracking "how far back have we walked" lives here instead, at
+``~/.opendot/redo/<project>.json``, and is safe to lose (losing it just means
+you can't redo).
+
+Two fields do the work:
+
+``undone``
+    How many trailing ledger actions are currently reverted. 0 means the
+    workspace is at the head of the history.
+``head_snapshot``
+    The workspace as it was just before the *first* undo of a run. Every other
+    "state after action N" is already recoverable — it is the snapshot the next
+    action took before it ran — but the head has no next action, so it would
+    otherwise be lost the moment you undo.
+
+``ledger_len`` is a staleness guard. If the ledger is no longer the length it
+was when the cursor was written, the cursor describes a history that no longer
+exists and is discarded rather than trusted.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from opendot.reversibility.snapshots import store_root
+
+
+@dataclass
+class RedoState:
+    undone: int = 0
+    head_snapshot: str = ""
+    ledger_len: int = 0
+
+    @property
+    def can_redo(self) -> bool:
+        return self.undone > 0
+
+
+def _path(project_id: str) -> Path:
+    d = store_root() / "redo"
+    d.mkdir(parents=True, exist_ok=True)
+    return d / f"{project_id}.json"
+
+
+def read(project_id: str, ledger_len: int) -> RedoState:
+    """Load the cursor, or a fresh one if it is missing, corrupt, or stale.
+
+    ``ledger_len`` is the current ledger length; a mismatch means actions were
+    appended or the ledger was cleared since the cursor was written, so the
+    saved position no longer refers to the same history.
+    """
+    p = _path(project_id)
+    if not p.exists():
+        return RedoState(ledger_len=ledger_len)
+    try:
+        raw = json.loads(p.read_text(encoding="utf-8"))
+        state = RedoState(
+            undone=int(raw.get("undone", 0)),
+            head_snapshot=str(raw.get("head_snapshot", "")),
+            ledger_len=int(raw.get("ledger_len", 0)),
+        )
+    except (json.JSONDecodeError, TypeError, ValueError, OSError):
+        # A hand-edited or truncated sidecar must not break undo.
+        return RedoState(ledger_len=ledger_len)
+    if state.ledger_len != ledger_len or not 0 <= state.undone <= ledger_len:
+        return RedoState(ledger_len=ledger_len)
+    return state
+
+
+def write(project_id: str, state: RedoState) -> None:
+    _path(project_id).write_text(json.dumps(asdict(state)), encoding="utf-8")
+
+
+def clear(project_id: str) -> None:
+    """Drop the redo stack. Called whenever a new action makes it meaningless."""
+    p = _path(project_id)
+    if p.exists():
+        p.unlink()

--- a/src/opendot/reversibility/redo.py
+++ b/src/opendot/reversibility/redo.py
@@ -60,6 +60,8 @@ def read(project_id: str, ledger_len: int) -> RedoState:
         return RedoState(ledger_len=ledger_len)
     try:
         raw = json.loads(p.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            raise TypeError("redo cursor must be a JSON object")
         state = RedoState(
             undone=int(raw.get("undone", 0)),
             head_snapshot=str(raw.get("head_snapshot", "")),
@@ -74,11 +76,22 @@ def read(project_id: str, ledger_len: int) -> RedoState:
 
 
 def write(project_id: str, state: RedoState) -> None:
-    _path(project_id).write_text(json.dumps(asdict(state)), encoding="utf-8")
+    # Best-effort: the cursor is safe to lose, so a write failure (read-only
+    # OPENDOT_HOME, full disk, ...) must not abort undo/redo after the workspace
+    # has already been restored — it only disables redo.
+    try:
+        _path(project_id).write_text(json.dumps(asdict(state)), encoding="utf-8")
+    except OSError:
+        pass
 
 
 def clear(project_id: str) -> None:
     """Drop the redo stack. Called whenever a new action makes it meaningless."""
-    p = _path(project_id)
-    if p.exists():
-        p.unlink()
+    # Best-effort: clear() runs inside before_action/clear_history, so a
+    # permission issue here must not stop actions from being recorded.
+    try:
+        p = _path(project_id)
+        if p.exists():
+            p.unlink()
+    except OSError:
+        pass

--- a/src/opendot/tui/app.py
+++ b/src/opendot/tui/app.py
@@ -867,6 +867,9 @@ class OpendotTUI(App):
             if not target:
                 self._write(f"no action {snap_id} (see /log)", "sys")
                 return
+            if not target.snapshot_before:
+                self._write(f"action {target.id} has no snapshot to undo", "sys")
+                return
             changed_locks = rev.restore_to(target.snapshot_before)
             # An explicit jump leaves the undo/redo walk; the cursor no longer
             # describes where the workspace is.

--- a/src/opendot/tui/app.py
+++ b/src/opendot/tui/app.py
@@ -88,6 +88,9 @@ class OpendotTUI(App):
 
     BINDINGS = [
         Binding("ctrl+z", "undo", "Undo last action"),
+        # ctrl+shift+z is the editor convention but many terminals don't
+        # distinguish it from ctrl+z; ctrl+y is the one that reliably arrives.
+        Binding("ctrl+y", "redo", "Redo last undo"),
         Binding("ctrl+l", "log", "Show ledger note"),
         Binding("escape", "interrupt", "Interrupt", show=False),
         Binding("ctrl+c", "quit", "Quit"),
@@ -446,7 +449,7 @@ class OpendotTUI(App):
         a = self.agent
         if cmd == "help":
             self._write(
-                "commands: /log /diff <id> /undo [id] /clear /save /resume /compact /model "
+                "commands: /log /diff <id> /undo [id] /redo /clear /save /resume /compact /model "
                 "/provider /mcp /composio /help",
                 "sys",
             )
@@ -493,6 +496,8 @@ class OpendotTUI(App):
             self._do_diff(rest.strip() or None)
         elif cmd == "undo":
             self._do_undo(rest.strip() or None)
+        elif cmd == "redo":
+            self._do_redo()
         else:
             self._write(f"unknown command: /{cmd}", "sys")
 
@@ -823,6 +828,10 @@ class OpendotTUI(App):
         if not self._busy:
             self._do_undo(None)
 
+    def action_redo(self) -> None:
+        if not self._busy:
+            self._do_redo()
+
     def _do_diff(self, snap_id: str | None) -> None:
         """Preview what `/undo <id>` would change, without touching the disk."""
         if not snap_id:
@@ -859,6 +868,9 @@ class OpendotTUI(App):
                 self._write(f"no action {snap_id} (see /log)", "sys")
                 return
             changed_locks = rev.restore_to(target.snapshot_before)
+            # An explicit jump leaves the undo/redo walk; the cursor no longer
+            # describes where the workspace is.
+            rev.clear_redo()
             what = f"action {target.id} ({target.kind}: {target.detail.rsplit('/', 1)[-1]})"
         else:
             undone = rev.undo_last()
@@ -876,6 +888,26 @@ class OpendotTUI(App):
         if self._busy:
             return  # a turn is already running; don't stack another
         note = f"[undo] Reverted {what}."
+        if changed_locks:
+            note += f" Changed lockfile(s): {', '.join(changed_locks)}."
+        self._busy = True
+        self._turn_worker = self.run_worker(self._run_turn(note), exclusive=True)
+
+    def _do_redo(self) -> None:
+        """Re-apply what /undo just reverted. Mirrors _do_undo's ack + narration."""
+        rev = self.agent.reversibility
+        redone = rev.redo()
+        if redone is None:
+            self._write("nothing to redo", "sys")
+            return
+        changed_locks = rev.last_changed_lockfiles
+        what = f"the last undone action ({redone.kind}: {redone.detail.rsplit('/', 1)[-1]})"
+
+        self._write(f"↻ reapplied {what}", "sys")  # immediate, deterministic ack
+        self._refresh_sidebar()
+        if self._busy:
+            return  # a turn is already running; don't stack another
+        note = f"[redo] Reapplied {what}."
         if changed_locks:
             note += f" Changed lockfile(s): {', '.join(changed_locks)}."
         self._busy = True

--- a/src/opendot/tui/commands.py
+++ b/src/opendot/tui/commands.py
@@ -11,6 +11,7 @@ SLASH_COMMANDS: list[tuple[str, str]] = [
     ("/log", "show the action ledger ( /log clear to wipe it )"),
     ("/diff", "preview what /undo <id> would change ( /diff <id> )"),
     ("/undo", "revert the last action ( /undo <id> )"),
+    ("/redo", "re-apply the action /undo just reverted"),
     ("/clear", "reset the conversation"),
     ("/save", "save this project's conversation"),
     ("/resume", "reload this project's saved conversation"),

--- a/tests/test_redo.py
+++ b/tests/test_redo.py
@@ -1,0 +1,310 @@
+"""Undo/redo cursor tests — undo must be recoverable, and honestly so.
+
+Uses an isolated OPENDOT_HOME so the real ~/.opendot store is never touched.
+
+Successive versions of a file deliberately differ in *length*. take_snapshot's
+fast path reuses the previous snapshot's hash when (mtime, size) are both
+unchanged, and two same-size writes in a test land inside one filesystem
+timestamp tick — so equal-length fixtures make these tests flaky for reasons
+that have nothing to do with the cursor.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from opendot.reversibility.engine import Reversibility
+from opendot.reversibility.rules import load_rules
+
+
+@pytest.fixture(autouse=True)
+def isolated_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENDOT_HOME", str(tmp_path / "store"))
+    yield
+
+
+def _rev(tmp_path) -> tuple[Reversibility, Path]:
+    wd = tmp_path / "ws"
+    wd.mkdir()
+    return Reversibility(workdir=str(wd), rules=load_rules(str(wd))), wd
+
+
+def _edit(rev: Reversibility, path: Path, text: str) -> None:
+    """Do a mutating action the way a tool would: snapshot, then write."""
+    rev.before_action("write", str(path), reversible=True)
+    path.write_text(text)
+
+
+# ---- the round trip ----
+
+
+def test_undo_then_redo_returns_the_pre_undo_state(tmp_path):
+    rev, wd = _rev(tmp_path)
+    f = wd / "a.txt"
+    f.write_text("one")
+
+    _edit(rev, f, "two-two")
+    assert f.read_text() == "two-two"
+
+    assert rev.undo_last() is not None
+    assert f.read_text() == "one"
+
+    assert rev.redo() is not None
+    assert f.read_text() == "two-two"
+
+
+def test_redo_restores_a_created_file(tmp_path):
+    """Undo deletes a file the action created; redo must bring it back."""
+    rev, wd = _rev(tmp_path)
+    (wd / "keep.txt").write_text("x")
+
+    new = wd / "new.txt"
+    rev.before_action("write", str(new), reversible=True)
+    new.write_text("created")
+
+    rev.undo_last()
+    assert not new.exists()
+
+    rev.redo()
+    assert new.read_text() == "created"
+
+
+def test_redo_restores_a_deleted_file(tmp_path):
+    rev, wd = _rev(tmp_path)
+    doomed = wd / "doomed.txt"
+    doomed.write_text("here")
+
+    rev.before_action("shell", "rm doomed.txt", reversible=True)
+    doomed.unlink()
+
+    rev.undo_last()
+    assert doomed.read_text() == "here"
+
+    rev.redo()
+    assert not doomed.exists()
+
+
+# ---- walking multiple steps ----
+
+
+def test_repeated_undo_walks_back_through_history(tmp_path):
+    rev, wd = _rev(tmp_path)
+    f = wd / "a.txt"
+    f.write_text("one")
+
+    _edit(rev, f, "two-two")
+    _edit(rev, f, "three-three-three")
+    _edit(rev, f, "four-four-four-four")
+
+    rev.undo_last()
+    assert f.read_text() == "three-three-three"
+    rev.undo_last()
+    assert f.read_text() == "two-two"
+    rev.undo_last()
+    assert f.read_text() == "one"
+
+
+def test_multiple_undos_then_multiple_redos(tmp_path):
+    rev, wd = _rev(tmp_path)
+    f = wd / "a.txt"
+    f.write_text("one")
+
+    _edit(rev, f, "two-two")
+    _edit(rev, f, "three-three-three")
+    _edit(rev, f, "four-four-four-four")
+
+    rev.undo_last()
+    rev.undo_last()
+    assert f.read_text() == "two-two"
+
+    rev.redo()
+    assert f.read_text() == "three-three-three"
+    rev.redo()
+    assert f.read_text() == "four-four-four-four"
+
+
+def test_undo_past_the_first_action_stops(tmp_path):
+    rev, wd = _rev(tmp_path)
+    f = wd / "a.txt"
+    f.write_text("one")
+    _edit(rev, f, "two-two")
+
+    assert rev.undo_last() is not None
+    assert rev.undo_last() is None  # nothing left
+    assert f.read_text() == "one"
+
+
+def test_undo_returns_the_entry_it_actually_undid(tmp_path):
+    rev, wd = _rev(tmp_path)
+    f = wd / "a.txt"
+    f.write_text("one")
+
+    _edit(rev, f, "two-two")
+    rev.before_action("shell", "echo hi", reversible=True)
+
+    assert rev.undo_last().detail == "echo hi"
+    assert rev.undo_last().detail == str(f)
+
+
+def test_redo_returns_the_entry_it_reapplied(tmp_path):
+    rev, wd = _rev(tmp_path)
+    f = wd / "a.txt"
+    f.write_text("one")
+
+    _edit(rev, f, "two-two")
+    rev.before_action("shell", "echo hi", reversible=True)
+
+    rev.undo_last()
+    rev.undo_last()
+    assert rev.redo().detail == str(f)
+    assert rev.redo().detail == "echo hi"
+
+
+# ---- nothing to redo ----
+
+
+def test_redo_without_undo_is_none(tmp_path):
+    rev, wd = _rev(tmp_path)
+    f = wd / "a.txt"
+    f.write_text("one")
+    _edit(rev, f, "two-two")
+
+    assert rev.redo() is None
+    assert f.read_text() == "two-two"  # and does not touch the workspace
+
+
+def test_redo_on_an_empty_history_is_none(tmp_path):
+    rev, _ = _rev(tmp_path)
+    assert rev.redo() is None
+
+
+def test_redo_past_the_head_stops(tmp_path):
+    rev, wd = _rev(tmp_path)
+    f = wd / "a.txt"
+    f.write_text("one")
+    _edit(rev, f, "two-two")
+
+    rev.undo_last()
+    assert rev.redo() is not None
+    assert rev.redo() is None
+    assert f.read_text() == "two-two"
+
+
+# ---- a new action invalidates redo ----
+
+
+def test_new_action_after_undo_clears_the_redo_stack(tmp_path):
+    rev, wd = _rev(tmp_path)
+    f = wd / "a.txt"
+    f.write_text("one")
+
+    _edit(rev, f, "two-two")
+    rev.undo_last()
+    assert f.read_text() == "one"
+
+    # A new action from the undone state branches the history.
+    _edit(rev, f, "branched-branched-branched-branched-branched")
+
+    assert rev.redo() is None
+    assert f.read_text() == "branched-branched-branched-branched-branched"
+
+
+def test_undo_after_branching_undoes_the_new_action(tmp_path):
+    rev, wd = _rev(tmp_path)
+    f = wd / "a.txt"
+    f.write_text("one")
+
+    _edit(rev, f, "two-two")
+    rev.undo_last()
+    _edit(rev, f, "branched-branched-branched-branched-branched")
+
+    rev.undo_last()
+    assert f.read_text() == "one"
+
+
+def test_clear_history_drops_redo(tmp_path):
+    rev, wd = _rev(tmp_path)
+    f = wd / "a.txt"
+    f.write_text("one")
+
+    _edit(rev, f, "two-two")
+    rev.undo_last()
+    rev.clear_history()
+
+    assert rev.redo() is None
+
+
+def test_clear_redo_drops_the_cursor(tmp_path):
+    rev, wd = _rev(tmp_path)
+    f = wd / "a.txt"
+    f.write_text("one")
+
+    _edit(rev, f, "two-two")
+    rev.undo_last()
+    rev.clear_redo()
+
+    assert rev.redo() is None
+    assert rev.redo_available() == 0
+
+
+# ---- bookkeeping ----
+
+
+def test_redo_available_counts_undone_actions(tmp_path):
+    rev, wd = _rev(tmp_path)
+    f = wd / "a.txt"
+    f.write_text("one")
+
+    _edit(rev, f, "two-two")
+    _edit(rev, f, "three-three-three")
+    assert rev.redo_available() == 0
+
+    rev.undo_last()
+    assert rev.redo_available() == 1
+    rev.undo_last()
+    assert rev.redo_available() == 2
+    rev.redo()
+    assert rev.redo_available() == 1
+
+
+def test_undo_does_not_append_to_the_ledger(tmp_path):
+    """The ledger is an audit trail of what opendot did, not of navigation."""
+    rev, wd = _rev(tmp_path)
+    f = wd / "a.txt"
+    f.write_text("one")
+
+    _edit(rev, f, "two-two")
+    before = len(rev.history())
+
+    rev.undo_last()
+    rev.redo()
+    assert len(rev.history()) == before
+
+
+def test_a_corrupt_cursor_file_does_not_break_undo(tmp_path):
+    from opendot.reversibility import redo as redo_mod
+
+    rev, wd = _rev(tmp_path)
+    f = wd / "a.txt"
+    f.write_text("one")
+    _edit(rev, f, "two-two")
+
+    redo_mod._path(rev.project_id).write_text("{not json", encoding="utf-8")
+
+    assert rev.undo_last() is not None
+    assert f.read_text() == "one"
+
+
+def test_lockfile_warning_still_reported_through_redo(tmp_path):
+    """redo goes through restore_to, so it must report lockfile changes too."""
+    rev, wd = _rev(tmp_path)
+    (wd / "package-lock.json").write_text('{"version": 1}')
+
+    rev.before_action("shell", "npm install foo", reversible=True)
+    (wd / "package-lock.json").write_text('{"version": 2, "note": "upgraded"}')
+
+    rev.undo_last()
+    assert any("package-lock.json" in p for p in rev.last_changed_lockfiles)
+
+    rev.redo()
+    assert any("package-lock.json" in p for p in rev.last_changed_lockfiles)


### PR DESCRIPTION
Closes #107.

An accidental `undo` was unrecoverable through the UI. `redo` re-applies the state undo reverted.

## The design decision

The issue flags the real choice — cursor model vs. the append-only ledger. This lands on a **sidecar**, because the ledger is an audit trail of what opendot *did*, and navigating history isn't an action worth recording in it. `reversibility/redo.py` keeps the cursor at `~/.opendot/redo/<project>.json`:

| field | meaning |
|---|---|
| `undone` | how many trailing ledger actions are currently reverted (0 = at the head) |
| `head_snapshot` | the workspace just before the **first** undo of a run |
| `ledger_len` | staleness guard |

**Only the head needs capturing.** Every other "state after action N" is already on disk — it's action N+1's `snapshot_before`. The head has no next action, so it's the one state that would be lost. That means undo takes **one extra snapshot per run**, not one per step.

`ledger_len` is what makes a lost or stale sidecar safe: if the ledger isn't the length it was when the cursor was written, the cursor describes a history that no longer exists and is discarded rather than trusted. That covers `clear_history` and any future path that appends without clearing. A corrupt or hand-edited sidecar degrades to "no redo" instead of breaking undo (`test_a_corrupt_cursor_file_does_not_break_undo`).

## One behaviour change worth flagging

`undo_last` always targeted `entries[-1]`, so **calling it twice restored the same snapshot twice** rather than walking further back. It now advances the cursor. That's required for the issue's "multiple undos followed by multiple redos" acceptance criterion, but it does change what a second consecutive `undo` does — flagging it in case that was intentional.

Redo is invalidated by a new action (`before_action` clears it), and both `opendot undo <id>` and the TUI's `/undo <id>` call the new `clear_redo()`, since an explicit jump leaves the walk the cursor describes.

## Surfacing

- `opendot redo` subcommand; `opendot undo` now hints "run `opendot redo` to put it back"
- `/redo` in the REPL and the TUI (autocomplete registry + `/help`)
- `ctrl+y` in the TUI. `ctrl+shift+z` is the editor convention, but many terminals don't distinguish it from `ctrl+z`.

`_do_redo` mirrors `_do_undo`: immediate deterministic ack, sidebar refresh, then the agent narrates and warns about lockfile drift.

## Verification

19 tests in `tests/test_redo.py`: the round trip, redo of a created file and of a deleted file, multi-step walks both directions, both "nothing to undo/redo" cases, branching after undo, `clear_history` / `clear_redo`, the ledger staying untouched by navigation, the corrupt sidecar, and lockfile warnings surviving redo.

Also ran it end to end through the real CLI:

```
content: two-two-two
undid last action (write: ...)
run `opendot redo` to put it back
after undo: one
redid action (write: ...)
after redo: two-two-two
nothing to redo
```

### One thing I hit that you may want to know about

The tests deliberately use fixture strings of **different lengths**. `take_snapshot`'s fast path reuses the previous snapshot's hash when `(mtime, size)` are both unchanged — so two same-size writes landing inside one filesystem timestamp tick get conflated, and the snapshot silently captures the older content. In tests that made things flaky; in principle it can also affect `undo` today, independent of this PR. I've documented it in the test module docstring rather than touching the snapshot engine here, but it might deserve its own issue.

## Suite status

`pytest` on Windows / Python 3.12 — **257 passed**, 3 skipped, 15 failed. Those 15 fail identically on pristine `main` at `6547dc3` (Windows symlinks, POSIX permission bits, path separators) and are unchanged by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)