### PR TITLE
Sandbox mode: kernel-enforced --sandbox for unattended runs (0.4.0, #130 Phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ opendot -p "..." --sandbox --sandbox-net                 # allow network (off by
 - Network is **off by default** inside the container; only the API key your model
   needs is forwarded, nothing else from your environment.
 - On success the workspace diff is committed back through the reversibility engine
-  (so it's snapshotted and undoable); on failure nothing is applied.
+  (snapshotted and undoable, subject to the snapshot size limit for very large
+  files); on a non-zero container exit nothing is applied.
 - One-shot only (`-p`) — an interactive session inside a headless container isn't
   useful. Your normal, direct terminal runs are unchanged when you don't pass it.
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,32 @@ opendot -p "..." --allow "pytest"                              # approve only th
 You can pin the same rules per project in `OPENDOT.md` (see below), so they
 travel with the repo; CLI flags merge on top.
 
+### Sandbox mode (`--sandbox`)
+
+The permission policy is a heuristic gate, not a security boundary (a script it
+runs can still reach outside the workspace). For an unattended run where that
+matters, `--sandbox` moves the guarantee to a **kernel-enforced** boundary: it
+runs the turn inside a container against a *copy* of the workspace, then commits
+only the resulting diff back on success.
+
+```bash
+opendot -p "refactor and run the tests" --sandbox        # run isolated in a container
+opendot -p "..." --sandbox --sandbox-net                 # allow network (off by default)
+```
+
+- Needs **docker or podman**; if neither is installed, `--sandbox` errors — it
+  never silently falls back to a direct run.
+- Network is **off by default** inside the container; only the API key your model
+  needs is forwarded, nothing else from your environment.
+- On success the workspace diff is committed back through the reversibility engine
+  (so it's snapshotted and undoable); on failure nothing is applied.
+- One-shot only (`-p`) — an interactive session inside a headless container isn't
+  useful. Your normal, direct terminal runs are unchanged when you don't pass it.
+
+The container image (`--sandbox-image`, default `python:3.12-slim`) must have
+opendot available. This is the strongest boundary opendot offers; the classifier
+remains the explainer for direct runs.
+
 ## Connect MCP servers
 
 opendot is an [MCP](https://modelcontextprotocol.io) client: connect any MCP

--- a/docs/design/sandbox.md
+++ b/docs/design/sandbox.md
@@ -24,8 +24,10 @@ guarantee must come from a boundary the kernel enforces.
 - **Copy-in / diff-out.** The (non-ignored) workspace is copied to a temp dir,
   that copy is mounted into the container, the turn runs there, and on success
   the copy is reconciled back to the real workspace. The commit-back is
-  snapshotted first via the reversibility engine, so it is itself undoable; on a
-  non-zero container exit, nothing is applied.
+  snapshotted first via the reversibility engine, so it is itself undoable
+  (subject to the snapshot size limit for very large files); on a non-zero
+  container exit, nothing is applied. Files that can't be reconciled (a copy/
+  delete that raises) are reported, never silently dropped.
 - **Least privilege.** Network off by default (`--network none`, opt in with
   `--sandbox-net`); only the API-key env var the model needs is forwarded.
 - **Scope.** One-shot (`-p`) only — a headless-container TUI/REPL isn't useful.

--- a/docs/design/sandbox.md
+++ b/docs/design/sandbox.md
@@ -1,0 +1,55 @@
+# Design: `--sandbox` (kernel-enforced containment for unattended runs)
+
+Tracks #130. The reversibility guarantee cannot rest on a text classifier
+understanding shell — that boundary is beatable (opaque subprocesses, TOCTOU
+symlink races, `cd`, sockets, `docker`). The classifier is an *explainer* that
+decides when to ask a human. For an unattended run there is no human, so the
+guarantee must come from a boundary the kernel enforces.
+
+## Mechanism choice
+
+| Option | Contains | Portability | Verdict |
+|---|---|---|---|
+| Copied working dir (no container) | in-workspace file mutations only | everywhere | not a boundary — `sudo`/absolute-path/network still escape |
+| overlayfs + user/mount namespaces | filesystem (Linux) | Linux + userns | strong native Linux tier; fiddly, env-dependent |
+| **Container (docker/podman)** | filesystem, network, processes, privileges | anywhere a runtime exists | **the real boundary — chosen for Phase 1** |
+
+## Phase 1 — shipped (`--sandbox`)
+
+`src/opendot/sandbox.py` + the `--sandbox` CLI flag.
+
+- **Opt-in, runtime-gated, fails closed.** Detects docker/podman (podman
+  preferred: rootless). If neither is present, `--sandbox` errors — it never
+  degrades to a direct run while implying isolation.
+- **Copy-in / diff-out.** The (non-ignored) workspace is copied to a temp dir,
+  that copy is mounted into the container, the turn runs there, and on success
+  the copy is reconciled back to the real workspace. The commit-back is
+  snapshotted first via the reversibility engine, so it is itself undoable; on a
+  non-zero container exit, nothing is applied.
+- **Least privilege.** Network off by default (`--network none`, opt in with
+  `--sandbox-net`); only the API-key env var the model needs is forwarded.
+- **Scope.** One-shot (`-p`) only — a headless-container TUI/REPL isn't useful.
+  Direct runs are unchanged when `--sandbox` isn't passed.
+
+Validation note: the host-side plumbing (detection, gating, copy-in, commit-back)
+is unit-tested with the runtime mocked; the *live in-container execution* is
+validated on a docker/podman host.
+
+Open follow-ups for Phase 1 hardening:
+- MCP servers across the boundary (stdio easy; remote/OAuth harder).
+- The default image (`python:3.12-slim`) assumes opendot is installed in it;
+  document/provide an image or an entrypoint that installs it.
+- Bind-mount vs copy-in tradeoff for very large repos (copy cost).
+
+## Phase 2 — optional
+
+An overlayfs tier for Linux users without a container runtime, and open-time
+`openat2(RESOLVE_BENEATH)` for the built-in file tools even in direct runs
+(already shipped for writes in 0.3.2). These narrow the direct-run gap but the
+container remains the guarantee.
+
+## Honesty contract
+
+- `--sandbox` fails closed; it never claims isolation it didn't establish.
+- Docs state which boundary each mode provides (direct = classifier/heuristic;
+  `--sandbox` = kernel/container), and what each does not.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.3.3"
+version = "0.4.0"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 from opendot.agent.loop import Agent
 
-__version__ = "0.3.3"
+__version__ = "0.4.0"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -804,6 +804,17 @@ def main() -> None:
     if oneshot is None and not sys.stdin.isatty():
         oneshot = sys.stdin.read().strip() or None
 
+    # --sandbox only makes sense for a one-shot run (a headless-container TUI/REPL
+    # isn't useful). Fail closed rather than silently running un-isolated — a user
+    # who asked for the sandbox must not get a direct run thinking they're isolated.
+    if getattr(args, "sandbox", False) and not oneshot:
+        console.print(
+            "[bold red]sandbox:[/bold red] --sandbox requires a one-shot prompt "
+            "(-p '...'); it can't isolate an interactive session. Run with -p, or "
+            "drop --sandbox."
+        )
+        raise SystemExit(2)
+
     if oneshot and getattr(args, "sandbox", False):
         # Kernel-isolated run: execute the turn inside a container against a copy
         # of the workspace, then commit the diff back. Fails closed (errors) if no
@@ -827,6 +838,13 @@ def main() -> None:
             f"[dim]sandbox ({result['runtime']}) exited {result['returncode']}; "
             f"committed {n} changed file(s) back to the workspace[/dim]"
         )
+        failed = result.get("failed") or []
+        if failed:
+            console.print(
+                f"[yellow]sandbox: {len(failed)} file(s) could not be committed back "
+                f"(check permissions): {', '.join(failed[:5])}"
+                f"{'…' if len(failed) > 5 else ''}[/yellow]"
+            )
         return
 
     if oneshot:

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -845,7 +845,8 @@ def main() -> None:
                 f"(check permissions): {', '.join(failed[:5])}"
                 f"{'…' if len(failed) > 5 else ''}[/yellow]"
             )
-        return
+        # Propagate the container's exit status so CI/scripting sees a failed run.
+        raise SystemExit(int(result["returncode"]))
 
     if oneshot:
         # Non-interactive: can't prompt, so decline irreversible commands unless

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -78,6 +78,16 @@ def _build_policy(args, workdir: str):
     return load_policy(workdir).merged_with(cli_policy)
 
 
+def _forwarded_env_keys(model: str) -> list[str]:
+    """API-key env vars to forward into a --sandbox container: just the one the
+    model needs (if set), so the containerized run can reach its provider without
+    leaking every secret in the host env."""
+    from opendot.providers import env_var_for
+
+    var = env_var_for(model)
+    return [var] if var and os.environ.get(var) else []
+
+
 def _make_confirm(args, workdir: str, interactive: bool):
     """Build the confirm callback: policy-gated, falling back to the interactive
     prompt (or an auto-decline in one-shot mode) for anything left to ask."""
@@ -687,6 +697,25 @@ def main() -> None:
         help="Always refuse actions whose confirm prompt contains PATTERN, even "
         "with --yes (repeatable, e.g. --deny 'git push').",
     )
