### PR TITLE
feat(usage): /trace — per-model-call cost and timing breakdown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.2.9"
+version = "0.3.0"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 from opendot.agent.loop import Agent
 
-__version__ = "0.2.9"
+__version__ = "0.3.0"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/agent/loop.py
+++ b/src/opendot/agent/loop.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, AsyncIterator
@@ -340,6 +341,7 @@ class Agent:
         Raises _StreamUnsupported if the stream looks like a provider that emits
         tool calls as plain text (so the caller can fall back to non-streaming).
         """
+        started = time.monotonic()
         stream = await litellm.acompletion(
             model=self.config.model,
             messages=self.messages,
@@ -384,7 +386,9 @@ class Agent:
                     slot["args"] += tc.function.arguments
 
         if usage_chunk is not None:
-            self.usage.add_response(usage_chunk, litellm, model=self.config.model)
+            self.usage.add_response(
+                usage_chunk, litellm, model=self.config.model, latency_s=time.monotonic() - started
+            )
 
         calls = [
             {"id": c["id"] or f"call_{i}", "name": c["name"], "args": c["args"]}
@@ -395,6 +399,7 @@ class Agent:
 
     async def _nonstream_turn(self, litellm, tools):
         """Non-streaming fallback (reliable tool calls; no live tokens)."""
+        started = time.monotonic()
         resp = await litellm.acompletion(
             model=self.config.model,
             messages=self.messages,
@@ -403,7 +408,9 @@ class Agent:
             stream=False,
             api_base=self.config.api_base,  # None => provider default
         )
-        self.usage.add_response(resp, litellm, model=self.config.model)
+        self.usage.add_response(
+            resp, litellm, model=self.config.model, latency_s=time.monotonic() - started
+        )
         msg = resp.choices[0].message
         raw = getattr(msg, "tool_calls", None) or []
         calls = [

--- a/src/opendot/agent/usage.py
+++ b/src/opendot/agent/usage.py
@@ -10,7 +10,18 @@ accumulate. Never raises.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+
+@dataclass
+class CallRecord:
+    """One model call, for the per-call trace (see ``opendot trace``)."""
+
+    model: str
+    prompt_tokens: int
+    completion_tokens: int
+    cost_usd: float
+    latency_s: float | None = None
 
 
 @dataclass
@@ -19,9 +30,15 @@ class Usage:
     completion_tokens: int = 0
     total_tokens: int = 0
     cost_usd: float = 0.0
+    #: One entry per model call, in order — powers the per-call trace. The
+    #: totals above stay the source of truth for the sidebar; this is additive.
+    calls: list[CallRecord] = field(default_factory=list)
 
-    def add_response(self, resp, litellm, model: str | None = None) -> None:
-        """Fold one LiteLLM response's usage + cost into the running totals.
+    def add_response(
+        self, resp, litellm, model: str | None = None, latency_s: float | None = None
+    ) -> None:
+        """Fold one LiteLLM response's usage + cost into the running totals, and
+        record it as a per-call entry for the trace.
 
         Cost is computed from the token counts + model (works for stream chunks),
         with completion_cost as a fallback — completion_cost often fails on raw
@@ -39,16 +56,46 @@ class Usage:
             pass
         # Prefer token-based cost (reliable for stream chunks); else try the
         # whole-response helper.
+        call_cost = 0.0
         added = False
         if model and (p or c):
             try:
                 pc, cc = litellm.cost_per_token(model=model, prompt_tokens=p, completion_tokens=c)
-                self.cost_usd += float(pc or 0.0) + float(cc or 0.0)
+                call_cost = float(pc or 0.0) + float(cc or 0.0)
+                self.cost_usd += call_cost
                 added = True
             except Exception:  # noqa: BLE001
                 pass
         if not added:
             try:
-                self.cost_usd += float(litellm.completion_cost(completion_response=resp) or 0.0)
+                call_cost = float(litellm.completion_cost(completion_response=resp) or 0.0)
+                self.cost_usd += call_cost
             except Exception:  # noqa: BLE001
                 pass
+        self.calls.append(
+            CallRecord(
+                model=model or "?",
+                prompt_tokens=p,
+                completion_tokens=c,
+                cost_usd=call_cost,
+                latency_s=latency_s,
+            )
+        )
+
+    def trace_lines(self) -> list[str]:
+        """Plain-text per-call breakdown for ``/trace``: one line per model call
+        (index, model, prompt/completion tokens, cost, latency), then a total."""
+        if not self.calls:
+            return ["no model calls yet this session"]
+        lines = []
+        for i, r in enumerate(self.calls, 1):
+            lat = f"{r.latency_s:.2f}s" if r.latency_s is not None else "?"
+            lines.append(
+                f"{i:>2}. {r.model}  in {r.prompt_tokens} / out {r.completion_tokens} tok  "
+                f"${r.cost_usd:.4f}  {lat}"
+            )
+        lines.append(
+            f"    total: {self.total_tokens} tok  ${self.cost_usd:.4f}  "
+            f"across {len(self.calls)} call(s)"
+        )
+        return lines

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -30,6 +30,7 @@ SLASH_HELP = """\
 [bold]Commands[/bold]
   /help     show this help
   /log      show the auditable history of actions taken
+  /trace    per-model-call cost and timing for this session
   /diff     preview what /undo <id> would change, without touching disk
   /undo     revert the last action ( /undo <id> to restore to a point )
   /redo     re-apply the action /undo just reverted
