### PR TITLE
Release 0.3.1: session summary, reversibility timeline, permission policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,28 @@ token cap is the meaningful one there). The defaults come from
 value is ignored, and unset means unlimited (the default). When a cap is hit the
 run ends with a clear `budget exceeded` / `token limit exceeded` message.
 
+## Unattended runs & permissions
+
+By default opendot confirms every irreversible or workspace-escaping action
+(and one-shot runs decline them, since there's no one to ask). For CI or an
+unattended run, a permission policy lets you decide up front what's allowed:
+
+```bash
+opendot -p "run the test suite and fix failures" --yes         # auto-approve prompts
+opendot -p "..." --yes --deny "git push" --deny "rm -rf"       # but hard-block these
+opendot -p "..." --allow "pytest"                              # approve only these
+```
+
+- `--yes` auto-approves anything that would otherwise prompt. Reversibility is
+  unchanged: every action is still snapshotted and undoable.
+- `--allow PATTERN` / `--deny PATTERN` match a substring of the action (the
+  command or path); both are repeatable.
+- Precedence is **deny > allow > (`--yes` ? approve : ask)** — so you can
+  auto-approve broadly and still guarantee specific things never run.
+
+You can pin the same rules per project in `OPENDOT.md` (see below), so they
+travel with the repo; CLI flags merge on top.
+
 ## Connect MCP servers
 
 opendot is an [MCP](https://modelcontextprotocol.io) client: connect any MCP
@@ -191,11 +213,16 @@ context. You can also control what gets snapshotted with an `opendot` block:
 snapshot: dist
 # never snapshot these:
 skip: data, *.log
+# permission policy (same as --allow/--deny; comma-separated, may contain spaces):
+allow: pytest, ruff
+deny: git push, rm -rf
 ```
 ````
 
 By default opendot skips `.git`, `node_modules`, virtualenvs, and build caches
-when snapshotting — your rules override those in either direction.
+when snapshotting — your rules override those in either direction. The `allow:`
+/ `deny:` lists set the project's permission policy; the `--allow` / `--deny`
+CLI flags merge on top of them.
 
 ## How the reversibility works
 
@@ -203,7 +230,9 @@ when snapshotting — your rules override those in either direction.
   directory into a **content-addressed store** in `~/.opendot` (each unique file
   stored once, so snapshots are cheap).
 - Every action is recorded in an **append-only ledger** you can inspect with
-  `opendot log`.
+  `opendot log`, which shows a timeline with a `▸ you are here` cursor — so you
+  can see at a glance which actions are applied and which have been undone (and
+  are still redoable).
 - `opendot undo` restores the workspace to a chosen point, exactly, and
   `opendot redo` re-applies what you last undid (a wrong undo is itself
   reversible).
@@ -269,9 +298,11 @@ pytest
 ## Status
 
 Early (alpha). The interactive agent, local tools, and the full reversibility
-engine (undo, redo, diff preview) work and are tested. Streaming, slash-commands,
-`OPENDOT.md` rules, per-project session resume, spend/token budgets, MCP and
-Composio connectors, and office (`.xlsx`/`.pptx`/`.docx`) tools are in. A richer
-TUI and more tools are coming.
+engine (undo, redo, diff preview, and a `you are here` timeline) work and are
+tested. Streaming, slash-commands, `OPENDOT.md` rules, per-project session
+resume, spend/token budgets, a permission policy (`--yes` / allow-deny) for
+unattended runs, an end-of-session summary, MCP and Composio connectors, and
+office (`.xlsx`/`.pptx`/`.docx`) tools are in. A richer TUI and more tools are
+coming.
 
 [MIT licensed.](LICENSE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.3.0"
+version = "0.3.1"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 from opendot.agent.loop import Agent
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/agent/loop.py
+++ b/src/opendot/agent/loop.py
@@ -118,6 +118,11 @@ class Agent:
 
         self.usage = Usage()  # running token/cost totals for the session
 
+        # Mark where the ledger stands at session start, so the end-of-session
+        # summary can report only the actions taken during *this* session (the
+        # ledger itself is append-only and spans every past session).
+        self._session_start_actions = len(self.reversibility.history())
+
         # The main agent can fan out read-only explorer subagents; explorers
         # themselves cannot (no recursive spawning). Read-only toolboxes = explorer.
         self.explorers_enabled = not getattr(self.toolbox, "read_only", False)
@@ -125,6 +130,23 @@ class Agent:
     def reset(self) -> None:
         """Clear the conversation (the /clear context-reset barrier), keeping system."""
         self.messages = self.messages[:1]
+
+    def session_summary(self) -> dict[str, Any]:
+        """A snapshot of what this session spent and did, for an end-of-run card.
+
+        Counts only actions taken since the session started (the ledger persists
+        across sessions), and splits them by whether they're reversible.
+        """
+        actions = self.reversibility.history()[self._session_start_actions :]
+        reversible = sum(1 for a in actions if a.reversible)
+        return {
+            "actions": len(actions),
+            "reversible": reversible,
+            "irreversible": len(actions) - reversible,
+            "cost_usd": self.usage.cost_usd,
+            "total_tokens": self.usage.total_tokens,
+            "calls": len(self.usage.calls),
+        }
 
     def _session_path(self) -> Path:
         from opendot.reversibility.snapshots import project_id_for, store_root

--- a/src/opendot/agent/permissions.py
+++ b/src/opendot/agent/permissions.py
@@ -1,0 +1,113 @@
+"""Permission policy for confirming (or auto-approving) risky actions.
+
+opendot gates every irreversible / workspace-escaping action behind a single
+``confirm(prompt) -> bool`` callback. This module turns that gate into a small,
+configurable policy so a run can be driven unattended and a project can pin its
+own rules:
+
+- ``--yes`` auto-approves what would otherwise be an interactive prompt.
+- ``--allow PATTERN`` / ``--deny PATTERN`` match substrings of the action's
+  confirm prompt (which contains the command or path). ``deny`` always wins, so
+  you can auto-approve broadly with ``--yes`` yet still hard-block specifics.
+- An ``OPENDOT.md`` ``policy`` block carries the same allow/deny lists for the
+  project, so the rules travel with the repo.
+
+Precedence, most-specific first: deny > allow > (--yes ? approve : ask). A denied
+action is refused without prompting; an allowed one runs without prompting;
+anything else falls back to the interactive prompt (or is auto-denied in a
+non-interactive run with no ``--yes``).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_BLOCK_RE = re.compile(r"```opendot\s*\n(.*?)```", re.DOTALL | re.IGNORECASE)
+
+
+def _split_list(value: str) -> list[str]:
+    # Split on commas only — a pattern may contain spaces (e.g. "git push"), so
+    # whitespace must not be a separator.
+    return [p.strip() for p in value.split(",") if p.strip()]
+
+
+@dataclass
+class Policy:
+    """Allow/deny patterns plus an auto-approve flag.
+
+    Patterns are matched case-insensitively as plain substrings of the confirm
+    prompt (which embeds the command or path). ``deny`` is checked before
+    ``allow``.
+    """
+
+    allow: list[str] = field(default_factory=list)
+    deny: list[str] = field(default_factory=list)
+    auto_approve: bool = False
+
+    def _matches(self, patterns: list[str], prompt: str) -> bool:
+        low = prompt.lower()
+        return any(p.lower() in low for p in patterns)
+
+    def decide(self, prompt: str) -> str:
+        """Return 'deny', 'allow', or 'ask' for an action's confirm prompt."""
+        if self._matches(self.deny, prompt):
+            return "deny"
+        if self._matches(self.allow, prompt):
+            return "allow"
+        return "allow" if self.auto_approve else "ask"
+
+    def merged_with(self, other: "Policy") -> "Policy":
+        """Combine two policies (e.g. OPENDOT.md rules + CLI flags). Allow/deny
+        lists union; auto_approve is OR."""
+        return Policy(
+            allow=[*self.allow, *other.allow],
+            deny=[*self.deny, *other.deny],
+            auto_approve=self.auto_approve or other.auto_approve,
+        )
+
+    def make_confirm(self, ask):
+        """Wrap an interactive ``ask(prompt) -> bool`` with this policy. Returns a
+        ``confirm(prompt) -> bool`` suitable for the Toolbox."""
+
+        def confirm(prompt: str) -> bool:
+            decision = self.decide(prompt)
+            if decision == "deny":
+                return False
+            if decision == "allow":
+                return True
+            return ask(prompt)
+
+        return confirm
+
+
+def parse_policy_text(text: str) -> Policy:
+    """Read allow:/deny: lists from an OPENDOT.md ``opendot`` block."""
+    policy = Policy()
+    m = _BLOCK_RE.search(text)
+    if not m:
+        return policy
+    for line in m.group(1).splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip().lower()
+        items = _split_list(value)
+        if key == "allow":
+            policy.allow.extend(items)
+        elif key == "deny":
+            policy.deny.extend(items)
+    return policy
+
+
+def load_policy(workdir: str | Path) -> Policy:
+    """Load the project policy from OPENDOT.md, or an empty policy if absent."""
+    p = Path(workdir) / "OPENDOT.md"
+    if not p.exists():
+        return Policy()
+    try:
+        return parse_policy_text(p.read_text(encoding="utf-8", errors="replace"))
+    except Exception:  # noqa: BLE001 - never let a bad file break the agent
+        return Policy()

--- a/src/opendot/agent/permissions.py
+++ b/src/opendot/agent/permissions.py
@@ -9,7 +9,7 @@ own rules:
 - ``--allow PATTERN`` / ``--deny PATTERN`` match substrings of the action's
   confirm prompt (which contains the command or path). ``deny`` always wins, so
   you can auto-approve broadly with ``--yes`` yet still hard-block specifics.
-- An ``OPENDOT.md`` ``policy`` block carries the same allow/deny lists for the
+- An ``OPENDOT.md`` ``opendot`` block carries the same allow/deny lists for the
   project, so the rules travel with the repo.
 
 Precedence, most-specific first: deny > allow > (--yes ? approve : ask). A denied

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -66,6 +66,26 @@ def _confirm(prompt: str) -> bool:
     return ans in {"y", "yes"}
 
 
+def _build_policy(args, workdir: str):
+    """Merge the project's OPENDOT.md policy with the CLI --yes/--allow/--deny."""
+    from opendot.agent.permissions import Policy, load_policy
+
+    cli_policy = Policy(
+        allow=list(getattr(args, "allow", []) or []),
+        deny=list(getattr(args, "deny", []) or []),
+        auto_approve=bool(getattr(args, "yes", False)),
+    )
+    return load_policy(workdir).merged_with(cli_policy)
+
+
+def _make_confirm(args, workdir: str, interactive: bool):
+    """Build the confirm callback: policy-gated, falling back to the interactive
+    prompt (or an auto-decline in one-shot mode) for anything left to ask."""
+    policy = _build_policy(args, workdir)
+    ask = _confirm if interactive else (lambda _p: False)
+    return policy.make_confirm(ask)
+
+
 def _warn_if_missing_key(model: str) -> None:
     """Print a friendly hint if the model's expected API key isn't in the env.
 
@@ -643,6 +663,30 @@ def main() -> None:
         help="Hard token cap for this agent (stops after exceeding). "
         "Also controlled by OPENDOT_MAX_TOKENS.",
     )
+    parser.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="Auto-approve actions that would otherwise prompt for confirmation "
+        "(for unattended / CI runs). Reversibility still snapshots everything; "
+        "--deny patterns still block.",
+    )
+    parser.add_argument(
+        "--allow",
+        action="append",
+        default=[],
+        metavar="PATTERN",
+        help="Auto-approve actions whose confirm prompt contains PATTERN "
+        "(repeatable, e.g. --allow 'pytest').",
+    )
+    parser.add_argument(
+        "--deny",
+        action="append",
+        default=[],
+        metavar="PATTERN",
+        help="Always refuse actions whose confirm prompt contains PATTERN, even "
+        "with --yes (repeatable, e.g. --deny 'git push').",
+    )
     parser.add_argument("--version", action="version", version=f"opendot {__version__}")
 
     sub = parser.add_subparsers(dest="command")
@@ -732,11 +776,12 @@ def main() -> None:
         oneshot = sys.stdin.read().strip() or None
 
     if oneshot:
-        # Non-interactive: can't prompt, so decline irreversible commands by default.
+        # Non-interactive: can't prompt, so decline irreversible commands unless
+        # a policy (--yes / --allow / OPENDOT.md) approves them.
         agent = _build_agent(
             args.model,
             workdir,
-            confirm=lambda _p: False,
+            confirm=_make_confirm(args, workdir, interactive=False),
             api_base=args.api_base,
             max_usd=args.usd,
             max_tokens=args.tokens,
@@ -752,7 +797,7 @@ def main() -> None:
         agent = _build_agent(
             args.model,
             workdir,
-            confirm=_confirm,
+            confirm=_make_confirm(args, workdir, interactive=True),
             api_base=args.api_base,
             max_usd=args.usd,
             max_tokens=args.tokens,
@@ -788,7 +833,7 @@ def main() -> None:
             # paths so a missing key surfaces now, not mid-turn.
             if not args.api_base:
                 _warn_if_missing_key(agent.config.model)
-        run_tui(agent)
+        run_tui(agent, policy=_build_policy(args, workdir))
 
 
 if __name__ == "__main__":

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -157,17 +157,39 @@ def _cmd_log(workdir: str, clear: bool = False) -> None:
     if not entries:
         console.print("[dim]no actions recorded yet[/dim]")
         return
+
+    # Timeline: actions oldest→newest, with a cursor marking where the workspace
+    # currently sits. `undone` trailing actions have been reverted (undo) and are
+    # redoable; they render dimmed below the cursor.
+    undone = rev.redo_available()
+    cursor_after = len(entries) - undone  # actions [0:cursor_after] are applied
+
     console.print("[bold]opendot action history[/bold] (most recent last)\n")
-    for e in entries:
-        mark = "[green]↺[/green]" if e.reversible else "[red]✗ irreversible[/red]"
+    for i, e in enumerate(entries):
+        is_undone = i >= cursor_after
         detail = e.detail if len(e.detail) < 70 else e.detail[:67] + "..."
-        console.print(f"  {e.id}  {mark}  [cyan]{e.kind}[/cyan]  {detail}")
-        if e.note:
-            console.print(f"        [dim]{e.note}[/dim]")
-        if e.model:
-            params = "".join(f" {k}={v}" for k, v in e.params.items())
-            console.print(f"        [dim]model: {e.model}{params}[/dim]")
-    console.print("\n[dim]opendot undo           revert the last action[/dim]")
+        if is_undone:
+            console.print(f"  [dim]{e.id}  ↶ undone  {e.kind}  {detail}[/dim]", highlight=False)
+        else:
+            mark = "[green]↺[/green]" if e.reversible else "[red]✗ irreversible[/red]"
+            console.print(f"  {e.id}  {mark}  [cyan]{e.kind}[/cyan]  {detail}")
+            if e.note:
+                console.print(f"        [dim]{e.note}[/dim]")
+            if e.model:
+                params = "".join(f" {k}={v}" for k, v in e.params.items())
+                console.print(f"        [dim]model: {e.model}{params}[/dim]")
+        # Draw the cursor right after the last applied action.
+        if i == cursor_after - 1:
+            console.print("  [bold cyan]▸ you are here[/bold cyan]")
+
+    if cursor_after == 0:
+        console.print("  [bold cyan]▸ you are here[/bold cyan] [dim](everything undone)[/dim]")
+
+    console.print("\n[dim]opendot undo           revert the last applied action[/dim]")
+    if undone:
+        console.print(
+            f"[dim]opendot redo           re-apply the next of {undone} undone action(s)[/dim]"
+        )
     console.print("[dim]opendot undo <id>      restore the workspace to before that action[/dim]")
 
 

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -14,6 +14,7 @@ import argparse
 import asyncio
 import os
 import sys
+import time
 from pathlib import Path
 
 from rich.console import Console
@@ -382,6 +383,34 @@ def _cmd_mcp(args) -> None:
         return
 
 
+def _print_session_summary(agent: Agent, elapsed_s: float) -> None:
+    """End-of-session card: time, spend, and how much of what the agent did is
+    reversible. Skipped when the session did nothing (no actions, no spend)."""
+    s = agent.session_summary()
+    if not s["actions"] and not s["cost_usd"] and not s["total_tokens"]:
+        return
+
+    took = f"{elapsed_s:.0f}s" if elapsed_s >= 1 else f"{elapsed_s * 1000:.0f}ms"
+    tokens = (
+        f"{s['total_tokens'] / 1000:.1f}k" if s["total_tokens"] >= 1000 else str(s["total_tokens"])
+    )
+    line1 = f"{took}  ·  ${s['cost_usd']:.4f}  ·  {tokens} tokens  ·  {s['calls']} call(s)"
+
+    if s["actions"] == 0:
+        line2 = "no files or commands touched"
+    elif s["irreversible"] == 0:
+        line2 = f"{s['actions']} action(s) · [green]all reversible[/green]"
+    else:
+        line2 = (
+            f"{s['actions']} action(s) · {s['reversible']} reversible · "
+            f"[yellow]{s['irreversible']} not undoable[/yellow]"
+        )
+
+    console.print(
+        Panel.fit(f"{line1}\n{line2}", title="session", border_style="dim", title_align="left")
+    )
+
+
 async def _run_turn(agent: Agent, message: str) -> None:
     """Run one turn, streaming events to the console live.
 
@@ -437,12 +466,14 @@ def _interactive(agent: Agent) -> None:
         )
     )
     session: PromptSession = PromptSession(history=InMemoryHistory())
+    started = time.monotonic()
 
     while True:
         try:
             text = session.prompt("\nopendot › ").strip()
         except (EOFError, KeyboardInterrupt):
             console.print("\n[dim]bye[/dim]")
+            _print_session_summary(agent, time.monotonic() - started)
             return
 
         if not text:
@@ -450,6 +481,7 @@ def _interactive(agent: Agent) -> None:
         low = text.lower()
         if low in {"exit", "/exit", "/quit", "quit"}:
             console.print("[dim]bye[/dim]")
+            _print_session_summary(agent, time.monotonic() - started)
             return
         if low == "/help":
             console.print(SLASH_HELP)
@@ -691,7 +723,9 @@ def main() -> None:
             agent.load_session()
             if not args.api_base:
                 _warn_if_missing_key(agent.config.model)
+        started = time.monotonic()
         asyncio.run(_run_turn(agent, oneshot))
+        _print_session_summary(agent, time.monotonic() - started)
     elif args.repl:
         agent = _build_agent(
             args.model,

--- a/src/opendot/tui/app.py
+++ b/src/opendot/tui/app.py
@@ -96,15 +96,21 @@ class OpendotTUI(App):
         Binding("ctrl+c", "quit", "Quit"),
     ]
 
-    def __init__(self, agent: Agent) -> None:
+    def __init__(self, agent: Agent, policy=None) -> None:
         super().__init__()
         self.agent = agent
         self._turn_worker = None
         self._busy = False
+        self._policy = policy
         # Give the agent a confirm callback that shows a blocking modal. It's
         # invoked from a worker thread (tool runs via asyncio.to_thread), so
         # call_from_thread is the correct, non-deadlocking bridge to the UI.
-        agent.toolbox._confirm = self._confirm_from_thread
+        # A permission policy (--yes / --allow / --deny / OPENDOT.md) can
+        # auto-approve or hard-deny before the modal is ever shown.
+        if policy is not None:
+            agent.toolbox._confirm = policy.make_confirm(self._confirm_from_thread)
+        else:
+            agent.toolbox._confirm = self._confirm_from_thread
 
     def _confirm_from_thread(self, prompt: str) -> bool:
         try:
@@ -950,5 +956,5 @@ class OpendotTUI(App):
         self._refresh_sidebar()
 
 
-def run_tui(agent: Agent) -> None:
-    OpendotTUI(agent).run()
+def run_tui(agent: Agent, policy=None) -> None:
+    OpendotTUI(agent, policy=policy).run()

--- a/src/opendot/tui/sidebar.py
+++ b/src/opendot/tui/sidebar.py
@@ -104,11 +104,26 @@ class Sidebar(Static):
         if not history:
             t.append("no actions yet\n", style="dim")
         else:
-            for e in history[-16:]:
-                mark, style = ("↺", "green") if e.reversible else ("✗", "red")
-                detail = e.detail.rsplit("/", 1)[-1][:20]
-                t.append("• ", style="dim")
-                t.append(f"{mark} ", style=style)
-                t.append(f"{e.kind[:5]} {detail}\n", style="dim")
-        t.append("\nctrl+z undo · ctrl+l log", style="dim italic")
+            undone = a.reversibility.redo_available()
+            cursor_after = len(history) - undone  # actions [0:cursor_after] applied
+            shown = history[-16:]
+            base = len(history) - len(shown)  # absolute index of the first shown row
+            for offset, e in enumerate(shown):
+                idx = base + offset
+                is_undone = idx >= cursor_after
+                if is_undone:
+                    detail = e.detail.rsplit("/", 1)[-1][:20]
+                    t.append("• ", style="dim")
+                    t.append(f"↶ {e.kind[:5]} {detail}\n", style="dim strike")
+                else:
+                    mark, style = ("↺", "green") if e.reversible else ("✗", "red")
+                    detail = e.detail.rsplit("/", 1)[-1][:20]
+                    t.append("• ", style="dim")
+                    t.append(f"{mark} ", style=style)
+                    t.append(f"{e.kind[:5]} {detail}\n", style="dim")
+                if idx == cursor_after - 1:
+                    t.append("▸ here\n", style="bold cyan")
+            if cursor_after <= base:
+                t.append("▸ here (all undone)\n", style="bold cyan")
+        t.append("\nctrl+z undo · ctrl+y redo · ctrl+l log", style="dim italic")
         return t

--- a/src/opendot/tui/sidebar.py
+++ b/src/opendot/tui/sidebar.py
@@ -105,9 +105,14 @@ class Sidebar(Static):
             t.append("no actions yet\n", style="dim")
         else:
             undone = a.reversibility.redo_available()
-            cursor_after = len(history) - undone  # actions [0:cursor_after] applied
+            cursor_after = max(0, len(history) - undone)  # actions [0:cursor_after] applied
             shown = history[-16:]
             base = len(history) - len(shown)  # absolute index of the first shown row
+            # The cursor may sit above the visible window (older applied actions
+            # scrolled off). Draw it up top then, so it's never lost or mislabeled.
+            if cursor_after <= base:
+                suffix = " (all undone)" if cursor_after == 0 else ""
+                t.append(f"▸ here{suffix}\n", style="bold cyan")
             for offset, e in enumerate(shown):
                 idx = base + offset
                 is_undone = idx >= cursor_after
@@ -123,7 +128,5 @@ class Sidebar(Static):
                     t.append(f"{e.kind[:5]} {detail}\n", style="dim")
                 if idx == cursor_after - 1:
                     t.append("▸ here\n", style="bold cyan")
-            if cursor_after <= base:
-                t.append("▸ here (all undone)\n", style="bold cyan")
         t.append("\nctrl+z undo · ctrl+y redo · ctrl+l log", style="dim italic")
         return t

--- a/tests/test_cli_log.py
+++ b/tests/test_cli_log.py
@@ -1,0 +1,74 @@
+"""`opendot log` timeline rendering: the undo/redo cursor and undone actions."""
+
+from __future__ import annotations
+
+import os
+
+from opendot import cli
+from opendot.reversibility import ledger, redo
+from opendot.reversibility.ledger import LedgerEntry
+from opendot.reversibility.snapshots import project_id_for
+
+
+def _seed(workdir: str, n: int) -> str:
+    pid = project_id_for(workdir)
+    for i in range(1, n + 1):
+        ledger.append(
+            pid,
+            LedgerEntry(
+                id=f"{i:06d}",
+                kind="write",
+                detail=f"file{i}.py",
+                snapshot_before=f"s{i}",
+                reversible=True,
+            ),
+        )
+    return pid
+
+
+def _log_output(workdir: str) -> str:
+    with cli.console.capture() as cap:
+        cli._cmd_log(workdir)
+    return cap.get()
+
+
+def test_log_cursor_at_head_when_nothing_undone(tmp_path):
+    _seed(str(tmp_path), 3)
+    out = _log_output(str(tmp_path))
+    # Cursor sits after the last (newest) action, and nothing is marked undone.
+    assert "you are here" in out
+    assert "undone" not in out
+    assert out.index("file3.py") < out.index("you are here")
+
+
+def test_log_marks_undone_actions_below_cursor(tmp_path):
+    pid = _seed(str(tmp_path), 3)
+    # Simulate one undo: the newest action is reverted (redoable).
+    state = redo.read(pid, 3)
+    state.undone = 1
+    state.head_snapshot = "h"
+    redo.write(pid, state)
+
+    out = _log_output(str(tmp_path))
+    assert "↶ undone" in out
+    # The cursor is above the undone action, which is the newest one.
+    assert out.index("you are here") < out.index("file3.py")
+    assert "re-apply the next of 1 undone action(s)" in out
+
+
+def test_log_everything_undone(tmp_path):
+    pid = _seed(str(tmp_path), 2)
+    state = redo.read(pid, 2)
+    state.undone = 2
+    state.head_snapshot = "h"
+    redo.write(pid, state)
+
+    out = _log_output(str(tmp_path))
+    assert "everything undone" in out
+
+
+def test_log_empty(tmp_path):
+    # A fresh project with no actions.
+    os.chdir(tmp_path)
+    out = _log_output(str(tmp_path))
+    assert "no actions recorded yet" in out

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -379,3 +379,40 @@ def test_no_budget_means_unlimited():
 
     c = AC(model="m", workdir="/tmp")
     assert c.max_usd is None and c.max_tokens is None
+
+
+def test_session_summary_counts_only_this_session(tmp_path):
+    # A ledger entry written before the agent starts must not be counted; only
+    # actions taken during this session appear, split by reversibility.
+    from opendot.reversibility.ledger import LedgerEntry
+    from opendot.reversibility.snapshots import project_id_for
+
+    workdir = str(tmp_path)
+    pid = project_id_for(workdir)
+
+    def _log(id_, reversible):
+        from opendot.reversibility import ledger
+
+        ledger.append(
+            pid,
+            LedgerEntry(
+                id=id_, kind="write", detail="f", snapshot_before="s", reversible=reversible
+            ),
+        )
+
+    _log("000001", True)  # a prior-session action
+
+    a = Agent(AgentConfig(model="m", workdir=workdir))
+    assert a.session_summary()["actions"] == 0  # baseline excludes the prior action
+
+    _log("000002", True)
+    _log("000003", False)
+    a.usage.cost_usd = 0.05
+    a.usage.total_tokens = 2000
+
+    s = a.session_summary()
+    assert s["actions"] == 2
+    assert s["reversible"] == 1
+    assert s["irreversible"] == 1
+    assert s["cost_usd"] == 0.05
+    assert s["total_tokens"] == 2000

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,91 @@
+"""Permission policy: --yes auto-approve, allow/deny patterns, OPENDOT.md block."""
+
+from __future__ import annotations
+
+from opendot.agent.permissions import Policy, load_policy, parse_policy_text
+
+
+def test_default_policy_asks():
+    p = Policy()
+    assert p.decide("This command may not be undoable: git push") == "ask"
+
+
+def test_auto_approve_allows_anything_not_denied():
+    p = Policy(auto_approve=True)
+    assert p.decide("run rm -rf build") == "allow"
+
+
+def test_deny_beats_auto_approve():
+    p = Policy(deny=["git push"], auto_approve=True)
+    assert p.decide("This command escapes the workspace: git push origin") == "deny"
+    assert p.decide("run pytest") == "allow"  # not denied, auto-approved
+
+
+def test_allow_pattern_without_auto_approve():
+    p = Policy(allow=["pytest"])
+    assert p.decide("run: pytest -q") == "allow"
+    assert p.decide("run: git push") == "ask"  # not matched, falls back to ask
+
+
+def test_deny_beats_allow():
+    p = Policy(allow=["git"], deny=["git push"])
+    assert p.decide("git push origin main") == "deny"
+    assert p.decide("git status") == "allow"
+
+
+def test_matching_is_case_insensitive():
+    p = Policy(deny=["GIT PUSH"])
+    assert p.decide("running git push now") == "deny"
+
+
+def test_make_confirm_wraps_ask():
+    asked = []
+
+    def ask(prompt):
+        asked.append(prompt)
+        return True
+
+    confirm = Policy(deny=["push"], allow=["pytest"]).make_confirm(ask)
+    assert confirm("git push") is False  # denied, ask never called
+    assert confirm("run pytest") is True  # allowed, ask never called
+    assert asked == []
+    assert confirm("delete something") is True  # falls through to ask
+    assert asked == ["delete something"]
+
+
+def test_merged_with_unions_and_ors():
+    a = Policy(allow=["a"], deny=["x"], auto_approve=False)
+    b = Policy(allow=["b"], deny=["y"], auto_approve=True)
+    m = a.merged_with(b)
+    assert set(m.allow) == {"a", "b"}
+    assert set(m.deny) == {"x", "y"}
+    assert m.auto_approve is True
+
+
+def test_parse_policy_block():
+    text = """
+    # notes
+    ```opendot
+    allow: pytest, ruff
+    deny: git push, rm -rf
+    skip: data
+    ```
+    """
+    p = parse_policy_text(text)
+    assert p.allow == ["pytest", "ruff"]
+    assert p.deny == ["git push", "rm -rf"]
+
+
+def test_load_policy_missing_file(tmp_path):
+    p = load_policy(str(tmp_path))
+    assert p.allow == [] and p.deny == [] and p.auto_approve is False
+
+
+def test_load_policy_from_opendot_md(tmp_path):
+    (tmp_path / "OPENDOT.md").write_text(
+        "guidance here\n\n```opendot\nallow: pytest\ndeny: git push\n```\n",
+        encoding="utf-8",
+    )
+    p = load_policy(str(tmp_path))
+    assert p.allow == ["pytest"]
+    assert p.deny == ["git push"]

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -89,7 +89,7 @@ def test_resume_command_loads_before_starting_ui(tmp_path, monkeypatch):
     started = []
     monkeypatch.setattr(sys, "stdin", TtyStdin())
     monkeypatch.setattr(sys, "argv", ["opendot", "-C", str(workdir), "resume"])
-    monkeypatch.setattr("opendot.tui.run_tui", started.append)
+    monkeypatch.setattr("opendot.tui.run_tui", lambda agent, **kw: started.append(agent))
 
     cli.main()
 

--- a/tests/test_sidebar_timeline.py
+++ b/tests/test_sidebar_timeline.py
@@ -1,0 +1,63 @@
+"""The TUI sidebar's reversibility cursor, including when it sits above the
+visible 16-row window (regression: it was mislabeled "all undone")."""
+
+from __future__ import annotations
+
+from opendot.agent.config import AgentConfig
+from opendot.agent.loop import Agent
+from opendot.reversibility import ledger, redo
+from opendot.reversibility.ledger import LedgerEntry
+from opendot.reversibility.snapshots import project_id_for
+from opendot.tui.sidebar import Sidebar
+
+
+def _seed(workdir: str, n: int) -> str:
+    pid = project_id_for(workdir)
+    for i in range(1, n + 1):
+        ledger.append(
+            pid,
+            LedgerEntry(
+                id=f"{i:06d}",
+                kind="write",
+                detail=f"file{i}.py",
+                snapshot_before=f"s{i}",
+                reversible=True,
+            ),
+        )
+    return pid
+
+
+def _render(workdir: str) -> str:
+    agent = Agent(AgentConfig(model="m", workdir=workdir))
+    return Sidebar(agent).render().plain
+
+
+def test_cursor_at_head_no_all_undone_label(tmp_path):
+    _seed(str(tmp_path), 3)
+    out = _render(str(tmp_path))
+    assert "here" in out
+    assert "all undone" not in out
+
+
+def test_all_undone_only_when_cursor_at_zero(tmp_path):
+    pid = _seed(str(tmp_path), 3)
+    state = redo.read(pid, 3)
+    state.undone = 3  # everything reverted
+    state.head_snapshot = "h"
+    redo.write(pid, state)
+    out = _render(str(tmp_path))
+    assert "all undone" in out
+
+
+def test_cursor_above_window_is_not_all_undone(tmp_path):
+    # 20 actions with 18 undone -> cursor_after == 2, which is above the 16-row
+    # window (base == 4). The cursor must render up top WITHOUT "(all undone)",
+    # because actions 0 and 1 are still applied.
+    pid = _seed(str(tmp_path), 20)
+    state = redo.read(pid, 20)
+    state.undone = 18
+    state.head_snapshot = "h"
+    redo.write(pid, state)
+    out = _render(str(tmp_path))
+    assert "here" in out
+    assert "all undone" not in out


### PR DESCRIPTION
## Summary

Three features that make opendot's core story (spend + reversibility) visible and lettable-loose, plus docs and a version bump to 0.3.1.

## What's new

### Session summary card
An end-of-run / on-exit card: elapsed time, spend, tokens, model calls, and how many actions were taken this session split by reversibility (`all reversible` / `N not undoable`). Counts only actions since the session started, so a resumed session's prior ledger doesn't inflate it. Ties the budget and reversibility stories together at a glance.

### Reversibility timeline
`opendot log` and the TUI ledger now render a `▸ you are here` cursor marking where the workspace currently sits. Undone-but-redoable actions show dimmed/struck below the cursor, with a redo hint when any exist. Derived from the existing redo state — no new persistence.

### Permission policy (unattended runs)
Turns the single `confirm()` gate into a small policy so a run can go unattended and a project can pin its own rules:
- `--yes` auto-approves what would otherwise prompt (CI / unattended). Snapshots still happen; reversibility is unchanged.
- `--allow PATTERN` / `--deny PATTERN` match substrings of an action's confirm prompt (command/path), repeatable.
- Precedence: **deny > allow > (`--yes` ? approve : ask)** — auto-approve broadly, still hard-block specifics like `git push`.
- An `OPENDOT.md` `opendot` block carries `allow:` / `deny:` for the project; CLI flags merge on top.
- Applied across one-shot, REPL, and TUI (the modal is shown only for `ask` decisions).

### Docs + bump
README gains an Unattended runs & permissions section, notes the log timeline, refreshes Status, and bumps to 0.3.1 (also folds in the earlier README refresh for budget/redo/diff/resume/`/trace`/office).

## Testing
- Full suite: 318 passed, 3 skipped.
- `ruff check` and `ruff format --check`: clean.
- New tests: session-summary counting, log-timeline cursor (4), permission policy (11). Updated one pre-existing test coupled to the old `run_tui` signature.

Closes #123 was already merged separately; this release is additive and backward-compatible (no policy / no budget = today's behavior).