+    parser.add_argument(
+        "--sandbox",
+        action="store_true",
+        help="Run a one-shot (-p) turn inside a container against a copy of the "
+        "workspace, committing only the resulting diff back on success. Needs "
+        "docker or podman; errors if neither is present (never falls back to a "
+        "direct run). Kernel-enforced isolation for unattended runs.",
+    )
+    parser.add_argument(
+        "--sandbox-image",
+        default="python:3.12-slim",
+        help="Container image for --sandbox (must have opendot installed, or "
+        "install it in an entrypoint). Default: python:3.12-slim.",
+    )
+    parser.add_argument(
+        "--sandbox-net",
+        action="store_true",
+        help="Allow network access inside the --sandbox container (off by default).",
+    )
     parser.add_argument("--version", action="version", version=f"opendot {__version__}")
 
     sub = parser.add_subparsers(dest="command")
@@ -774,6 +803,31 @@ def main() -> None:
     oneshot = args.prompt
     if oneshot is None and not sys.stdin.isatty():
         oneshot = sys.stdin.read().strip() or None
+
+    if oneshot and getattr(args, "sandbox", False):
+        # Kernel-isolated run: execute the turn inside a container against a copy
+        # of the workspace, then commit the diff back. Fails closed (errors) if no
+        # container runtime — never silently runs directly.
+        from opendot import sandbox
+
+        try:
+            result = sandbox.run_sandboxed(
+                workdir,
+                oneshot,
+                args.model,
+                image=args.sandbox_image,
+                network=args.sandbox_net,
+                env_keys=_forwarded_env_keys(args.model),
+            )
+        except sandbox.SandboxError as exc:
+            console.print(f"[bold red]sandbox:[/bold red] {exc}")
+            raise SystemExit(2) from exc
+        n = len(result["changed"])
+        console.print(
+            f"[dim]sandbox ({result['runtime']}) exited {result['returncode']}; "
+            f"committed {n} changed file(s) back to the workspace[/dim]"
+        )
+        return
 
     if oneshot:
         # Non-interactive: can't prompt, so decline irreversible commands unless

