### PR TITLE
fix: resolve TUI short action IDs

### DIFF
--- a/src/opendot/tui/app.py
+++ b/src/opendot/tui/app.py
@@ -25,10 +25,31 @@ from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.widgets import Footer, Header, Input, Static
 
 from opendot.agent.loop import Agent
+from opendot.reversibility.ledger import LedgerEntry
 from opendot.tui.commands import SLASH_COMMANDS
 from opendot.tui.helpers import _LOGO_PATH, _render_tool_result, _row_bar
 from opendot.tui.modals import ApiKeyModal, ConfirmModal, McpAddModal, SearchListModal
 from opendot.tui.sidebar import Sidebar
+
+
+def _resolve_action_id(entries: list[LedgerEntry], snap_id: str) -> LedgerEntry | None:
+    """Resolve a displayed action ID without relying on a fixed-width suffix."""
+    target = next((entry for entry in entries if entry.id == snap_id), None)
+    if target is not None:
+        return target
+
+    try:
+        numeric_id = int(snap_id)
+    except (TypeError, ValueError):
+        return None
+
+    for entry in entries:
+        try:
+            if int(entry.id) == numeric_id:
+                return entry
+        except (TypeError, ValueError):
+            continue
+    return None
 
 
 class OpendotTUI(App):
@@ -847,7 +868,7 @@ class OpendotTUI(App):
             return
         rev = self.agent.reversibility
         entries = rev.history()
-        target = next((e for e in entries if e.id == snap_id or e.id[-3:] == snap_id), None)
+        target = _resolve_action_id(entries, snap_id)
         if not target:
             self._write(f"no action {snap_id} (see /log)", "sys")
             return
@@ -871,7 +892,7 @@ class OpendotTUI(App):
             self._write("nothing to undo", "sys")
             return
         if snap_id:
-            target = next((e for e in entries if e.id == snap_id or e.id[-3:] == snap_id), None)
+            target = _resolve_action_id(entries, snap_id)
             if not target:
                 self._write(f"no action {snap_id} (see /log)", "sys")
                 return

--- a/tests/test_tui_action_ids.py
+++ b/tests/test_tui_action_ids.py
@@ -1,0 +1,44 @@
+"""TUI action ID resolution."""
+
+from opendot.reversibility.ledger import LedgerEntry
+from opendot.tui.app import _resolve_action_id
+
+
+def _entry(action_id: str) -> LedgerEntry:
+    return LedgerEntry(
+        id=action_id,
+        kind="write",
+        detail="file.txt",
+        snapshot_before="snapshot",
+    )
+
+
+def test_short_id_resolves_padded_action_id():
+    target = _entry("000004")
+
+    assert _resolve_action_id([target], "4") is target
+
+
+def test_short_id_uses_numeric_value_not_suffix():
+    first = _entry("000123")
+    later = _entry("001123")
+
+    assert _resolve_action_id([first, later], "123") is first
+
+
+def test_full_padded_id_matches_exactly():
+    first = _entry("000123")
+    later = _entry("001123")
+
+    assert _resolve_action_id([first, later], "001123") is later
+
+
+def test_invalid_short_id_returns_no_match():
+    assert _resolve_action_id([_entry("000004")], "not-an-id") is None
+
+
+def test_malformed_stored_id_does_not_crash_numeric_resolution():
+    malformed = _entry("not-an-id")
+    target = _entry("000004")
+
+    assert _resolve_action_id([malformed, target], "4") is target


### PR DESCRIPTION
## What & why

TUI `/undo` and `/diff` previously used a fixed 3-character suffix match. This made `4` fail for `000004` and allowed ambiguous suffix matches after 999 actions. Both TUI paths now share a resolver that preserves exact padded-ID matching first, then safely resolves numeric shorthand by integer value; malformed stored IDs and invalid input fail safely.

Closes #142

## How I verified it

- `tests/test_tui_action_ids.py`: 5 passed
- `ruff check src/ tests/`: passed
- `ruff format --check src/ tests/`: passed
- The local full suite on Windows encountered environment-dependent failures; Ubuntu Python 3.10-3.12 CI is authoritative.

## Checklist

- [x] Small and focused (one change)
- [ ] Added/updated tests; `pytest` passes locally. Focused resolver tests pass; the full suite did not pass locally.
- [ ] If it touches `reversibility/` or a mutating tool: not applicable
- [ ] If it changes the UI: screenshot / short recording included below.

<!-- No visual UI change; this is a behavior-only TUI command fix. -->
