### PR TITLE
fix: preserve ignored empty directories on restore

### DIFF
--- a/src/opendot/reversibility/snapshots.py
+++ b/src/opendot/reversibility/snapshots.py
@@ -547,7 +547,7 @@ def restore_snapshot(snap: Snapshot, rules: IgnoreRules | None = None) -> list[s
         p = Path(dirpath)
         if p == wd:
             continue
-        if rules.skipped(p.name):
+        if any(rules.skipped(part) for part in p.relative_to(wd).parts):
             continue
         try:
             if not any(p.iterdir()):

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -186,6 +186,30 @@ def test_restore_never_touches_skipped_paths(tmp_path):
     assert (wd / ".git" / "HEAD").read_text() == "precious"
 
 
+def test_restore_preserves_empty_dirs_inside_skipped_paths(tmp_path):
+    wd = _workspace(tmp_path)
+    snap = S.take_snapshot(wd)
+
+    nested = wd / ".git" / "refs" / "tags"
+    nested.mkdir(parents=True)
+
+    S.restore_snapshot(snap)
+
+    assert nested.is_dir()
+
+
+def test_restore_removes_new_empty_non_ignored_dirs(tmp_path):
+    wd = _workspace(tmp_path)
+    snap = S.take_snapshot(wd)
+
+    empty = wd / "build" / "cache"
+    empty.mkdir(parents=True)
+
+    S.restore_snapshot(snap)
+
+    assert not empty.exists()
+
+
 def test_snapshot_ids_are_monotonic(tmp_path):
     wd = _workspace(tmp_path)
     (wd / "f").write_text("a")


### PR DESCRIPTION
## What & why

`restore_snapshot()` prunes empty directories bottom-up, but previously checked only each directory's leaf name against ignore rules. Descendants such as `.git/refs/tags` could therefore be deleted. The fix checks every component of the directory's relative path with `rules.skipped()`, preserving ignored trees and ordinary cleanup; it avoids `dirnames` pruning because this cleanup walk uses `topdown=False`.

This preserves the reversibility invariant that restore does not mutate ignored paths.

Closes #138

## How I verified it

- New focused regressions: 2 passed
- `ruff check src/ tests/`: passed
- `ruff format --check src/ tests/`: passed
- `tests/test_snapshots.py`: 41 passed, 3 failed, 3 skipped locally on Windows; the failures are platform-sensitive mode, encoding, and timestamp behavior.
- The full local Windows suite also encountered environment/temp-directory and platform-specific failures; upstream Ubuntu CI is authoritative.

## Checklist

- [x] Small and focused (one change)
- [ ] Added/updated tests; `pytest` passes locally
- [x] If it touches `reversibility/` or a mutating tool: ignored paths remain unmutated during restore; focused restore regressions are added
- [ ] If it changes the UI: screenshot / short recording included below

<!-- No visual UI change; this is a restore-behavior fix. -->