--- a/src/opendot/sandbox.py
+++ b/src/opendot/sandbox.py
@@ -1,0 +1,208 @@
+"""Container sandbox for unattended runs (``--sandbox``).
+
+The classifier decides *when to ask*; it is not a security boundary (see #130).
+For an unattended run there is no human to ask, so ``--sandbox`` moves the
+guarantee to a **kernel-enforced** boundary: run the agent inside a container
+against a *copy* of the workspace, and commit only the resulting workspace diff
+back to the real tree on success. Whatever the agent does — opaque subprocess,
+symlink race, ``rm -rf`` — is contained by the container, not by parsing shell.
+
+Design (Phase 1 of #130):
+
+- **Opt-in, runtime-gated, fails closed.** ``--sandbox`` needs docker or podman;
+  if neither is present it errors, it never silently falls back to running
+  directly (that would imply an isolation the run doesn't have).
+- **Copy-in / diff-out.** The workspace is copied to a temp dir, that copy is
+  mounted into the container, and after the run the copy is reconciled back to
+  the real workspace through the reversibility engine — so the commit-back is
+  itself snapshotted and undoable.
+- **Only for one-shot runs.** An interactive TUI/REPL inside a headless
+  container isn't useful; ``--sandbox`` applies to ``opendot -p`` (and CI).
+
+NOTE: the *live in-container execution* is validated on a docker/podman host; the
+host-side plumbing here (runtime detection, gating, copy-in, commit-back) is
+unit-tested with the runtime mocked.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+from opendot.reversibility.rules import load_rules
+from opendot.reversibility.snapshots import IgnoreRules, _iter_files
+
+# Container runtimes we support, in preference order. podman first: rootless by
+# default, so the contained process can't trivially act as host root.
+_RUNTIMES = ("podman", "docker")
+
+
+class SandboxError(Exception):
+    """Raised when a sandbox run can't be set up (no runtime, copy failure, …).
+
+    ``--sandbox`` fails closed: this is surfaced to the user, never swallowed
+    into a silent direct run."""
+
+
+def detect_runtime() -> str | None:
+    """Return the first available container runtime on PATH, or None."""
+    for rt in _RUNTIMES:
+        if shutil.which(rt):
+            return rt
+    return None
+
+
+def require_runtime() -> str:
+    """Return an available runtime, or raise SandboxError (fail closed)."""
+    rt = detect_runtime()
+    if rt is None:
+        raise SandboxError(
+            "--sandbox needs a container runtime, but neither podman nor docker "
+            "was found on PATH. Install one, or drop --sandbox to run directly "
+            "(no kernel isolation)."
+        )
+    return rt
+
+
+def _copy_workspace(workdir: Path, dest: Path, rules: IgnoreRules) -> None:
+    """Copy the (non-ignored) workspace tree into ``dest``.
+
+    Ignored trees (.git, node_modules, venvs, …) are skipped, matching what the
+    snapshot engine captures — the sandbox operates on the same view the
+    reversibility engine can reconcile."""
+    for f in _iter_files(workdir, rules):
+        rel = f.relative_to(workdir)
+        target = dest / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(f, target)
+
+
+def _hash(path: Path) -> str | None:
+    import hashlib
+
+    try:
+        h = hashlib.sha256()
+        with open(path, "rb") as fh:
+            for block in iter(lambda: fh.read(1 << 20), b""):
+                h.update(block)
+        return h.hexdigest()
+    except OSError:
+        return None
+
+
+def commit_back(sandbox_dir: Path, workdir: Path, rules: IgnoreRules) -> list[str]:
+    """Reconcile the post-run sandbox copy back into the real workspace.
+
+    Applies files that were created or changed in the sandbox, and removes
+    (non-ignored) files the sandbox deleted, so the real workspace ends up
+    matching the sandbox's non-ignored view. Ignored trees are never touched.
+    Returns the list of relative paths that changed (for the caller to report).
+
+    The caller snapshots the real workspace *before* calling this (via the
+    reversibility engine), so the whole commit-back is itself undoable.
+    """
+    changed: list[str] = []
+
+    sandbox_files = {
+        f.relative_to(sandbox_dir).as_posix(): f for f in _iter_files(sandbox_dir, rules)
+    }
+    real_files = {f.relative_to(workdir).as_posix(): f for f in _iter_files(workdir, rules)}
+
+    # 1. Create / update files present in the sandbox (new, or content changed).
+    for rel, src in sandbox_files.items():
+        dst = workdir / rel
+        if rel not in real_files or _hash(src) != _hash(dst):
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+            changed.append(rel)
+
+    # 2. Remove files the sandbox deleted (present in real, absent in sandbox).
+    for rel, dst in real_files.items():
+        if rel not in sandbox_files:
+            try:
+                dst.unlink()
+                changed.append(rel)
+            except OSError:
+                pass
+
+    return sorted(set(changed))
+
+
+def build_run_command(
+    runtime: str,
+    image: str,
+    sandbox_dir: Path,
+    prompt: str,
+    model: str,
+    *,
+    network: bool,
+    env_keys: list[str],
+) -> list[str]:
+    """Build the ``docker/podman run`` argv that runs opendot one-shot inside the
+    container against the mounted sandbox workspace.
+
+    - the sandbox copy is mounted at /work and used as the working dir
+    - network is off by default (``--network none``) unless explicitly allowed
+    - only the named API-key env vars are forwarded (``-e KEY``), nothing else
+    - runs ``opendot -p <prompt> --yes`` inside (already isolated, so auto-approve)
+    """
+    argv = [runtime, "run", "--rm", "-v", f"{sandbox_dir}:/work", "-w", "/work"]
+    if not network:
+        argv += ["--network", "none"]
+    for key in env_keys:
+        argv += ["-e", key]  # forward the value from the host env by name
+    argv += [image, "opendot", "-p", prompt, "--model", model, "--yes"]
+    return argv
+
+
+def run_sandboxed(
+    workdir: str,
+    prompt: str,
+    model: str,
+    *,
+    image: str,
+    network: bool = False,
+    env_keys: list[str] | None = None,
+    runner=subprocess.run,
+) -> dict:
+    """Run one opendot turn inside a container against a copy of ``workdir``, then
+    commit the resulting diff back to the real workspace (snapshotted first).
+
+    Returns ``{"runtime", "changed", "returncode"}``. Raises SandboxError if no
+    runtime is available or the workspace can't be staged. ``runner`` is injected
+    for testing (defaults to subprocess.run).
+    """
+    import tempfile
+
+    runtime = require_runtime()
+    wd = Path(workdir).resolve()
+    rules = load_rules(str(wd))
+    env_keys = env_keys or []
+
+    staging = Path(tempfile.mkdtemp(prefix="opendot-sbx-"))
+    sandbox_dir = staging / "work"
+    sandbox_dir.mkdir()
+    try:
+        _copy_workspace(wd, sandbox_dir, rules)
+
+        argv = build_run_command(
+            runtime, image, sandbox_dir, prompt, model, network=network, env_keys=env_keys
+        )
+        proc = runner(argv)
+        returncode = getattr(proc, "returncode", 0)
+
+        changed: list[str] = []
+        if returncode == 0:
+            # Snapshot the real workspace first so the commit-back is undoable,
+            # then reconcile the sandbox result into it.
+            from opendot.reversibility.engine import Reversibility
+
+            rev = Reversibility(workdir=str(wd), rules=rules)
+            rev.before_action(
+                "write", "sandbox commit", reversible=True, note="sandbox --sandbox run"
+            )
+            changed = commit_back(sandbox_dir, wd, rules)
+        return {"runtime": runtime, "changed": changed, "returncode": returncode}
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)

--- a/src/opendot/sandbox.py
+++ b/src/opendot/sandbox.py
@@ -118,7 +118,14 @@ def commit_back(
     # 1. Create / update files present in the sandbox (new, or content changed).
     for rel, src in sandbox_files.items():
         dst = workdir / rel
-        if rel not in real_files or _hash(src) != _hash(dst):
+        src_h = _hash(src)
+        if src_h is None:
+            # Can't read the sandbox file to compare or copy it — report it rather
+            # than let a None==None hash comparison skip it as "unchanged".
+            failed.append(rel)
+            continue
+        dst_h = _hash(dst) if rel in real_files else None
+        if rel not in real_files or src_h != dst_h:
             try:
                 dst.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(src, dst)
@@ -178,9 +185,9 @@ def run_sandboxed(
     """Run one opendot turn inside a container against a copy of ``workdir``, then
     commit the resulting diff back to the real workspace (snapshotted first).
 
