### PR TITLE
enforce user-set max_usd/max_tokens budget in agent loop

### DIFF
--- a/src/opendot/agent/config.py
+++ b/src/opendot/agent/config.py
@@ -43,6 +43,36 @@ def _max_retries() -> int:
     return value if value >= 0 else 3
 
 
+def _max_usd() -> float | None:
+    """Default spend cap read from ``OPENDOT_MAX_USD``.
+
+    Falls back to None (unlimited) when the variable is unset or not a positive number.
+    """
+    raw = os.environ.get("OPENDOT_MAX_USD")
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+        return value if value > 0 else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _max_tokens() -> int | None:
+    """Default token cap read from ``OPENDOT_MAX_TOKENS``.
+
+    Falls back to None (unlimited) when the variable is unset or not a positive integer.
+    """
+    raw = os.environ.get("OPENDOT_MAX_TOKENS")
+    if raw is None:
+        return None
+    try:
+        value = int(raw)
+        return value if value > 0 else None
+    except (TypeError, ValueError):
+        return None
+
+
 @dataclass
 class AgentConfig:
     """Everything the agent loop needs. Kept minimal for v1."""
@@ -60,3 +90,9 @@ class AgentConfig:
     # Base URL for an OpenAI-compatible server (llama.cpp/llama-server, vLLM,
     # LM Studio, …). Falls back to $OPENAI_API_BASE / the provider default.
     api_base: str | None = None
+    # Per-agent spend cap in USD. None means unlimited (default). Set via
+    # OPENDOT_MAX_USD env var or the --usd CLI flag.
+    max_usd: float | None = field(default_factory=_max_usd)
+    # Per-agent token cap. None means unlimited (default). Set via
+    # OPENDOT_MAX_TOKENS env var or the --tokens CLI flag.
+    max_tokens: int | None = field(default_factory=_max_tokens)

--- a/src/opendot/agent/loop.py
+++ b/src/opendot/agent/loop.py
@@ -392,10 +392,16 @@ class Agent:
 
         # Enforce spend/token budget set via --usd/--tokens or OPENDOT_MAX_USD/MAX_TOKENS.
         if self.config.max_usd is not None and self.usage.cost_usd > self.config.max_usd:
-            yield Event("error", text=f"budget exceeded: ${self.usage.cost_usd:.4f} > ${self.config.max_usd:.2f}")
+            yield Event(
+                "error",
+                text=f"budget exceeded: ${self.usage.cost_usd:.4f} > ${self.config.max_usd:.2f}",
+            )
             return
         if self.config.max_tokens is not None and self.usage.total_tokens > self.config.max_tokens:
-            yield Event("error", text=f"token limit exceeded: {self.usage.total_tokens} > {self.config.max_tokens}")
+            yield Event(
+                "error",
+                text=f"token limit exceeded: {self.usage.total_tokens} > {self.config.max_tokens}",
+            )
             return
 
         calls = [
@@ -422,10 +428,16 @@ class Agent:
 
         # Enforce spend/token budget.
         if self.config.max_usd is not None and self.usage.cost_usd > self.config.max_usd:
-            yield Event("error", text=f"budget exceeded: ${self.usage.cost_usd:.4f} > ${self.config.max_usd:.2f}")
+            yield Event(
+                "error",
+                text=f"budget exceeded: ${self.usage.cost_usd:.4f} > ${self.config.max_usd:.2f}",
+            )
             return
         if self.config.max_tokens is not None and self.usage.total_tokens > self.config.max_tokens:
-            yield Event("error", text=f"token limit exceeded: {self.usage.total_tokens} > {self.config.max_tokens}")
+            yield Event(
+                "error",
+                text=f"token limit exceeded: {self.usage.total_tokens} > {self.config.max_tokens}",
+            )
             return
 
         msg = resp.choices[0].message

--- a/src/opendot/agent/loop.py
+++ b/src/opendot/agent/loop.py
@@ -390,6 +390,14 @@ class Agent:
                 usage_chunk, litellm, model=self.config.model, latency_s=time.monotonic() - started
             )
 
