### PR TITLE
fix: write MCP config with owner-only permissions

### DIFF
--- a/src/opendot/mcp/manager.py
+++ b/src/opendot/mcp/manager.py
@@ -62,6 +62,12 @@ def save_mcp_config(servers: dict[str, dict]) -> None:
     """Write the full server map back to ~/.opendot/mcp.json."""
     path = _config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
+    # A static config can carry Authorization headers, so it must never exist
+    # group/world-readable — not even briefly. Mirror the OAuth token writer:
+    # create a temp file 0600 *from the first byte* (O_CREAT with mode 0o600),
+    # then atomically rename it in. os.replace preserves the temp file's mode, so
+    # no follow-up chmod is needed (and none is wanted — an unguarded chmod can
+    # fail on permission-mapped mounts the creation mode already handles).
     payload = json.dumps({"mcpServers": servers}, indent=2).encode("utf-8")
     tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
@@ -69,7 +75,6 @@ def save_mcp_config(servers: dict[str, dict]) -> None:
         with os.fdopen(fd, "wb") as f:
             f.write(payload)
         os.replace(tmp, path)
-        path.chmod(0o600)
     finally:
         if tmp.exists():
             tmp.unlink()

--- a/src/opendot/mcp/manager.py
+++ b/src/opendot/mcp/manager.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import threading
 from concurrent.futures import Future
 from dataclasses import dataclass
@@ -61,7 +62,17 @@ def save_mcp_config(servers: dict[str, dict]) -> None:
     """Write the full server map back to ~/.opendot/mcp.json."""
     path = _config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps({"mcpServers": servers}, indent=2), encoding="utf-8")
+    payload = json.dumps({"mcpServers": servers}, indent=2).encode("utf-8")
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(payload)
+        os.replace(tmp, path)
+        path.chmod(0o600)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
 
 
 def add_mcp_server(name: str, spec: dict) -> None:

--- a/src/opendot/mcp/manager.py
+++ b/src/opendot/mcp/manager.py
@@ -73,13 +73,18 @@ def save_mcp_config(servers: dict[str, dict]) -> None:
     payload = json.dumps({"mcpServers": servers}, indent=2).encode("utf-8")
     fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
     tmp = Path(tmp_name)
+    replaced = False
     try:
         with os.fdopen(fd, "wb") as f:
             f.write(payload)
         os.replace(tmp, path)
+        replaced = True
     finally:
-        if tmp.exists():
-            tmp.unlink()
+        # Only clean up on failure. After a successful replace the temp name is
+        # freed, and a blind unlink could race and delete an unrelated file that
+        # took that name — so key the cleanup on `replaced`, not tmp.exists().
+        if not replaced:
+            tmp.unlink(missing_ok=True)
 
 
 def add_mcp_server(name: str, spec: dict) -> None:

--- a/src/opendot/mcp/manager.py
+++ b/src/opendot/mcp/manager.py
@@ -75,7 +75,13 @@ def save_mcp_config(servers: dict[str, dict]) -> None:
     tmp = Path(tmp_name)
     replaced = False
     try:
-        with os.fdopen(fd, "wb") as f:
+        # If fdopen itself fails, the raw fd would leak — close it and re-raise.
+        try:
+            f = os.fdopen(fd, "wb")
+        except OSError:
+            os.close(fd)
+            raise
+        with f:
             f.write(payload)
         os.replace(tmp, path)
         replaced = True

--- a/src/opendot/mcp/manager.py
+++ b/src/opendot/mcp/manager.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import tempfile
 import threading
 from concurrent.futures import Future
 from dataclasses import dataclass
@@ -63,14 +64,15 @@ def save_mcp_config(servers: dict[str, dict]) -> None:
     path = _config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     # A static config can carry Authorization headers, so it must never exist
-    # group/world-readable — not even briefly. Mirror the OAuth token writer:
-    # create a temp file 0600 *from the first byte* (O_CREAT with mode 0o600),
-    # then atomically rename it in. os.replace preserves the temp file's mode, so
-    # no follow-up chmod is needed (and none is wanted — an unguarded chmod can
-    # fail on permission-mapped mounts the creation mode already handles).
+    # group/world-readable — not even briefly. Create a unique temp file that is
+    # 0600 *from the first byte* (mkstemp uses O_EXCL + mode 0600, so no collision
+    # and no world-readable window), then atomically rename it in. os.replace
+    # preserves the temp file's mode, so no follow-up chmod is needed (and none is
+    # wanted — an unguarded chmod can fail on permission-mapped mounts the creation
+    # mode already handles).
     payload = json.dumps({"mcpServers": servers}, indent=2).encode("utf-8")
-    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
+    tmp = Path(tmp_name)
     try:
         with os.fdopen(fd, "wb") as f:
             f.write(payload)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -30,6 +30,29 @@ def test_missing_config_is_empty(tmp_path):
     assert load_mcp_config() == {}
 
 
+def test_save_mcp_config_is_owner_only(tmp_path):
+    from opendot.mcp.manager import load_mcp_config, save_mcp_config
+
+    store = tmp_path / "store"
+    store.mkdir(parents=True)
+    path = store / "mcp.json"
+    path.write_text(json.dumps({"mcpServers": {}}), encoding="utf-8")
+    path.chmod(0o644)
+
+    save_mcp_config(
+        {
+            "supabase": {
+                "url": "https://mcp.supabase.com/mcp",
+                "headers": {"Authorization": "Bearer tok123"},
+            }
+        }
+    )
+
+    assert (path.stat().st_mode & 0o777) == 0o600
+    assert load_mcp_config()["supabase"]["headers"]["Authorization"] == "Bearer tok123"
+    assert not any(p.name.endswith(".tmp") for p in store.iterdir())
+
+
 class _FakeMCP:
     """Stand-in MCPManager: exposes one tool, records calls."""
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,6 +1,7 @@
 """Tests for MCP client integration (config, tool exposure, irreversible gating)."""
 
 import json
+import os
 
 import pytest
 
@@ -48,7 +49,10 @@ def test_save_mcp_config_is_owner_only(tmp_path):
         }
     )
 
-    assert (path.stat().st_mode & 0o777) == 0o600
+    # POSIX permission bits are meaningless on Windows; the mode check is the
+    # security guarantee, so gate just that assertion, not the whole test.
+    if os.name == "posix":
+        assert (path.stat().st_mode & 0o777) == 0o600
     assert load_mcp_config()["supabase"]["headers"]["Authorization"] == "Bearer tok123"
     assert not any(p.name.endswith(".tmp") for p in store.iterdir())
 


### PR DESCRIPTION
## What & why

Fixes #141. Static MCP server configs can include Authorization headers, so the config write now uses owner-only permissions like OAuth token storage.

## How I verified it

- Added a regression test that saves a config containing an Authorization header over an existing 0644 `mcp.json`, checks the file is 0600, and confirms the header still loads.
- `pytest -q`
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`

## Checklist

- [x] Small and focused (one change)
- [x] Added/updated tests; `pytest` passes locally
- [x] Reversibility/mutating tools not touched
- [x] No UI change, so no screenshot is applicable