-    Returns ``{"runtime", "changed", "returncode"}``. Raises SandboxError if no
-    runtime is available or the workspace can't be staged. ``runner`` is injected
-    for testing (defaults to subprocess.run).
+    Returns ``{"runtime", "changed", "failed", "returncode"}``. Raises SandboxError
+    if no runtime is available, the workspace can't be staged, or the runner returns
+    no usable process. ``runner`` is injected for testing (defaults to subprocess.run).
     """
     import tempfile
 
@@ -193,13 +200,20 @@ def run_sandboxed(
     sandbox_dir = staging / "work"
     sandbox_dir.mkdir()
     try:
-        _copy_workspace(wd, sandbox_dir, rules)
+        try:
+            _copy_workspace(wd, sandbox_dir, rules)
+        except OSError as exc:
+            raise SandboxError(f"failed to stage workspace copy: {exc}") from exc
 
         argv = build_run_command(
             runtime, image, sandbox_dir, prompt, model, network=network, env_keys=env_keys
         )
         proc = runner(argv)
-        returncode = getattr(proc, "returncode", 0)
+        # A runner that returns nothing usable means the container never ran; treat
+        # that as a failure rather than a returncode-0 "success" that commits back.
+        if proc is None or not hasattr(proc, "returncode"):
+            raise SandboxError("container runner returned no process/returncode")
+        returncode = int(proc.returncode)
 
         changed: list[str] = []
         failed: list[str] = []

--- a/src/opendot/sandbox.py
+++ b/src/opendot/sandbox.py
@@ -68,9 +68,10 @@ def require_runtime() -> str:
 def _copy_workspace(workdir: Path, dest: Path, rules: IgnoreRules) -> None:
     """Copy the (non-ignored) workspace tree into ``dest``.
 
