### PR TITLE
prompt: point moves/renames at the move tool, not shell mv (0.4.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opendot"
-version = "0.4.1"
+version = "0.4.2"
 description = "An interactive terminal AI agent you can fully undo — any model, acts on your real files, every action reversible."
 readme = "README.md"
 license = "MIT"

--- a/src/opendot/__init__.py
+++ b/src/opendot/__init__.py
@@ -13,6 +13,6 @@ from opendot.agent.config import AgentConfig
 from opendot.agent.events import Event
 from opendot.agent.loop import Agent
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 __all__ = ["Agent", "AgentConfig", "Event", "__version__"]

--- a/src/opendot/agent/prompt.py
+++ b/src/opendot/agent/prompt.py
@@ -14,7 +14,8 @@ Tools:
 - glob — find files by pattern (e.g. **/*.py)
 - edit — make a targeted find-and-replace in a file (PREFER THIS for changes)
 - write_file — create a new file or fully rewrite one
-- run_shell — anything else (npm, git, build, mv, cp, tests, …)
+- move — move or rename a file or directory (PREFER THIS over `mv`; surgical, undoable)
+- run_shell — anything else (npm, git, build, cp, tests, …)
 
 Opening apps, files, or URLs: use run_shell with the command for the user's OS —
   macOS:   open -a "AppName"   (or `open <file-or-url>`)

--- a/src/opendot/tools/local.py
+++ b/src/opendot/tools/local.py
@@ -929,7 +929,8 @@ class Toolbox:
             ),
             Tool(
                 "run_shell",
-                "Run a shell command in the working directory (npm, git, build, mv, cp, etc.).",
+                "Run a shell command in the working directory (npm, git, build, cp, etc.; "
+                "prefer the move tool over `mv`).",
                 {
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
Fixes #160.

## Problem
There's a dedicated `move` tool (`local.py` — "Move or rename a file or directory (surgical, undoable)"), but two pieces of tool guidance steered the model toward shell `mv` instead:
- the default system prompt (`prompt.py`) listed `mv` as a `run_shell` example and never mentioned `move`;
- the `run_shell` tool description itself said "npm, git, build, **mv**, cp, etc."

So for an ordinary rename the model would reach for shell `mv` — which routes through the classifier/confirm path and isn't the surgical, undoable operation the `move` tool provides.

## Fix
- Add `move` to the prompt's tool list, marked PREFER over `mv`.
- Drop `mv` from both `run_shell` example lists. `cp` stays — there is no dedicated copy tool, so shell `cp` remains correct.

Guidance-only; no code behavior changes. 369 passed, ruff clean. Bumped to 0.4.2.

Thanks @22373448 for the well-grounded report (and the manual verification note).