### PR TITLE
fix: preserve equals signs in MCP header values

### DIFF
--- a/src/opendot/tui/modals.py
+++ b/src/opendot/tui/modals.py
@@ -14,12 +14,22 @@ from opendot.tui.helpers import _row_bar, _title_bar
 
 
 def _split_header(header: str) -> tuple[str, str]:
-    """Split an HTTP header without treating ``=`` in its value as a delimiter."""
+    """Split an HTTP header without treating ``=`` in its value as a delimiter.
+
+    Returns ``("", "")`` for a malformed header (no delimiter, or an empty key
+    like ``=abc`` / ``:abc``) so the caller can skip it rather than persist an
+    invalid ``{"": ...}`` entry into the server spec.
+    """
     colon = header.find(":")
     equals = header.find("=")
+    if colon < 0 and equals < 0:
+        return "", ""  # no delimiter at all: not a key/value header
     separator = ":" if colon >= 0 and (equals < 0 or colon < equals) else "="
     key, _, value = header.partition(separator)
-    return key.strip(), value.strip()
+    key = key.strip()
+    if not key:
+        return "", ""
+    return key, value.strip()
 
 
 class ConfirmModal(ModalScreen[bool]):
@@ -247,7 +257,8 @@ class McpAddModal(ModalScreen[dict | None]):
                 spec["auth"] = "oauth"  # browser-OAuth flow, no static token
             elif header:
                 key, value = _split_header(header)
-                spec["headers"] = {key: value}
+                if key:  # skip a malformed header rather than persist {"": ...}
+                    spec["headers"] = {key: value}
         else:
             parts = target.split()
             spec = {"command": parts[0]}

--- a/src/opendot/tui/modals.py
+++ b/src/opendot/tui/modals.py
@@ -13,6 +13,15 @@ from textual.widgets import Button, Input, Static
 from opendot.tui.helpers import _row_bar, _title_bar
 
 
+def _split_header(header: str) -> tuple[str, str]:
+    """Split an HTTP header without treating ``=`` in its value as a delimiter."""
+    colon = header.find(":")
+    equals = header.find("=")
+    separator = ":" if colon >= 0 and (equals < 0 or colon < equals) else "="
+    key, _, value = header.partition(separator)
+    return key.strip(), value.strip()
+
+
 class ConfirmModal(ModalScreen[bool]):
     """A blocking yes/no modal for irreversible commands. Returns True to run."""
 
@@ -237,8 +246,8 @@ class McpAddModal(ModalScreen[dict | None]):
             if header.lower() == "oauth":
                 spec["auth"] = "oauth"  # browser-OAuth flow, no static token
             elif header:
-                k, _, v = header.partition("=") if "=" in header else header.partition(":")
-                spec["headers"] = {k.strip(): v.strip()}
+                key, value = _split_header(header)
+                spec["headers"] = {key: value}
         else:
             parts = target.split()
             spec = {"command": parts[0]}

--- a/tests/test_tui_modals.py
+++ b/tests/test_tui_modals.py
@@ -62,6 +62,15 @@ def test_mcp_header_split_supports_both_input_forms():
     )
 
 
+def test_mcp_header_split_rejects_malformed_headers():
+    # An empty key or a value with no delimiter must not produce an invalid
+    # {"": ...} / keyless header dict; the caller skips ("", "").
+    assert _split_header("=abc") == ("", "")
+    assert _split_header(":abc") == ("", "")
+    assert _split_header("no-delimiter-here") == ("", "")
+    assert _split_header("   ") == ("", "")
+
+
 async def test_mcp_add_modal_preserves_equals_in_authorization_value(tmp_path, monkeypatch):
     monkeypatch.setenv("OPENDOT_HOME", str(tmp_path / "store"))
     app = OpendotTUI(_FakeAgent())

--- a/tests/test_tui_modals.py
+++ b/tests/test_tui_modals.py
@@ -6,7 +6,8 @@ guards the leak where pressing Enter in ApiKeyModal sent the key to the agent.
 """
 
 from opendot.agent.events import Event
-from opendot.tui import ApiKeyModal, OpendotTUI
+from opendot.tui import ApiKeyModal, McpAddModal, OpendotTUI
+from opendot.tui.modals import _split_header
 
 
 class _FakeUsage:
@@ -43,6 +44,48 @@ class _FakeAgent:
     async def run(self, msg):
         self.ran.append(msg)
         yield Event(type="text", text="x")
+
+
+def test_mcp_header_split_preserves_equals_in_colon_value():
+    assert _split_header("Authorization: Bearer abc=def") == (
+        "Authorization",
+        "Bearer abc=def",
+    )
+    assert _split_header("X-Api-Key: k==") == ("X-Api-Key", "k==")
+
+
+def test_mcp_header_split_supports_both_input_forms():
+    assert _split_header("Key: Value") == ("Key", "Value")
+    assert _split_header("Authorization=Bearer abc=def") == (
+        "Authorization",
+        "Bearer abc=def",
+    )
+
+
+async def test_mcp_add_modal_preserves_equals_in_authorization_value(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENDOT_HOME", str(tmp_path / "store"))
+    app = OpendotTUI(_FakeAgent())
+    submitted = []
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.push_screen(McpAddModal(), submitted.append)
+        await pilot.pause()
+        app.screen.query_one("#name").value = "example"
+        app.screen.query_one("#target").value = "https://example.com/mcp"
+        app.screen.query_one("#header").value = "Authorization: Bearer abc=def"
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert submitted == [
+        {
+            "name": "example",
+            "spec": {
+                "url": "https://example.com/mcp",
+                "headers": {"Authorization": "Bearer abc=def"},
+            },
+        }
+    ]
 
 
 async def test_apikey_modal_enter_does_not_leak_to_chat(tmp_path, monkeypatch):


### PR DESCRIPTION
## What & why

Fixes #137.

The MCP add-server modal now chooses the first header delimiter, so `Authorization: Bearer abc=def` keeps the full token value while the existing `KEY=VALUE` form still works.

## How I verified it

- `pytest -q tests/test_tui_modals.py` — 5 passed
- `ruff check src/opendot/tui/modals.py tests/test_tui_modals.py`
- `ruff format --check src/opendot/tui/modals.py tests/test_tui_modals.py`
- Full suite: 308 passed, 5 skipped, 26 failed on Windows-only assumptions (POSIX modes, symlinks, `/` paths, and `sleep`); none touch these files

## Checklist

- [x] Small and focused (one change)
- [x] Added/updated tests; focused tests pass locally
- [x] Reversibility/mutating tools not touched
- [x] No visual layout change, so no screenshot is applicable