-    Ignored trees (.git, node_modules, venvs, …) are skipped, matching what the
-    snapshot engine captures — the sandbox operates on the same view the
-    reversibility engine can reconcile."""
+    Ignored trees (.git, node_modules, venvs, …) are skipped per the ignore rules,
+    so the sandbox works on the same ignored-path view the reversibility engine
+    reconciles. (Unlike snapshotting, this does not skip very large files — the
+    whole non-ignored tree is copied.)"""
     for f in _iter_files(workdir, rules):
         rel = f.relative_to(workdir)
         target = dest / rel
@@ -91,18 +92,23 @@ def _hash(path: Path) -> str | None:
         return None
 
 
-def commit_back(sandbox_dir: Path, workdir: Path, rules: IgnoreRules) -> list[str]:
+def commit_back(
+    sandbox_dir: Path, workdir: Path, rules: IgnoreRules
+) -> tuple[list[str], list[str]]:
     """Reconcile the post-run sandbox copy back into the real workspace.
 
     Applies files that were created or changed in the sandbox, and removes
     (non-ignored) files the sandbox deleted, so the real workspace ends up
     matching the sandbox's non-ignored view. Ignored trees are never touched.
-    Returns the list of relative paths that changed (for the caller to report).
 
-    The caller snapshots the real workspace *before* calling this (via the
-    reversibility engine), so the whole commit-back is itself undoable.
+    Returns ``(changed, failed)``: relative paths successfully reconciled, and
+    paths that could NOT be reconciled (a copy or delete that raised) — the
+    caller surfaces ``failed`` so a partial commit-back is never reported as a
+    clean one. The caller snapshots the real workspace *before* calling this, so
+    the whole commit-back is itself undoable (subject to the snapshot size limit).
     """
     changed: list[str] = []
