### PR TITLE
fix(snapshots): include ctime_ns in unchanged-file fast path

### DIFF
--- a/src/opendot/reversibility/snapshots.py
+++ b/src/opendot/reversibility/snapshots.py
@@ -166,6 +166,7 @@ class FileEntry:
     mode: int | None = None  # st_mode & 0o777, or None if unknown (old snapshots)
     mtime: float | None = None
     size: int | None = None
+    ctime_ns: int | None = None  # change-time in nanoseconds, used to detect rewrites
 
 
 @dataclass
@@ -215,10 +216,26 @@ def take_snapshot(workdir: str | Path, rules: IgnoreRules | None = None) -> Snap
         except OSError:
             continue
         mode = st.st_mode & 0o777
-        # Fast path: unchanged since the last snapshot → reuse its hash, no read.
+        # Fast path: unchanged since the last snapshot -> reuse its hash, no read.
+        # We compare (mtime, size, ctime_ns). ctime advances on every write even
+        # when mtime is pinned to the same value, so including it prevents a
+        # same-size rewrite inside one mtime tick from reusing a stale hash.
         old = prev.get(rel)
-        if old is not None and old.mtime == st.st_mtime and old.size == st.st_size and old.h:
-            files[rel] = FileEntry(h=old.h, mode=mode, mtime=st.st_mtime, size=st.st_size)
+        if (
+            old is not None
+            and old.h
+            and old.mtime == st.st_mtime
+            and old.size == st.st_size
+            and old.ctime_ns is not None
+            and old.ctime_ns == st.st_ctime_ns
+        ):
+            files[rel] = FileEntry(
+                h=old.h,
+                mode=mode,
+                mtime=st.st_mtime,
+                size=st.st_size,
+                ctime_ns=st.st_ctime_ns,
+            )
             continue
         if st.st_size > _MAX_FILE_BYTES:
             skipped_large.append(rel)
@@ -227,7 +244,9 @@ def take_snapshot(workdir: str | Path, rules: IgnoreRules | None = None) -> Snap
             h = _write_object_from_path(f)  # streams: never loads the file whole
         except OSError:
             continue  # unreadable file: skip rather than fail the whole snapshot