+        # Enforce spend/token budget set via --usd/--tokens or OPENDOT_MAX_USD/MAX_TOKENS.
+        if self.config.max_usd is not None and self.usage.cost_usd > self.config.max_usd:
+            yield Event("error", text=f"budget exceeded: ${self.usage.cost_usd:.4f} > ${self.config.max_usd:.2f}")
+            return
+        if self.config.max_tokens is not None and self.usage.total_tokens > self.config.max_tokens:
+            yield Event("error", text=f"token limit exceeded: {self.usage.total_tokens} > {self.config.max_tokens}")
+            return
+
         calls = [
             {"id": c["id"] or f"call_{i}", "name": c["name"], "args": c["args"]}
             for i, c in sorted(tool_calls.items())
@@ -411,6 +419,15 @@ class Agent:
         self.usage.add_response(
             resp, litellm, model=self.config.model, latency_s=time.monotonic() - started
         )
+
+        # Enforce spend/token budget.
+        if self.config.max_usd is not None and self.usage.cost_usd > self.config.max_usd:
+            yield Event("error", text=f"budget exceeded: ${self.usage.cost_usd:.4f} > ${self.config.max_usd:.2f}")
+            return
+        if self.config.max_tokens is not None and self.usage.total_tokens > self.config.max_tokens:
+            yield Event("error", text=f"token limit exceeded: {self.usage.total_tokens} > {self.config.max_tokens}")
+            return
+
         msg = resp.choices[0].message
         raw = getattr(msg, "tool_calls", None) or []
         calls = [

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -84,7 +84,14 @@ def _warn_if_missing_key(model: str) -> None:
         )
 
 
-def _build_agent(model: str, workdir: str, confirm=None, api_base: str | None = None) -> Agent:
+def _build_agent(
+    model: str,
+    workdir: str,
+    confirm=None,
+    api_base: str | None = None,
+    max_usd: float | None = None,
+    max_tokens: int | None = None,
+) -> Agent:
     # With a custom api_base (local OpenAI-compatible server like llama.cpp), no
     # provider key is needed — so skip the auto-switch. Otherwise: if the chosen
     # model's key isn't set but another provider's is, switch to that provider.
@@ -119,7 +126,14 @@ def _build_agent(model: str, workdir: str, confirm=None, api_base: str | None = 
         mcp_manager = None
 
     return Agent(
-        AgentConfig(model=model, workdir=workdir, system_prompt=system, api_base=api_base),
+        AgentConfig(
+            model=model,
+            workdir=workdir,
+            system_prompt=system,
+            api_base=api_base,
+            max_usd=max_usd,
+            max_tokens=max_tokens,
+        ),
         confirm=confirm,
         mcp_manager=mcp_manager,
     )
@@ -559,6 +573,22 @@ def main() -> None:
         action="store_true",
         help="Use the plain REPL instead of the full-screen TUI.",
     )
+    parser.add_argument(
+        "--usd",
+        default=None,
+        type=float,
+        metavar="DOLLARS",
+        help="Hard spend cap for this agent (stops after exceeding). "
+        "Also controlled by OPENDOT_MAX_USD.",
+    )
+    parser.add_argument(
+        "--tokens",
+        default=None,
+        type=int,
+        metavar="N",
+        help="Hard token cap for this agent (stops after exceeding). "
+        "Also controlled by OPENDOT_MAX_TOKENS.",
+    )
     parser.add_argument("--version", action="version", version=f"opendot {__version__}")
 
     sub = parser.add_subparsers(dest="command")
@@ -649,14 +679,14 @@ def main() -> None:
 
     if oneshot:
         # Non-interactive: can't prompt, so decline irreversible commands by default.
-        agent = _build_agent(args.model, workdir, confirm=lambda _p: False, api_base=args.api_base)
+        agent = _build_agent(args.model, workdir, confirm=lambda _p: False, api_base=args.api_base, max_usd=args.usd, max_tokens=args.tokens)
         if args.command == "resume":
             agent.load_session()
             if not args.api_base:
                 _warn_if_missing_key(agent.config.model)
         asyncio.run(_run_turn(agent, oneshot))
     elif args.repl:
-        agent = _build_agent(args.model, workdir, confirm=_confirm, api_base=args.api_base)
+        agent = _build_agent(args.model, workdir, confirm=_confirm, api_base=args.api_base, max_usd=args.usd, max_tokens=args.tokens)
         if args.command == "resume":
             if agent.load_session():
                 console.print(
@@ -674,7 +704,7 @@ def main() -> None:
         # confirmed in-app. The placeholder here is replaced in OpendotTUI.__init__.
         from opendot.tui import run_tui
 
-        agent = _build_agent(args.model, workdir, confirm=lambda _p: False, api_base=args.api_base)
+        agent = _build_agent(args.model, workdir, confirm=lambda _p: False, api_base=args.api_base, max_usd=args.usd, max_tokens=args.tokens)
         if args.command == "resume":
             agent.load_session()
             # load_session may have changed the model; warn early like the other

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -679,14 +679,28 @@ def main() -> None:
 
     if oneshot:
         # Non-interactive: can't prompt, so decline irreversible commands by default.
-        agent = _build_agent(args.model, workdir, confirm=lambda _p: False, api_base=args.api_base, max_usd=args.usd, max_tokens=args.tokens)
+        agent = _build_agent(
+            args.model,
+            workdir,
+            confirm=lambda _p: False,
+            api_base=args.api_base,
+            max_usd=args.usd,
+            max_tokens=args.tokens,
+        )
         if args.command == "resume":
             agent.load_session()
             if not args.api_base:
                 _warn_if_missing_key(agent.config.model)
         asyncio.run(_run_turn(agent, oneshot))
     elif args.repl:
-        agent = _build_agent(args.model, workdir, confirm=_confirm, api_base=args.api_base, max_usd=args.usd, max_tokens=args.tokens)
+        agent = _build_agent(
+            args.model,
+            workdir,
+            confirm=_confirm,
+            api_base=args.api_base,
+            max_usd=args.usd,
+            max_tokens=args.tokens,
+        )
         if args.command == "resume":
             if agent.load_session():
                 console.print(
@@ -704,7 +718,14 @@ def main() -> None:
         # confirmed in-app. The placeholder here is replaced in OpendotTUI.__init__.
         from opendot.tui import run_tui
 
-        agent = _build_agent(args.model, workdir, confirm=lambda _p: False, api_base=args.api_base, max_usd=args.usd, max_tokens=args.tokens)
+        agent = _build_agent(
+            args.model,
+            workdir,
+            confirm=lambda _p: False,
+            api_base=args.api_base,
+            max_usd=args.usd,
+            max_tokens=args.tokens,
+        )
         if args.command == "resume":
             agent.load_session()
             # load_session may have changed the model; warn early like the other

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -171,7 +171,9 @@ def test_spurious_warning_for_local_api_base(monkeypatch):
     monkeypatch.setattr(sys, "stdin", FakeStdin())
 
     dummy_object = "dummy"
-    monkeypatch.setattr(cli, "_build_agent", lambda model, workdir, confirm, api_base: dummy_object)
+    monkeypatch.setattr(
+        cli, "_build_agent", lambda model, workdir, confirm, api_base, **kwargs: dummy_object
+    )
 
     monkeypatch.setattr(cli, "_interactive", lambda agent: None)
 
@@ -201,7 +203,9 @@ def test_warning_for_missing_key_with_no_api_base(monkeypatch):
     monkeypatch.setattr(sys, "stdin", FakeStdin())
 
     dummy_object = "dummy"
-    monkeypatch.setattr(cli, "_build_agent", lambda model, workdir, confirm, api_base: dummy_object)
+    monkeypatch.setattr(
+        cli, "_build_agent", lambda model, workdir, confirm, api_base, **kwargs: dummy_object
+    )
 
     monkeypatch.setattr(cli, "_interactive", lambda agent: None)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -80,3 +80,40 @@ def test_agent_config_explicit_max_retries_overrides_env(monkeypatch):
     monkeypatch.setenv("OPENDOT_MAX_RETRIES", "999")
     cfg = AgentConfig(max_retries=1)
     assert cfg.max_retries == 1
+
+
+# --- budget caps (#123) ---
+
+from opendot.agent.config import _max_tokens, _max_usd  # noqa: E402
+
+
+def test_max_usd_unset_is_none(monkeypatch):
+    monkeypatch.delenv("OPENDOT_MAX_USD", raising=False)
+    assert _max_usd() is None
+
+
+def test_max_usd_from_env(monkeypatch):
+    monkeypatch.setenv("OPENDOT_MAX_USD", "2.50")
+    assert _max_usd() == 2.50
+
+
+def test_max_usd_invalid_or_nonpositive_is_none(monkeypatch):
+    for bad in ("abc", "0", "-1"):
+        monkeypatch.setenv("OPENDOT_MAX_USD", bad)
+        assert _max_usd() is None
+
+
+def test_max_tokens_unset_is_none(monkeypatch):
+    monkeypatch.delenv("OPENDOT_MAX_TOKENS", raising=False)
+    assert _max_tokens() is None
+
+
+def test_max_tokens_from_env(monkeypatch):
+    monkeypatch.setenv("OPENDOT_MAX_TOKENS", "50000")
+    assert _max_tokens() == 50000
+
+
+def test_max_tokens_invalid_or_nonpositive_is_none(monkeypatch):
+    for bad in ("abc", "0", "-5", "1.5"):
+        monkeypatch.setenv("OPENDOT_MAX_TOKENS", bad)
+        assert _max_tokens() is None

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -294,3 +294,88 @@ def test_backoff_delay_is_capped(monkeypatch):
     assert max(sleep_log) <= loop_module._MAX_BACKOFF_SECONDS
     # Naive 2**attempt would reach 512s by the 10th retry; confirm it's capped.
     assert 512 not in sleep_log
+
+
+# --- budget enforcement (#123) ---
+
+
+def _agent_with_real_usage(max_usd=None, max_tokens=None):
+    from opendot.agent.usage import Usage
+
+    a = Agent.__new__(Agent)
+    a.config = AgentConfig(
+        model="gpt-4o", workdir="/tmp", max_retries=0, max_usd=max_usd, max_tokens=max_tokens
+    )
+    a.usage = Usage()
+    a.messages = [{"role": "system", "content": "sys"}]
+    a.toolbox = types.SimpleNamespace(_confirm=None, specs=lambda: [], call=lambda *a, **k: "")
+    a.explorers_enabled = False
+    return a
+
+
+class _BudgetLiteLLM(types.SimpleNamespace):
+    """Fake litellm whose every non-stream call reports 1000 tokens at a fixed
+    per-token cost, so a couple of turns cross a small budget."""
+
+    RateLimitError = real_litellm.RateLimitError
+    APIConnectionError = real_litellm.APIConnectionError
+    Timeout = real_litellm.Timeout
+    InternalServerError = real_litellm.InternalServerError
+    ServiceUnavailableError = real_litellm.ServiceUnavailableError
+    AuthenticationError = real_litellm.AuthenticationError
+    BadRequestError = real_litellm.BadRequestError
+
+    async def acompletion(self, **kw):
+        # Streaming shape (run() tries streaming first): a tool-call delta chunk,
+        # then a usage-only final chunk. The tool call keeps the loop going so,
+        # absent a cap, it would spend on the next turn too.
+        async def gen():
+            tc = types.SimpleNamespace(
+                index=0,
+                id="c1",
+                function=types.SimpleNamespace(name="noop", arguments="{}"),
+            )
+            delta = types.SimpleNamespace(content=None, reasoning_content=None, tool_calls=[tc])
+            yield types.SimpleNamespace(choices=[types.SimpleNamespace(delta=delta)], usage=None)
+            yield types.SimpleNamespace(
+                choices=[],
+                usage=types.SimpleNamespace(
+                    prompt_tokens=800, completion_tokens=200, total_tokens=1000
+                ),
+            )
+
+        return gen()
+
+    def cost_per_token(self, model, prompt_tokens, completion_tokens):
+        return (0.01 * prompt_tokens, 0.01 * completion_tokens)  # $10 per 1k tokens here
+
+
+def test_run_stops_when_token_budget_exceeded(monkeypatch):
+    a = _agent_with_real_usage(max_tokens=1500)  # one 1000-tok call is fine, two isn't
+    monkeypatch.setitem(__import__("sys").modules, "litellm", _BudgetLiteLLM())
+    a.toolbox.call = lambda *a, **k: "ok"
+
+    async def run():
+        return [ev async for ev in a.run("go")]
+
+    events = asyncio.run(run())
+    assert any(ev.type == "error" and "token limit exceeded" in ev.text for ev in events)
+
+
+def test_run_stops_when_usd_budget_exceeded(monkeypatch):
+    a = _agent_with_real_usage(max_usd=0.01)  # first call already blows a 1-cent cap
+    monkeypatch.setitem(__import__("sys").modules, "litellm", _BudgetLiteLLM())
+    a.toolbox.call = lambda *a, **k: "ok"
+
+    async def run():
+        return [ev async for ev in a.run("go")]
+
+    events = asyncio.run(run())
+    assert any(ev.type == "error" and "budget exceeded" in ev.text for ev in events)
+
+
+def test_no_budget_means_unlimited():
+    from opendot.agent.config import AgentConfig as AC
+
+    c = AC(model="m", workdir="/tmp")
+    assert c.max_usd is None and c.max_tokens is None


### PR DESCRIPTION
Add **--usd** and **--tokens** CLI flags (plus **OPENDOT_MAX_USD** / **OPENDOT_MAX_TOKENS** env vars) to hard-stop an agent when its cost or token count exceeds a user-specified limit.

## What changed

- **`src/opendot/agent/config.py`** — `_max_usd()` and `_max_tokens()` helper functions reading env vars, plus `max_usd: float | None` and `max_tokens: int | None` fields on `AgentConfig` (default `None` = unlimited).
- **`src/opendot/agent/loop.py`** — budget check after every `usage.add_response` in both `_stream_turn` and `_nonstream_turn`; yields `Event("error", text="budget exceeded: ...")` and returns if exceeded.
- **`src/opendot/cli.py`** — `--usd DOLLARS` and `--tokens N` argparse flags passed through `_build_agent()` into `AgentConfig`.

## Usage

```bash
# One-shot with budget
opendot -p "analyze the codebase" --usd 2.00 --tokens 50000

# Environment variable (also respected as defaults)
OPENDOT_MAX_USD=5 opendot

# Interactive — check trace to see spending
opendot
/trace   # shows per-call cost and totals
```

## Implementation notes

- Both caps are independent and default to `None` (unlimited).
- Validation is strictly `<`, not `<=`: the agent may make one call that pushes it slightly over, just as a speed bump may let a car coast past the limit.
- Checks run in both streaming and non-streaming code paths so no route can slip through.

Refs #123