### PR TITLE
sandbox: harden commit-back against symlink escape; fail CI on partial commit (0.4.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,9 +288,12 @@ subprocess does (the script run by `python foo.py` is as unknowable as
 `python -c`), and a determined adversary could race a symlink swap. That's why
 interpreters are confirm-first and built-in file writes are contained at open
 time — but the honest framing is that the classifier *explains* why a
-confirmation is prudent; it is not a guarantee against hostile input.
-Kernel-enforced isolation (an overlay/container for unattended runs) would be the
-stronger boundary, and is planned but not yet built
+confirmation is prudent; it is not a guarantee against hostile input. When you
+need a real boundary, `--sandbox` runs the turn inside a container against a
+copy of the workspace and commits only the resulting diff back — kernel-enforced
+containment rather than a heuristic (see the Sandbox mode section above). An
+overlayfs tier for Linux
+hosts without a container runtime is the remaining follow-up
 ([#130](https://github.com/vedaant00/opendot/issues/130)).
 
 **Skipping the snapshot on purpose.** When opendot runs a shell command it

--- a/docs/design/sandbox.md
+++ b/docs/design/sandbox.md
@@ -27,7 +27,12 @@ guarantee must come from a boundary the kernel enforces.
   snapshotted first via the reversibility engine, so it is itself undoable
   (subject to the snapshot size limit for very large files); on a non-zero
   container exit, nothing is applied. Files that can't be reconciled (a copy/
-  delete that raises) are reported, never silently dropped.
+  delete that raises) are reported, never silently dropped. Commit-back treats
+  the sandbox as untrusted: it won't follow a symlink path component out of the
+  workspace (any such link is neutralized, and a destination that still resolves
+  outside the workspace is refused), so a malicious path can't escape containment
+  on the way back. The CLI exits non-zero if the container failed *or* the
+  commit-back was only partial (the workspace is then indeterminate).
 - **Least privilege.** Network off by default (`--network none`, opt in with
   `--sandbox-net`); only the API-key env var the model needs is forwarded.
 - **Scope.** One-shot (`-p`) only — a headless-container TUI/REPL isn't useful.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.4.0"
+version = "0.4.1"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 from opendot.agent.loop import Agent
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/cli.py
+++ b/src/opendot/cli.py
@@ -846,7 +846,12 @@ def main() -> None:
                 f"{'…' if len(failed) > 5 else ''}[/yellow]"
             )
         # Propagate the container's exit status so CI/scripting sees a failed run.
-        raise SystemExit(int(result["returncode"]))
+        # A clean container exit with a partial commit-back leaves the workspace in
+        # an indeterminate state, so surface that as a failure too (exit 1).
+        exit_code = int(result["returncode"])
+        if exit_code == 0 and failed:
+            exit_code = 1
+        raise SystemExit(exit_code)
 
     if oneshot:
         # Non-interactive: can't prompt, so decline irreversible commands unless

--- a/src/opendot/sandbox.py
+++ b/src/opendot/sandbox.py
@@ -92,6 +92,39 @@ def _hash(path: Path) -> str | None:
         return None
 
 
+def _prepare_dest(dst: Path, real_root: Path) -> None:
+    """Make ``dst`` safe to write during commit-back, or raise SandboxError.
+
+    The sandbox is untrusted, so a path it produces must not let commit-back
+    write outside the workspace. Two escapes are closed here:
+
+    - A symlink anywhere in ``dst``'s existing path would make ``shutil.copy2``
+      follow it and write to the link target (possibly outside ``real_root``).
+      Any existing symlink component is removed so the copy lands on a real path.
+    - Even with symlinks gone, the resolved parent must stay under ``real_root``;
+      if it doesn't, we refuse rather than write outside containment.
+    """
+    # Remove an existing symlink (or a symlink standing in for a needed dir) at or
+    # above dst, walking down from real_root, so nothing on the path is followed.
+    for parent in reversed(dst.parents):
+        try:
+            if parent.is_relative_to(real_root) and parent != real_root and parent.is_symlink():
+                parent.unlink()
+        except OSError:
+            pass
+    if dst.is_symlink() or (dst.exists() and dst.is_dir()):
+        # A symlink at dst would be followed by copy2; a dir there blocks the file
+        # write. Neutralize both (the sandbox's view is authoritative on commit).
+        if dst.is_dir() and not dst.is_symlink():
+            shutil.rmtree(dst, ignore_errors=True)
+        else:
+            dst.unlink(missing_ok=True)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    resolved_parent = dst.parent.resolve()
+    if not (resolved_parent == real_root or resolved_parent.is_relative_to(real_root)):
+        raise SandboxError(f"commit-back destination escapes workspace: {dst}")
+
+
 def commit_back(
     sandbox_dir: Path, workdir: Path, rules: IgnoreRules
 ) -> tuple[list[str], list[str]]:
