### PR TITLE
fix: prevent recursive explorer spawning #139

### DIFF
--- a/src/opendot/agent/explorers.py
+++ b/src/opendot/agent/explorers.py
@@ -64,12 +64,9 @@ async def run_explorers(
                 system_prompt=_EXPLORER_SYSTEM,
                 api_base=api_base,
                 temperature=temperature,
-            )
+            ),
+            read_only=True,
         )
-        # Force a read-only toolbox regardless of defaults.
-        from opendot.tools.local import Toolbox
-
-        agent.toolbox = Toolbox(workdir, reversibility=None, read_only=True)
         answer_parts: list[str] = []
         try:
             async for ev in agent.run(task):

--- a/src/opendot/agent/loop.py
+++ b/src/opendot/agent/loop.py
@@ -79,7 +79,13 @@ def _assistant_msg(content: str, calls: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 class Agent:
-    def __init__(self, config: AgentConfig | None = None, confirm=None, mcp_manager=None) -> None:
+    def __init__(
+        self,
+        config: AgentConfig | None = None,
+        confirm=None,
+        mcp_manager=None,
+        read_only: bool = False,
+    ) -> None:
         self.config = config or AgentConfig()
         self.mcp = mcp_manager
 
@@ -105,10 +111,13 @@ class Agent:
             model=self.config.model,
             params=params,
         )
+        # Explorer toolboxes are read-only and previously used reversibility=None.
+        # Preserve that behavior while constructing the correct toolbox up front.
         self.toolbox = Toolbox(
             self.config.workdir,
-            reversibility=self.reversibility,
+            reversibility=None if read_only else self.reversibility,
             confirm=confirm,
+            read_only=read_only,
             mcp_manager=mcp_manager,
         )
         system = self.config.system_prompt or DEFAULT_SYSTEM_PROMPT

--- a/tests/test_explorers.py
+++ b/tests/test_explorers.py
@@ -40,11 +40,11 @@ async def test_explorers_run_parallel_readonly_and_return_findings(tmp_path, mon
 
     # Replace the real Agent with a fake read-only agent that "explores".
     class FakeAgent:
-        def __init__(self, config=None, confirm=None):
+        def __init__(self, config=None, confirm=None, read_only=False):
             self.config = config
             from opendot.tools.local import Toolbox
 
-            self.toolbox = Toolbox(config.workdir, read_only=True)
+            self.toolbox = Toolbox(config.workdir, read_only=read_only)
 
         async def run(self, task):
             order.append(f"start:{task}")

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -416,3 +416,58 @@ def test_session_summary_counts_only_this_session(tmp_path):
     assert s["irreversible"] == 1
     assert s["cost_usd"] == 0.05
     assert s["total_tokens"] == 2000
+
+
+# -- issue #139: explorer subagents must not be able to spawn explorers --
+
+
+def _run_and_capture_tools(a: Agent, monkeypatch) -> list[dict]:
+    """Run one turn with `_dispatch_turn` faked out (no real model call), and
+    return the `tools` list `run()` actually handed to the dispatch path —
+    the same list a live model call would have seen."""
+    captured: dict[str, list[dict]] = {}
+
+    async def fake_dispatch_turn(litellm, tools):
+        captured["tools"] = tools
+        yield _Assembled({"role": "assistant", "content": "done"}, [])
+
+    monkeypatch.setattr(a, "_dispatch_turn", fake_dispatch_turn)
+
+    async def run():
+        async for _ in a.run("hi"):
+            pass
+
+    asyncio.run(run())
+    return captured["tools"]
+
+
+def test_normal_agent_toolbox_is_not_read_only(tmp_path):
+    a = Agent(AgentConfig(model="m", workdir=str(tmp_path)))
+    assert a.toolbox.read_only is False
+
+
+def test_normal_agent_has_explorers_enabled(tmp_path):
+    a = Agent(AgentConfig(model="m", workdir=str(tmp_path)))
+    assert a.explorers_enabled is True
+
+
+def test_read_only_agent_toolbox_is_read_only(tmp_path):
+    a = Agent(AgentConfig(model="m", workdir=str(tmp_path)), read_only=True)
+    assert a.toolbox.read_only is True
+
+
+def test_read_only_agent_has_explorers_disabled(tmp_path):
+    a = Agent(AgentConfig(model="m", workdir=str(tmp_path)), read_only=True)
+    assert a.explorers_enabled is False
+
+
+def test_read_only_agent_run_does_not_pass_spawn_explorers(tmp_path, monkeypatch):
+    a = Agent(AgentConfig(model="m", workdir=str(tmp_path)), read_only=True)
+    tools = _run_and_capture_tools(a, monkeypatch)
+    assert not any(t["function"]["name"] == "spawn_explorers" for t in tools)
+
+
+def test_normal_agent_run_passes_spawn_explorers(tmp_path, monkeypatch):
+    a = Agent(AgentConfig(model="m", workdir=str(tmp_path)))
+    tools = _run_and_capture_tools(a, monkeypatch)
+    assert any(t["function"]["name"] == "spawn_explorers" for t in tools)


### PR DESCRIPTION
This fixes #139 by creating explorer subagents with a read-only configuration from the start, instead of replacing their toolbox after the agent has already been initialized. As a result, explorer subagents no longer receive the `spawn_explorers` tool and cannot recursively create additional explorers. The main agent still retains that capability, so normal parallel exploration continues to work as intended. 

Regression tests cover both sides of this behavior: explorers are denied the tool while the main agent is still offered it. I verified the change with a three-explorer manual test and the full Python 3.12 test suite, which completed with 364 passed and 2 platform-specific skips.

The new regression tests verify both sides of that behavior and can be run with uv run pytest tests/test_explorers.py tests/test_loop.py tests/test_mcp.py