### PR TITLE
fix: skip no-snapshot actions during undo and redo

### DIFF
--- a/src/opendot/reversibility/engine.py
+++ b/src/opendot/reversibility/engine.py
@@ -162,11 +162,15 @@ class Reversibility:
             return None
         state = redo.read(self.project_id, len(entries))
         if state.undone >= len(entries):
-            return None  # already walked back past the first action
-        target = entries[-1 - state.undone]
-        if not target.snapshot_before:
-            # A no-snapshot action (OPENDOT_NO_SNAPSHOT) has nothing to restore.
             return None
+        target_idx = None
+        for i in range(len(entries) - 1 - state.undone, -1, -1):
+            if entries[i].snapshot_before:
+                target_idx = i
+                break
+        if target_idx is None:
+            return None
+        target = entries[target_idx]
 
         if state.undone == 0:
             # The state we're leaving is the head, and no later action snapshotted
@@ -175,7 +179,7 @@ class Reversibility:
             state.head_snapshot = snapshots.take_snapshot(self.workdir, self.rules).id
 
         self.last_changed_lockfiles = self.restore_to(target.snapshot_before)
-        state.undone += 1
+        state.undone = len(entries) - target_idx
         redo.write(self.project_id, state)
         return target
 
@@ -192,20 +196,24 @@ class Reversibility:
         if not state.can_redo:
             return None
 
-        # With `undone` actions reverted, the one to re-apply is the first of
-        # them. Its "after" state is the next action's before-snapshot, or the
-        # captured head when it is the newest action.
         target_index = len(entries) - state.undone
         target = entries[target_index]
-        after = (
-            state.head_snapshot
-            if target_index == len(entries) - 1
-            else entries[target_index + 1].snapshot_before
-        )
+
+        after = ""
+        next_undone = 0
+        for i in range(target_index + 1, len(entries)):
+            if entries[i].snapshot_before:
+                after = entries[i].snapshot_before
+                next_undone = len(entries) - i
+                break
+        if not after:
+            after = state.head_snapshot
+            next_undone = 0
+
         if not after:
             return None
 
         self.last_changed_lockfiles = self.restore_to(after)
-        state.undone -= 1
+        state.undone = next_undone
         redo.write(self.project_id, state)
         return target

--- a/tests/test_redo.py
+++ b/tests/test_redo.py
@@ -308,3 +308,113 @@ def test_lockfile_warning_still_reported_through_redo(tmp_path):
 
     rev.redo()
     assert any("package-lock.json" in p for p in rev.last_changed_lockfiles)
+
+
+# ---- no-snapshot actions (issue #136) ----
+
+
+def test_trailing_no_snapshot_action_does_not_block_undo_and_redo(tmp_path):
+    """Issue #136: A trailing no-snapshot action (snapshot_before="") must be
+    skipped by undo_last() so earlier reversible actions can be undone and redone."""
+    rev, wd = _rev(tmp_path)
+    f = wd / "a.txt"
+    f.write_text("one")
+
+    _edit(rev, f, "two-two")
+    rev.before_action("shell", "shred secret.txt", snapshot=False)
+
+    assert rev.redo_available() == 0
+
+    undone = rev.undo_last()
+    assert undone is not None
+    assert undone.detail == str(f)
+    assert f.read_text() == "one"
+    assert rev.redo_available() == 2
+
+    assert rev.undo_last() is None
+
+    redone = rev.redo()
+    assert redone is not None
+    assert redone.detail == str(f)
+    assert f.read_text() == "two-two"
+    assert rev.redo_available() == 0
+    assert rev.redo() is None
+
+
+def test_interleaved_no_snapshot_action_undo_and_redo(tmp_path):
+    """A no-snapshot action between reversible actions is skipped during both
+    undo and redo while maintaining correct order and cursor bookkeeping."""
+    rev, wd = _rev(tmp_path)
+    f = wd / "a.txt"
+    f.write_text("one")
+
+    _edit(rev, f, "two-two")
+    rev.before_action("shell", "shred secret.txt", snapshot=False)
+    _edit(rev, f, "three-three-three")
+
+    assert rev.redo_available() == 0
+
+    # Undo C
+    undone_c = rev.undo_last()
+    assert undone_c is not None
+    assert undone_c.detail == str(f)
+    assert f.read_text() == "two-two"
+    assert rev.redo_available() == 1
+
+    # Undo A (skipping no-snapshot B)
+    undone_a = rev.undo_last()
+    assert undone_a is not None
+    assert undone_a.detail == str(f)
+    assert f.read_text() == "one"
+    assert rev.redo_available() == 3
+
+    assert rev.undo_last() is None
+
+    # Redo A (lands at snapshot before C, after B)
+    redone_a = rev.redo()
+    assert redone_a is not None
+    assert redone_a.detail == str(f)
+    assert f.read_text() == "two-two"
+    assert rev.redo_available() == 1
+
+    # Redo C (lands at head)
+    redone_c = rev.redo()
+    assert redone_c is not None
+    assert redone_c.detail == str(f)
+    assert f.read_text() == "three-three-three"
+    assert rev.redo_available() == 0
+    assert rev.redo() is None
+
+
+def test_multiple_trailing_no_snapshot_actions(tmp_path):
+    """Multiple trailing no-snapshot actions are all skipped when undoing."""
+    rev, wd = _rev(tmp_path)
+    f = wd / "a.txt"
+    f.write_text("one")
+
+    _edit(rev, f, "two-two")
+    rev.before_action("shell", "shred secret1.txt", snapshot=False)
+    rev.before_action("shell", "shred secret2.txt", snapshot=False)
+
+    undone = rev.undo_last()
+    assert undone is not None
+    assert undone.detail == str(f)
+    assert f.read_text() == "one"
+    assert rev.redo_available() == 3
+
+    redone = rev.redo()
+    assert redone is not None
+    assert redone.detail == str(f)
+    assert f.read_text() == "two-two"
+    assert rev.redo_available() == 0
+
+
+def test_all_no_snapshot_actions_undo_returns_none(tmp_path):
+    """When history contains only no-snapshot actions, undo returns None cleanly."""
+    rev, wd = _rev(tmp_path)
+    rev.before_action("shell", "shred secret1.txt", snapshot=False)
+    rev.before_action("shell", "shred secret2.txt", snapshot=False)
+
+    assert rev.undo_last() is None
+    assert rev.redo_available() == 0
+    assert rev.redo() is None


### PR DESCRIPTION
## What & why

Skip no-snapshot ledger actions during undo/redo so they don't block earlier reversible actions.

## How I verified it

Added tests for trailing and interleaved no-snapshot actions, including undo/redo ordering and cursor state.

`pytest tests/test_redo.py` — 23 passed.

## Checklist

- [x] Small and focused (one change)
- [x] Added/updated tests; `pytest` passes locally
- [x] If it touches `reversibility/` or a mutating tool: actions are snapshotted and undo still restores exactly (tests added)
- [ ] If it changes the UI: screenshot / short recording included below

<!-- UI screenshots (before / after) go here if applicable. -->

Related to #136