-        files[rel] = FileEntry(h=h, mode=mode, mtime=st.st_mtime, size=st.st_size)
+        files[rel] = FileEntry(
+            h=h, mode=mode, mtime=st.st_mtime, size=st.st_size, ctime_ns=st.st_ctime_ns
+        )
 
     snap_id = _next_snapshot_id(pid)
     snap = Snapshot(
@@ -372,7 +391,7 @@ def _write_manifest(snap: Snapshot) -> None:
                 "project_id": snap.project_id,
                 "workdir": snap.workdir,
                 "files": {
-                    rel: {"h": e.h, "m": e.mode, "t": e.mtime, "s": e.size}
+                    rel: {"h": e.h, "m": e.mode, "t": e.mtime, "s": e.size, "c": e.ctime_ns}
                     for rel, e in snap.files.items()
                 },
                 "skipped_large": snap.skipped_large,
@@ -392,7 +411,13 @@ def load_snapshot(project_id: str, snap_id: str) -> Snapshot:
         if isinstance(v, str):
             files[rel] = FileEntry(h=v, mode=None)
         else:
-            files[rel] = FileEntry(h=v["h"], mode=v.get("m"), mtime=v.get("t"), size=v.get("s"))
+            files[rel] = FileEntry(
+                h=v["h"],
+                mode=v.get("m"),
+                mtime=v.get("t"),
+                size=v.get("s"),
+                ctime_ns=v.get("c"),
+            )
     return Snapshot(
         id=d["id"],
         project_id=d["project_id"],

--- a/src/opendot/reversibility/snapshots.py
+++ b/src/opendot/reversibility/snapshots.py
@@ -159,8 +159,10 @@ _MAX_FILE_BYTES = 25 * 1024 * 1024  # 25 MB
 
 @dataclass
 class FileEntry:
-    """One captured file: content hash, POSIX mode bits, and (mtime, size) so a
-    later snapshot can skip re-hashing an unchanged file."""
+    """One captured file: content hash, POSIX mode bits, and (mtime, size,
+    ctime_ns) so a later snapshot can skip re-hashing an unchanged file. ctime_ns
+    is part of the change signature so a same-size rewrite within one mtime tick
+    is still detected."""
 
     h: str
     mode: int | None = None  # st_mode & 0o777, or None if unknown (old snapshots)

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -748,7 +748,7 @@ def test_diff_to_engine_wrapper(tmp_path):
     assert delta["modified"][0]["path"] == "a.txt"
 
 
-def test_same_size_rewrite_inside_one_mtime_tick_is_captured(tmp_path, monkeypatch):
+def test_same_size_rewrite_inside_one_mtime_tick_is_captured(tmp_path):
     """Regression for issue #115: a same-size rewrite that lands inside one mtime
     tick must be captured with its new content, not reuse the old hash.
 

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -746,3 +746,34 @@ def test_diff_to_engine_wrapper(tmp_path):
     entries = rev.history()
     delta = rev.diff_to(entries[-1].snapshot_before)
     assert delta["modified"][0]["path"] == "a.txt"
+
+
+def test_same_size_rewrite_inside_one_mtime_tick_is_captured(tmp_path, monkeypatch):
+    """Regression for issue #115: a same-size rewrite that lands inside one mtime
+    tick must be captured with its new content, not reuse the old hash.
+
+    We pin the file's mtime to a fixed value after writing so the fast path sees
+    identical (mtime, size). The fix relies on ctime_ns, which is updated even when
+    mtime is pinned, to detect the rewrite.
+    """
+    wd = _workspace(tmp_path)
+    f = wd / "f.txt"
+    f.write_text("alpha")  # 5 bytes
+    snap1 = S.take_snapshot(wd)
+
+    # Rewrite to different 5-byte content and pin mtime to the *old* value.
+    f.write_text("omega")  # same size, different content
+    old_stat = f.stat()
+    pinned_mtime_ns = int(snap1.files["f.txt"].mtime * 1_000_000_000)
+    os.utime(f, ns=(old_stat.st_atime_ns, pinned_mtime_ns))
+
+    snap2 = S.take_snapshot(wd)
+
+    # The second snapshot must capture the new content, not reuse the old hash.
+    assert snap2.files["f.txt"].h != snap1.files["f.txt"].h
+
+    # Restoring snap2 must yield the new bytes, and restoring snap1 the old ones.
+    S.restore_snapshot(snap2)
+    assert f.read_text() == "omega"
+    S.restore_snapshot(snap1)
+    assert f.read_text() == "alpha"


### PR DESCRIPTION
## Problem
The snapshot fast path in `src/opendot/reversibility/snapshots.py` decided that a file was unchanged by comparing only `(mtime, size)`. On filesystems with coarse mtime resolution, two writes of the **same byte length** can land inside the same mtime tick and report the same size. The second snapshot then reused the old content hash from the previous snapshot, silently capturing stale bytes. Restoring that snapshot would roll back to content that never existed at that point, breaking opendot's reversibility guarantee (issue #115).

## Analysis
`take_snapshot` keeps the previous manifest in memory and skips re-hashing when `old.mtime == st.st_mtime and old.size == st.st_size`. That tuple is not a sufficient change signature: a rewrite that preserves size and explicitly or accidentally preserves mtime looks identical to no change at all.

The fix needs a change-detection signal that advances on every write, even when mtime is pinned. `st_ctime_ns` (the inode change time) fits: it is updated by the kernel on content writes, permission changes, and metadata updates, and it is available in nanosecond resolution on the supported platforms.

## Solution
1. Add `ctime_ns: int | None = None` to `FileEntry`.
2. Serialize it as the `"c"` field in manifests.
3. Include `old.ctime_ns == st.st_ctime_ns` in the fast-path check.
4. Treat a missing `ctime_ns` in the previous entry as a fall-through to a full re-hash. Old manifests still load; they just pay the re-hash cost once and then join the new regime.
5. Updated `load_snapshot` to read the optional `"c"` field for backward compatibility.

The common unchanged-file case still avoids re-hashing. The only extra work is reading `st.st_ctime_ns` from `os.stat`, which is already available because `stat()` was already called.

## Benchmarks
No synthetic benchmark is needed for a correctness fix. The relevant measure is the regression test `test_same_size_rewrite_inside_one_mtime_tick_is_captured` in `tests/test_snapshots.py`:
- It writes a 5-byte file, snapshots it, rewrites it with a different 5-byte string, and pins the mtime to the original value.
- It asserts that the second snapshot records a different content hash.
- It restores both snapshots and asserts each yields the bytes that existed at the time of the snapshot.

The existing unchanged-file fast-path test (`test_unchanged_files_are_not_rehashed`) still passes, confirming that genuinely unchanged files still skip re-hashing.

Full test suite: `pytest tests/ -q -W error::RuntimeWarning` → 294 passed.
`ruff check` and `ruff format --check` pass on the changed files.

## Notes
- This is intentionally a minimal change to the core snapshot path. The extra field is optional, so backward compatibility is preserved.
- I considered comparing `st_mtime_ns` instead of `st_mtime`, but that only shrinks the collision window; `ctime_ns` closes the hole for same-mtime rewrites entirely.
- The regression test uses `os.utime(..., ns=...)` to pin mtime, which is deterministic and does not depend on the host filesystem's mtime granularity.
- I have verified that this repo has no AI policy files or PR-template AI disclosure requirements.