@@ -495,6 +496,10 @@ def _interactive(agent: Agent) -> None:
             continue
         if low == "/log":
             _cmd_log(agent.config.workdir)
+            continue
+        if low == "/trace":
+            for line in agent.usage.trace_lines():
+                console.print(f"[dim]{line}[/dim]")
             continue
         if low.startswith("/diff"):
             parts = text.split(maxsplit=1)

--- a/src/opendot/tui/app.py
+++ b/src/opendot/tui/app.py
@@ -449,8 +449,8 @@ class OpendotTUI(App):
         a = self.agent
         if cmd == "help":
             self._write(
-                "commands: /log /diff <id> /undo [id] /redo /clear /save /resume /compact /model "
-                "/provider /mcp /composio /help",
+                "commands: /log /trace /diff <id> /undo [id] /redo /clear /save /resume "
+                "/compact /model /provider /mcp /composio /help",
                 "sys",
             )
         elif cmd == "clear":
@@ -492,6 +492,8 @@ class OpendotTUI(App):
                 self.run_worker(self._clear_log(), exclusive=False)
             else:
                 self.action_log()
+        elif cmd == "trace":
+            self._write("\n".join(self.agent.usage.trace_lines()), "sys")
         elif cmd == "diff":
             self._do_diff(rest.strip() or None)
         elif cmd == "undo":

--- a/src/opendot/tui/commands.py
+++ b/src/opendot/tui/commands.py
@@ -9,6 +9,7 @@ SLASH_COMMANDS: list[tuple[str, str]] = [
     ("/mcp", "manage MCP servers"),
     ("/composio", "connect apps (Gmail, Slack, …)"),
     ("/log", "show the action ledger ( /log clear to wipe it )"),
+    ("/trace", "per-model-call cost and timing for this session"),
     ("/diff", "preview what /undo <id> would change ( /diff <id> )"),
     ("/undo", "revert the last action ( /undo <id> )"),
     ("/redo", "re-apply the action /undo just reverted"),

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -91,3 +91,41 @@ def test_add_response_cost_from_tokens():
     assert u.total_tokens == 1500
     assert round(u.cost_usd, 4) == 0.03  # 0.01 + 0.02 from cost_per_token
     assert calls["completion_cost"] == 0  # token-based path was used
+
+
+def test_add_response_records_per_call_trace():
+    """Each add_response appends a CallRecord (model, tokens, cost, latency), and
+    the per-call costs/tokens sum to the running totals."""
+
+    class _StubLiteLLM(types.SimpleNamespace):
+        def cost_per_token(self, model, prompt_tokens, completion_tokens):
+            return (0.01, 0.02)
+
+    u = Usage()
+    u.add_response(
+        types.SimpleNamespace(usage=_Usage()), _StubLiteLLM(), model="gpt-4o", latency_s=1.5
+    )
+    u.add_response(
+        types.SimpleNamespace(usage=_Usage()), _StubLiteLLM(), model="gpt-4o", latency_s=2.0
+    )
+
+    assert len(u.calls) == 2
+    first = u.calls[0]
+    assert first.model == "gpt-4o"
+    assert first.prompt_tokens == 1000 and first.completion_tokens == 500
+    assert round(first.cost_usd, 4) == 0.03
+    assert first.latency_s == 1.5
+    # Per-call costs/tokens sum to the running totals.
+    assert round(sum(r.cost_usd for r in u.calls), 4) == round(u.cost_usd, 4)
+    assert sum(r.prompt_tokens + r.completion_tokens for r in u.calls) == u.total_tokens
+
+
+def test_trace_lines_render():
+    u = Usage()
+    assert u.trace_lines() == ["no model calls yet this session"]
+    u.add_response(
+        types.SimpleNamespace(usage=_Usage()), types.SimpleNamespace(), model="m", latency_s=0.5
+    )
+    lines = u.trace_lines()
+    assert any("m" in ln and "0.50s" in ln for ln in lines)
+    assert any("total:" in ln for ln in lines)


### PR DESCRIPTION
## What & why

opendot has `/log` (the action ledger) but no view of the model calls themselves, so a slow or expensive run has no per-turn breakdown. This adds `/trace`: `Usage` now records a per-call entry (model, prompt/completion tokens, cost, latency) alongside the running totals, and `/trace` renders one line per call plus a total.

## How I verified it

- `pytest tests/test_usage.py` — new tests assert the per-call records sum back to the running totals, and that `trace_lines()` renders the calls and the empty case.
- Full suite: `pytest` — 293 passed, 3 skipped. `ruff check` and `ruff format --check` clean.
- Manually: ran a multi-turn session and confirmed `/trace` in the REPL and TUI lists each call with tokens / cost / latency and a total. `Usage` totals (and the sidebar's "N tokens · $X spent") are unchanged — the per-call list is additive.

## Checklist

- [x] Small and focused (one change)
- [x] Added/updated tests; `pytest` passes locally
- [ ] If it touches `reversibility/` or a mutating tool: actions are snapshotted and undo still restores exactly (tests added)
- [ ] If it changes the UI: screenshot / short recording included below

Not applicable: this doesn't touch `reversibility/` or add a mutating tool (read-only accounting). The UI change is a text-only `/trace` command output; a recording can be added if useful.