### PR TITLE
docs: state that the classifier is an explainer, not a boundary (#130)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,14 +256,15 @@ email, a dropped remote database, a `git push`). It tells you *before* running
 those, rather than pretending otherwise.
 
 The classifier is a **heuristic that decides when to ask, not a security
-sandbox.** It reads shell text, so it can't fully account for what an opaque
-subprocess does (a script `python foo.py` runs is as unknowable as `python -c`),
-and a determined adversary could race a symlink swap. That's why interpreters are
-confirm-first and built-in file writes are contained at open time — but the
-honest framing is that the classifier *explains* why a confirmation is prudent;
-it is not a guarantee against hostile input. Kernel-enforced isolation (an
-overlay/container for unattended runs) is the stronger boundary, and it's on the
-roadmap ([#130](https://github.com/vedaant00/opendot/issues/130)).
+boundary.** It reads shell text, so it can't fully account for what an opaque
+subprocess does (the script run by `python foo.py` is as unknowable as
+`python -c`), and a determined adversary could race a symlink swap. That's why
+interpreters are confirm-first and built-in file writes are contained at open
+time — but the honest framing is that the classifier *explains* why a
+confirmation is prudent; it is not a guarantee against hostile input.
+Kernel-enforced isolation (an overlay/container for unattended runs) would be the
+stronger boundary, and is planned but not yet built
+([#130](https://github.com/vedaant00/opendot/issues/130)).
 
 **Skipping the snapshot on purpose.** When opendot runs a shell command it
 snapshots first — but for something you *want* gone (securely wiping a secret) or

--- a/README.md
+++ b/README.md
@@ -255,6 +255,16 @@ Honest boundary: opendot cannot undo effects that leave your machine (a sent
 email, a dropped remote database, a `git push`). It tells you *before* running
 those, rather than pretending otherwise.
 
+The classifier is a **heuristic that decides when to ask, not a security
+sandbox.** It reads shell text, so it can't fully account for what an opaque
+subprocess does (a script `python foo.py` runs is as unknowable as `python -c`),
+and a determined adversary could race a symlink swap. That's why interpreters are
+confirm-first and built-in file writes are contained at open time — but the
+honest framing is that the classifier *explains* why a confirmation is prudent;
+it is not a guarantee against hostile input. Kernel-enforced isolation (an
+overlay/container for unattended runs) is the stronger boundary, and it's on the
+roadmap ([#130](https://github.com/vedaant00/opendot/issues/130)).
+
 **Skipping the snapshot on purpose.** When opendot runs a shell command it
 snapshots first — but for something you *want* gone (securely wiping a secret) or
 a huge throwaway file, that snapshot would keep a recoverable copy in the store.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.3.2"
+version = "0.3.3"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"
@@ -21,7 +21,10 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "litellm>=1.50",     # any model: cloud, local, HF, through one interface
+    # A newer litellm release (its context_management module) hard-imports
+    # typing.NotRequired with no typing_extensions fallback, so it fails to import
+    # on Python 3.10. Cap below that until it's fixed upstream / 3.10 is dropped.
+    "litellm>=1.50,<1.95",  # any model: cloud, local, HF, through one interface
     "rich>=13.0",        # pretty terminal output (plain REPL fallback)
     "textual>=0.60",     # full-screen TUI (main pane + live ledger sidebar)
     "prompt_toolkit>=3.0",  # plain REPL input (history, editing)

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 from opendot.agent.loop import Agent
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/reversibility/classifier.py
+++ b/src/opendot/reversibility/classifier.py
@@ -10,6 +10,13 @@ Design stance: CONSERVATIVE / fail-safe. When in doubt, treat a command as
 irreversible. A few extra confirmations are fine; a silent un-undoable surprise
 is not. This is a heuristic on shell text, not a guarantee — the reason string
 explains the call so the user can judge.
+
+It is an *explainer*, not a security boundary. Reading shell text can't fully
+account for an opaque subprocess (`python foo.py` is as unknowable as `python
+-c`, so interpreters are confirm-first) and can't win a TOCTOU symlink race
+against hostile input. Kernel-enforced isolation (open-time containment for the
+built-in file tools; a sandbox/overlay for unattended runs) is the real
+boundary — see issue #130.
 """
 
 from __future__ import annotations

--- a/src/opendot/reversibility/classifier.py
+++ b/src/opendot/reversibility/classifier.py
@@ -12,11 +12,11 @@ is not. This is a heuristic on shell text, not a guarantee — the reason string
 explains the call so the user can judge.
 
 It is an *explainer*, not a security boundary. Reading shell text can't fully
-account for an opaque subprocess (`python foo.py` is as unknowable as `python
--c`, so interpreters are confirm-first) and can't win a TOCTOU symlink race
-against hostile input. Kernel-enforced isolation (open-time containment for the
-built-in file tools; a sandbox/overlay for unattended runs) is the real
-boundary — see issue #130.
+account for an opaque subprocess (`python foo.py` is as unknowable as `python -c`,
+so interpreters are confirm-first) and can't win a TOCTOU symlink race against
+hostile input. Kernel-enforced isolation is the real boundary: open-time
+containment for the built-in file tools ships today; a sandbox/overlay for
+unattended runs is planned (see issue #130).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Closes the docs-honesty item from #130.

## Change

README + the classifier docstring now state plainly that the classifier is a heuristic that decides *when to ask*, not a security boundary: it can't fully reason about opaque subprocesses (`python foo.py` is as unknowable as `python -c`) or win a TOCTOU symlink race, and kernel-enforced isolation is the real boundary.

## Not in this PR

The sandbox design spike and the sandbox implementation remain open under #130. Docs only — no code, patch version bump.