@@ -109,6 +142,7 @@ def commit_back(
     """
     changed: list[str] = []
     failed: list[str] = []
+    real_root = workdir.resolve()
 
     sandbox_files = {
         f.relative_to(sandbox_dir).as_posix(): f for f in _iter_files(sandbox_dir, rules)
@@ -127,10 +161,10 @@ def commit_back(
         dst_h = _hash(dst) if rel in real_files else None
         if rel not in real_files or src_h != dst_h:
             try:
-                dst.parent.mkdir(parents=True, exist_ok=True)
+                _prepare_dest(dst, real_root)
                 shutil.copy2(src, dst)
                 changed.append(rel)
-            except OSError:
+            except (OSError, SandboxError):
                 failed.append(rel)
 
     # 2. Remove files the sandbox deleted (present in real, absent in sandbox).

--- a/src/opendot/sandbox.py
+++ b/src/opendot/sandbox.py
@@ -96,33 +96,45 @@ def _prepare_dest(dst: Path, real_root: Path) -> None:
     """Make ``dst`` safe to write during commit-back, or raise SandboxError.
 
     The sandbox is untrusted, so a path it produces must not let commit-back
-    write outside the workspace. Two escapes are closed here:
+    write outside the workspace. A symlink anywhere in ``dst``'s existing path
+    would make ``shutil.copy2`` (and any ``mkdir``) follow it and touch the link
+    target — possibly outside ``real_root``.
 
-    - A symlink anywhere in ``dst``'s existing path would make ``shutil.copy2``
-      follow it and write to the link target (possibly outside ``real_root``).
-      Any existing symlink component is removed so the copy lands on a real path.
-    - Even with symlinks gone, the resolved parent must stay under ``real_root``;
-      if it doesn't, we refuse rather than write outside containment.
+    Everything here is check-first: no directory is created and no file is copied
+    until the whole path is proven contained. Walking top-down from ``real_root``:
+
+    - each existing component that resolves outside ``real_root`` is refused;
+    - a symlink component is removed so nothing downstream follows it, and if it
+      can't be removed we refuse rather than fall through to a ``mkdir`` that
+      would traverse it and create dirs in the link target;
+    - only once the path is clean and contained do we create parents.
     """
-    # Remove an existing symlink (or a symlink standing in for a needed dir) at or
-    # above dst, walking down from real_root, so nothing on the path is followed.
-    for parent in reversed(dst.parents):
-        try:
-            if parent.is_relative_to(real_root) and parent != real_root and parent.is_symlink():
-                parent.unlink()
-        except OSError:
-            pass
-    if dst.is_symlink() or (dst.exists() and dst.is_dir()):
-        # A symlink at dst would be followed by copy2; a dir there blocks the file
-        # write. Neutralize both (the sandbox's view is authoritative on commit).
-        if dst.is_dir() and not dst.is_symlink():
-            shutil.rmtree(dst, ignore_errors=True)
-        else:
-            dst.unlink(missing_ok=True)
-    dst.parent.mkdir(parents=True, exist_ok=True)
-    resolved_parent = dst.parent.resolve()
-    if not (resolved_parent == real_root or resolved_parent.is_relative_to(real_root)):
+    # dst must be lexically under real_root to begin with; a crafted rel path with
+    # ".." components would fail this before we touch the filesystem.
+    if not dst.is_relative_to(real_root):
         raise SandboxError(f"commit-back destination escapes workspace: {dst}")
+
+    # Walk the components strictly between real_root and dst (real_root is the
+    # trusted base and is never a symlink we'd remove), top-down, ending at dst.
+    rel_parts = dst.relative_to(real_root).parts
+    for i in range(1, len(rel_parts) + 1):
+        comp = real_root.joinpath(*rel_parts[:i])
+        if comp.is_symlink():
+            # Remove the link (never follow it). Do NOT swallow the error: a
+            # symlink we can't unlink must abort before any mkdir traverses it and
+            # creates directories inside the link target.
+            try:
+                comp.unlink()
+            except OSError as exc:
+                raise SandboxError(
+                    f"commit-back can't neutralize symlink on path: {comp} ({exc})"
+                ) from exc
+        elif comp == dst and comp.is_dir():
+            # A real directory where the sandbox now has a file: the sandbox view
+            # is authoritative on commit, so replace it.
+            shutil.rmtree(dst, ignore_errors=True)
+    # Path is now symlink-free and contained; safe to create the parent tree.
+    dst.parent.mkdir(parents=True, exist_ok=True)
 
 
 def commit_back(

--- a/src/opendot/sandbox.py
+++ b/src/opendot/sandbox.py
@@ -130,9 +130,14 @@ def _prepare_dest(dst: Path, real_root: Path) -> None:
                     f"commit-back can't neutralize symlink on path: {comp} ({exc})"
                 ) from exc
         elif comp == dst and comp.is_dir():
-            # A real directory where the sandbox now has a file: the sandbox view
-            # is authoritative on commit, so replace it.
-            shutil.rmtree(dst, ignore_errors=True)
+            # A real directory where the sandbox now has a file. We must NOT rmtree
+            # it: that tree can contain ignored subtrees (.venv, node_modules, …)
+            # that commit_back promises never to touch, and _iter_files only skips
+            # them during enumeration, not during a recursive delete. Refuse the
+            # replacement and let the caller report it as failed.
+            raise SandboxError(
+                f"commit-back destination is a directory (refusing to delete): {dst}"
+            )
     # Path is now symlink-free and contained; safe to create the parent tree.
     dst.parent.mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -175,6 +175,29 @@ def test_commit_back_reports_unreadable_sandbox_file(tmp_path, monkeypatch):
     assert not (wd / "bad.txt").exists()
 
 
+def test_commit_back_does_not_follow_symlink_out_of_workspace(tmp_path):
+    # A symlinked path component in the real workspace must not let commit-back
+    # write through it to a target outside the workspace (containment escape).
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "victim.txt").write_text("original-outside")
+
+    wd = tmp_path / "ws"
+    wd.mkdir()
+    (wd / "linkdir").symlink_to(outside, target_is_directory=True)
+
+    sbx = tmp_path / "sbx"
+    (sbx / "linkdir").mkdir(parents=True)
+    (sbx / "linkdir" / "victim.txt").write_text("HACKED")
+
+    changed, failed = sandbox.commit_back(sbx, wd, IgnoreRules())
+    # The outside file is untouched; the write landed inside the workspace instead.
+    assert (outside / "victim.txt").read_text() == "original-outside"
+    assert not (wd / "linkdir").is_symlink()
+    assert (wd / "linkdir" / "victim.txt").read_text() == "HACKED"
+    assert "linkdir/victim.txt" in changed
+
+
 def test_commit_back_leaves_ignored_trees_untouched(tmp_path):
     # A change under an ignored tree in the sandbox must not be copied back.
     wd = tmp_path / "ws"
@@ -248,3 +271,27 @@ def test_cli_sandbox_propagates_container_exit_code(monkeypatch):
     with pytest.raises(SystemExit) as ei:
         cli.main()
     assert ei.value.code == 3
+
+
+def test_cli_sandbox_partial_commit_back_exits_nonzero(monkeypatch):
+    # Container exited 0 but some files could not be committed back -> the
+    # workspace is indeterminate, so the CLI must exit non-zero for CI/scripting.
+    import sys as _sys
+
+    from opendot import cli
+    from opendot import sandbox as sbx
+
+    monkeypatch.setattr(_sys, "argv", ["opendot", "-p", "do it", "--model", "gpt-5.1", "--sandbox"])
+    monkeypatch.setattr(
+        sbx,
+        "run_sandboxed",
+        lambda *a, **k: {
+            "runtime": "docker",
+            "changed": ["a.txt"],
+            "failed": ["b.txt"],
+            "returncode": 0,
+        },
+    )
+    with pytest.raises(SystemExit) as ei:
+        cli.main()
+    assert ei.value.code == 1

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -198,6 +198,37 @@ def test_commit_back_does_not_follow_symlink_out_of_workspace(tmp_path):
     assert "linkdir/victim.txt" in changed
 
 
+def test_commit_back_refuses_when_symlink_cannot_be_neutralized(tmp_path, monkeypatch):
+    # If a symlink path component can't be unlinked, commit-back must refuse
+    # (-> failed) BEFORE any mkdir traverses it and creates dirs in the target.
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    wd = tmp_path / "ws"
+    wd.mkdir()
+    (wd / "linkdir").symlink_to(outside, target_is_directory=True)
+
+    sbx = tmp_path / "sbx"
+    (sbx / "linkdir").mkdir(parents=True)
+    (sbx / "linkdir" / "deep" / "x.txt").parent.mkdir(parents=True)
+    (sbx / "linkdir" / "deep" / "x.txt").write_text("nope")
+
+    import pathlib
+
+    real_unlink = pathlib.Path.unlink
+
+    def refuse_link(self, *a, **k):
+        if self.is_symlink():
+            raise OSError("cannot unlink symlink")
+        return real_unlink(self, *a, **k)
+
+    monkeypatch.setattr(pathlib.Path, "unlink", refuse_link)
+    changed, failed = sandbox.commit_back(sbx, wd, IgnoreRules())
+    assert "linkdir/deep/x.txt" in failed
+    # Nothing was created in the symlink target outside the workspace.
+    assert not (outside / "deep").exists()
+
+
 def test_commit_back_leaves_ignored_trees_untouched(tmp_path):
     # A change under an ignored tree in the sandbox must not be copied back.
     wd = tmp_path / "ws"

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -229,6 +229,25 @@ def test_commit_back_refuses_when_symlink_cannot_be_neutralized(tmp_path, monkey
     assert not (outside / "deep").exists()
 
 
+def test_commit_back_refuses_dir_to_file_replacement(tmp_path):
+    # The sandbox has a file where the real workspace has a directory. rmtree-ing
+    # that dir could wipe ignored subtrees (.venv, node_modules), which commit_back
+    # promises never to touch — so it must refuse and report the path as failed.
+    wd = tmp_path / "ws"
+    (wd / "thing" / ".venv").mkdir(parents=True)
+    (wd / "thing" / ".venv" / "keep").write_text("precious")
+
+    sbx = tmp_path / "sbx"
+    sbx.mkdir()
+    (sbx / "thing").write_text("now a file")  # dir -> file in the sandbox
+
+    changed, failed = sandbox.commit_back(sbx, wd, IgnoreRules())
+    assert "thing" in failed
+    assert "thing" not in changed
+    assert (wd / "thing").is_dir()  # directory (and its contents) left intact
+    assert (wd / "thing" / ".venv" / "keep").read_text() == "precious"
+
+
 def test_commit_back_leaves_ignored_trees_untouched(tmp_path):
     # A change under an ignored tree in the sandbox must not be copied back.
     wd = tmp_path / "ws"


### PR DESCRIPTION
Follow-up to #143. Copilot's third review pass surfaced two findings right as #143 merged; both are real and fixed here.

## Fixes

**High — commit-back could write outside the workspace (containment escape).**
`shutil.copy2` follows an existing symlink at the destination, so a sandbox path like `linkdir/hack.txt` where `linkdir` is a symlink in the real workspace would write *through* the link to its target — potentially outside the workspace, defeating the whole point of `--sandbox`. `commit_back` now treats the sandbox as untrusted: `_prepare_dest` removes any symlink component on the destination path and refuses a destination that still resolves outside the workspace.

**Medium — partial commit-back exited 0.**
When the container exits 0 but some files land in `failed`, the workspace is in an indeterminate state. The CLI now exits 1 in that case (while still propagating a non-zero container exit code), so CI/scripting sees it.

## Tests
- `test_commit_back_does_not_follow_symlink_out_of_workspace` — regression-proven: fails on the pre-fix code (writes `HACKED` to the outside file), passes with the fix.
- `test_cli_sandbox_partial_commit_back_exits_nonzero` — rc 0 + non-empty `failed` → exit 1.

349 passed, 5 skipped; ruff check + format clean. Bumps to 0.4.1; design doc documents the containment + exit-code contract.

Refs #130.