+    failed: list[str] = []
 
     sandbox_files = {
         f.relative_to(sandbox_dir).as_posix(): f for f in _iter_files(sandbox_dir, rules)
@@ -113,9 +119,12 @@ def commit_back(sandbox_dir: Path, workdir: Path, rules: IgnoreRules) -> list[st
     for rel, src in sandbox_files.items():
         dst = workdir / rel
         if rel not in real_files or _hash(src) != _hash(dst):
-            dst.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(src, dst)
-            changed.append(rel)
+            try:
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, dst)
+                changed.append(rel)
+            except OSError:
+                failed.append(rel)
 
     # 2. Remove files the sandbox deleted (present in real, absent in sandbox).
     for rel, dst in real_files.items():
@@ -124,9 +133,9 @@ def commit_back(sandbox_dir: Path, workdir: Path, rules: IgnoreRules) -> list[st
                 dst.unlink()
                 changed.append(rel)
             except OSError:
-                pass
+                failed.append(rel)
 
-    return sorted(set(changed))
+    return sorted(set(changed)), sorted(set(failed))
 
 
 def build_run_command(
@@ -193,6 +202,7 @@ def run_sandboxed(
         returncode = getattr(proc, "returncode", 0)
 
         changed: list[str] = []
+        failed: list[str] = []
         if returncode == 0:
             # Snapshot the real workspace first so the commit-back is undoable,
             # then reconcile the sandbox result into it.
@@ -202,7 +212,12 @@ def run_sandboxed(
             rev.before_action(
                 "write", "sandbox commit", reversible=True, note="sandbox --sandbox run"
             )
-            changed = commit_back(sandbox_dir, wd, rules)
-        return {"runtime": runtime, "changed": changed, "returncode": returncode}
+            changed, failed = commit_back(sandbox_dir, wd, rules)
+        return {
+            "runtime": runtime,
+            "changed": changed,
+            "failed": failed,
+            "returncode": returncode,
+        }
     finally:
         shutil.rmtree(staging, ignore_errors=True)

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -49,9 +49,8 @@ def test_build_run_command_network_off_and_scoped_env():
     assert argv[:2] == ["docker", "run"]
     assert "--network" in argv and "none" in argv  # isolated by default
     assert "-e" in argv and "OPENAI_API_KEY" in argv  # only the named key
-    # runs opendot one-shot, auto-approve (already isolated)
-    assert argv[-5:] == ["opendot", "-p", "do it", "--model", "gpt-5.1"] or "--yes" in argv
-    assert "--yes" in argv
+    # runs opendot one-shot inside the container, auto-approve (already isolated)
+    assert argv[-7:] == ["img", "opendot", "-p", "do it", "--model", "gpt-5.1", "--yes"]
 
 
 def test_build_run_command_network_on_when_allowed():
@@ -137,6 +136,48 @@ def test_commit_back_leaves_ignored_trees_untouched(tmp_path):
     (sbx / ".git" / "config").write_text("sneaky")
     (sbx / "real.txt").write_text("ok")
 
-    changed = sandbox.commit_back(sbx, wd, IgnoreRules())
+    changed, failed = sandbox.commit_back(sbx, wd, IgnoreRules())
     assert "real.txt" in changed
+    assert failed == []
     assert not (wd / ".git").exists()  # ignored tree not committed back
+
+
+def test_commit_back_reports_failed_deletion(tmp_path, monkeypatch):
+    # A delete that can't be performed is reported in `failed`, not silently dropped.
+    wd = tmp_path / "ws"
+    wd.mkdir()
+    (wd / "locked.txt").write_text("x")  # present in real, absent in sandbox -> delete
+    sbx = tmp_path / "sbx"
+    sbx.mkdir()
+
+    import pathlib
+
+    real_unlink = pathlib.Path.unlink
+
+    def boom(self, *a, **k):
+        if self.name == "locked.txt":
+            raise OSError("permission denied")
+        return real_unlink(self, *a, **k)
+
+    monkeypatch.setattr(pathlib.Path, "unlink", boom)
+    changed, failed = sandbox.commit_back(sbx, wd, IgnoreRules())
+    assert failed == ["locked.txt"]
+    assert "locked.txt" not in changed
+
+
+def test_sandbox_without_prompt_fails_closed(monkeypatch, capsys):
+    # --sandbox with no one-shot prompt must error, not run un-isolated.
+    import sys as _sys
+
+    from opendot import cli
+
+    monkeypatch.setattr(_sys, "argv", ["opendot", "--sandbox", "--repl"])
+
+    class _Tty:
+        def isatty(self):
+            return True
+
+    monkeypatch.setattr(_sys, "stdin", _Tty())
+    with pytest.raises(SystemExit) as ei:
+        cli.main()
+    assert ei.value.code == 2

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,0 +1,142 @@
+"""Tests for the --sandbox container isolation scaffold (#130 Phase 1).
+
+The live in-container run is validated on a docker/podman host; these cover the
+host-side plumbing — runtime detection/fail-closed, the run command, and
+copy-in/diff-out commit-back — with the runtime mocked.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from opendot import sandbox
+from opendot.reversibility.snapshots import IgnoreRules
+
+# -- runtime detection / fail-closed --
+
+
+def test_require_runtime_fails_closed_when_none(monkeypatch):
+    monkeypatch.setattr(sandbox, "detect_runtime", lambda: None)
+    with pytest.raises(sandbox.SandboxError, match="container runtime"):
+        sandbox.require_runtime()
+
+
+def test_require_runtime_returns_detected(monkeypatch):
+    monkeypatch.setattr(sandbox, "detect_runtime", lambda: "podman")
+    assert sandbox.require_runtime() == "podman"
+
+
+def test_detect_runtime_prefers_podman(monkeypatch):
+    monkeypatch.setattr(sandbox.shutil, "which", lambda name: "/usr/bin/" + name)
+    assert sandbox.detect_runtime() == "podman"  # first in preference order
+
+
+# -- run command shape --
+
+
+def test_build_run_command_network_off_and_scoped_env():
+    argv = sandbox.build_run_command(
+        "docker",
+        "img",
+        Path("/tmp/sbx"),
+        "do it",
+        "gpt-5.1",
+        network=False,
+        env_keys=["OPENAI_API_KEY"],
+    )
+    assert argv[:2] == ["docker", "run"]
+    assert "--network" in argv and "none" in argv  # isolated by default
+    assert "-e" in argv and "OPENAI_API_KEY" in argv  # only the named key
+    # runs opendot one-shot, auto-approve (already isolated)
+    assert argv[-5:] == ["opendot", "-p", "do it", "--model", "gpt-5.1"] or "--yes" in argv
+    assert "--yes" in argv
+
+
+def test_build_run_command_network_on_when_allowed():
+    argv = sandbox.build_run_command(
+        "podman", "img", Path("/tmp/sbx"), "x", "m", network=True, env_keys=[]
+    )
+    assert "--network" not in argv  # network allowed -> no isolation flag
+
+
+# -- copy-in / commit-back --
+
+
+def _fake_runner_editing(edits):
+    """A runner that applies `edits(sandbox_dir)` and returns rc=0."""
+
+    def run(argv):
+        sbx = Path(argv[argv.index("-v") + 1].split(":")[0])
+        edits(sbx)
+
+        class P:
+            returncode = 0
+
+        return P()
+
+    return run
+
+
+def test_run_sandboxed_commits_changes_back(tmp_path, monkeypatch):
+    monkeypatch.setattr(sandbox, "detect_runtime", lambda: "docker")
+    wd = tmp_path / "ws"
+    wd.mkdir()
+    (wd / "keep.txt").write_text("original")
+    (wd / "gone.txt").write_text("bye")
+
+    def edits(sbx: Path):
+        (sbx / "keep.txt").write_text("EDITED")  # modify
+        (sbx / "new.txt").write_text("created")  # create
+        (sbx / "gone.txt").unlink()  # delete
+
+    res = sandbox.run_sandboxed(
+        str(wd), "go", "gpt-5.1", image="img", runner=_fake_runner_editing(edits)
+    )
+    assert res["returncode"] == 0
+    assert set(res["changed"]) == {"keep.txt", "new.txt", "gone.txt"}
+    assert (wd / "keep.txt").read_text() == "EDITED"
+    assert (wd / "new.txt").read_text() == "created"
+    assert not (wd / "gone.txt").exists()
+
+
+def test_run_sandboxed_no_commit_on_container_failure(tmp_path, monkeypatch):
+    monkeypatch.setattr(sandbox, "detect_runtime", lambda: "docker")
+    wd = tmp_path / "ws"
+    wd.mkdir()
+    (wd / "keep.txt").write_text("original")
+
+    def run(argv):
+        sbx = Path(argv[argv.index("-v") + 1].split(":")[0])
+        (sbx / "keep.txt").write_text("half-done")  # container messed with it then failed
+
+        class P:
+            returncode = 1
+
+        return P()
+
+    res = sandbox.run_sandboxed(str(wd), "x", "gpt-5.1", image="img", runner=run)
+    assert res["returncode"] == 1
+    assert res["changed"] == []
+    assert (wd / "keep.txt").read_text() == "original"  # workspace untouched on failure
+
+
+def test_run_sandboxed_fails_closed_without_runtime(tmp_path, monkeypatch):
+    monkeypatch.setattr(sandbox, "detect_runtime", lambda: None)
+    with pytest.raises(sandbox.SandboxError):
+        sandbox.run_sandboxed(str(tmp_path), "x", "m", image="img", runner=lambda a: None)
+
+
+def test_commit_back_leaves_ignored_trees_untouched(tmp_path):
+    # A change under an ignored tree in the sandbox must not be copied back.
+    wd = tmp_path / "ws"
+    wd.mkdir()
+    sbx = tmp_path / "sbx"
+    (sbx / ".git").mkdir(parents=True)
+    (sbx / ".git" / "config").write_text("sneaky")
+    (sbx / "real.txt").write_text("ok")
+
+    changed = sandbox.commit_back(sbx, wd, IgnoreRules())
+    assert "real.txt" in changed
+    assert not (wd / ".git").exists()  # ignored tree not committed back

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -127,6 +127,54 @@ def test_run_sandboxed_fails_closed_without_runtime(tmp_path, monkeypatch):
         sandbox.run_sandboxed(str(tmp_path), "x", "m", image="img", runner=lambda a: None)
 
 
+def test_run_sandboxed_fails_closed_when_runner_returns_no_process(tmp_path, monkeypatch):
+    # A runner that returns None (or anything without .returncode) means the
+    # container never ran; that must fail closed, not commit back as rc=0.
+    monkeypatch.setattr(sandbox, "detect_runtime", lambda: "docker")
+    wd = tmp_path / "ws"
+    wd.mkdir()
+    (wd / "keep.txt").write_text("original")
+    with pytest.raises(sandbox.SandboxError, match="returncode"):
+        sandbox.run_sandboxed(str(wd), "x", "m", image="img", runner=lambda a: None)
+    assert (wd / "keep.txt").read_text() == "original"  # nothing committed
+
+
+def test_run_sandboxed_wraps_staging_error_as_sandbox_error(tmp_path, monkeypatch):
+    # A copy-in failure surfaces as SandboxError (the CLI's fail-closed handler),
+    # not a raw OSError that bypasses it.
+    monkeypatch.setattr(sandbox, "detect_runtime", lambda: "docker")
+
+    def boom(*a, **k):
+        raise OSError("unreadable")
+
+    monkeypatch.setattr(sandbox, "_copy_workspace", boom)
+    wd = tmp_path / "ws"
+    wd.mkdir()
+    with pytest.raises(sandbox.SandboxError, match="stage workspace"):
+        sandbox.run_sandboxed(str(wd), "x", "m", image="img", runner=lambda a: None)
+
+
+def test_commit_back_reports_unreadable_sandbox_file(tmp_path, monkeypatch):
+    # A sandbox file whose hash can't be read is reported in `failed`, not skipped
+    # as "unchanged" via a None == None comparison.
+    wd = tmp_path / "ws"
+    wd.mkdir()
+    sbx = tmp_path / "sbx"
+    sbx.mkdir()
+    (sbx / "bad.txt").write_text("x")
+
+    real_hash = sandbox._hash
+
+    def maybe_none(path):
+        return None if path.name == "bad.txt" else real_hash(path)
+
+    monkeypatch.setattr(sandbox, "_hash", maybe_none)
+    changed, failed = sandbox.commit_back(sbx, wd, IgnoreRules())
+    assert failed == ["bad.txt"]
+    assert "bad.txt" not in changed
+    assert not (wd / "bad.txt").exists()
+
+
 def test_commit_back_leaves_ignored_trees_untouched(tmp_path):
     # A change under an ignored tree in the sandbox must not be copied back.
     wd = tmp_path / "ws"
@@ -181,3 +229,22 @@ def test_sandbox_without_prompt_fails_closed(monkeypatch, capsys):
     with pytest.raises(SystemExit) as ei:
         cli.main()
     assert ei.value.code == 2
+
+
+def test_cli_sandbox_propagates_container_exit_code(monkeypatch):
+    # A non-zero container exit must become the process exit code so CI/scripting
+    # sees the failure, not a silent success.
+    import sys as _sys
+
+    from opendot import cli
+    from opendot import sandbox as sbx
+
+    monkeypatch.setattr(_sys, "argv", ["opendot", "-p", "do it", "--model", "gpt-5.1", "--sandbox"])
+    monkeypatch.setattr(
+        sbx,
+        "run_sandboxed",
+        lambda *a, **k: {"runtime": "docker", "changed": [], "failed": [], "returncode": 3},
+    )
+    with pytest.raises(SystemExit) as ei:
+        cli.main()
+    assert ei.value.code == 3


### PR DESCRIPTION
Phase 1 of #130. Moves the reversibility guarantee for unattended runs off the text classifier and onto a kernel-enforced container boundary.

## What

`--sandbox` runs a one-shot turn inside a container against a *copy* of the workspace, then commits only the resulting diff back on success.

```bash
opendot -p "refactor and run the tests" --sandbox      # isolated in a container
opendot -p "..." --sandbox --sandbox-net               # allow network (off by default)
```

- **Opt-in, runtime-gated, fails closed.** Detects docker/podman (podman preferred — rootless). If neither is present, `--sandbox` **errors** — it never silently falls back to a direct run while implying isolation.
- **Copy-in / diff-out.** The non-ignored workspace is copied to a temp dir, that copy is mounted into the container, the turn runs there, and on success the copy is reconciled back through the reversibility engine (snapshotted first → the commit-back is itself undoable). On a non-zero container exit, **nothing** is applied.
- **Least privilege.** `--network none` by default (opt in with `--sandbox-net`); only the API-key env var the model needs is forwarded, nothing else.
- **Additive.** One-shot (`-p`) only; direct and interactive runs are byte-for-byte unchanged when `--sandbox` isn't passed.

## Testing
- 9 new tests: runtime detection/fail-closed, run-command shape (network-off + scoped env), copy-in/diff-out commit-back (create/modify/delete), no-commit-on-failure, ignored-trees-not-committed.
- Full suite: 341 passed, 5 skipped, ruff check + format clean. The direct path is unchanged (the pre-existing 332 still pass).

## Honest scope
Host-side plumbing (detection, gating, copy-in, commit-back) is unit-tested with the container runtime **mocked**. The **live in-container execution** is validated on a docker/podman host — I can't spin real containers in the dev/CI environment, so that end-to-end path should be smoke-tested on a machine with a runtime before relying on it. The default image (`python:3.12-slim`) assumes opendot is installed in it; documenting/providing an image is a Phase-1 follow-up noted in `docs/design/sandbox.md`.

## #130
This ships Phase 1 (the container boundary) + the design doc. Phase 2 (optional overlayfs tier for Linux without a runtime) remains. Bumps to **0.4.0**.